### PR TITLE
Updates to get it working with Fast Models 11.5 and Design Studio 2019.1

### DIFF
--- a/docker/arm-tool-base-cms/Dockerfile
+++ b/docker/arm-tool-base-cms/Dockerfile
@@ -1,0 +1,43 @@
+# # Build command
+# # 	docker build -t arm-tool-base:latest --build-arg license_path=/path/to/license .
+#
+# # Run command
+# # 	docker run -it arm-tool-base:latest
+
+
+FROM centos:6.6
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN yum -y groupinstall "Additional Development" "Compatibility Libraries" "Development tools" "Perl Support"  && yum clean all
+RUN yum -y install gstreamer-plugins-base && yum clean all || true
+
+
+# # set the license path from command line argument
+ARG license_path
+ENV ARMLMD_LICENSE_FILE=$license_path
+
+# # create /arm-tools/ dirctory to install all tools into
+RUN mkdir /arm-tools/		&&\
+	chmod 755 /arm-tools/
+
+
+
+### 	Tool Version Select 	###
+
+ARG CMS_INSTALL=Arm-CycleModel-release-v11_0_4
+ARG CMS_DIR=Arm-CycleModel-release-v11_0_4
+
+ARG CMS_SYSC_INSTALL=Arm-CycleModelSystemC-Runtime-files-Linux64-v11.0.1
+ARG CMS_SYSC_DIR=Arm-CycleModelSystemC-Runtime-files-Linux64-v11.0.1
+
+
+
+
+
+### 	Install Fast Models 	###
+
+# # copy file from same directory as this Dockerfile
+COPY $CMS_INSTALL.tgz /home/
+COPY $CMS_SYSC_INSTALL.tgz /home/
+

--- a/docker/arm-tool-base-cms/Dockerfile
+++ b/docker/arm-tool-base-cms/Dockerfile
@@ -1,8 +1,8 @@
 # # Build command
-# # 	docker build -t arm-tool-base:latest --build-arg license_path=/path/to/license .
+# # 	docker build -t arm-tool-base-cms:latest --build-arg license_path=/path/to/license .
 #
 # # Run command
-# # 	docker run -it arm-tool-base:latest
+# # 	docker run -it arm-tool-base-cms:latest bash
 
 
 FROM centos:6.6
@@ -11,33 +11,38 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN yum -y groupinstall "Additional Development" "Compatibility Libraries" "Development tools" "Perl Support"  && yum clean all
 RUN yum -y install gstreamer-plugins-base && yum clean all || true
+RUN yum -y install tar && yum -y install vim-enhanced || true
 
 
 # # set the license path from command line argument
 ARG license_path
 ENV ARMLMD_LICENSE_FILE=$license_path
 
-# # create /arm-tools/ dirctory to install all tools into
-RUN mkdir /arm-tools/		&&\
-	chmod 755 /arm-tools/
-
-
 
 ### 	Tool Version Select 	###
-
 ARG CMS_INSTALL=Arm-CycleModel-release-v11_0_4
-ARG CMS_DIR=Arm-CycleModel-release-v11_0_4
-
 ARG CMS_SYSC_INSTALL=Arm-CycleModelSystemC-Runtime-files-Linux64-v11.0.1
-ARG CMS_SYSC_DIR=Arm-CycleModelSystemC-Runtime-files-Linux64-v11.0.1
 
 
-
-
-
-### 	Install Fast Models 	###
+### 	Install Cycle Models 	###
 
 # # copy file from same directory as this Dockerfile
 COPY $CMS_INSTALL.tgz /home/
 COPY $CMS_SYSC_INSTALL.tgz /home/
 
+# # create /arm-tools/ dirctory to install all tools into
+RUN mkdir -p /arm-tools/$CMS_INSTALL		&&\
+    mkdir -p /arm-tools/$CMS_SYSC_INSTALL	&&\
+	chmod 755 /arm-tools/$CMS_INSTALL		&&\
+	chmod 755 /arm-tools/$CMS_SYSC_INSTALL	&&\
+	tar -C /arm-tools/$CMS_INSTALL      -zxvf /home/$CMS_INSTALL.tgz  		&&\
+	tar -C /arm-tools/$CMS_SYSC_INSTALL -zxvf /home/$CMS_SYSC_INSTALL.tgz	&&\
+	chmod 777 /arm-tools/$CMS_INSTALL/examples/ -R	&&\
+	rm -rf /home/$CMS_INSTALL.tgz					&&\
+	rm -rf /home/$CMS_SYSC_INSTALL.tgz
+
+# # add setup to /init.sh 
+RUN	echo	"export CARBON_HOST_ARCH=Linux64"    >> /init.sh	&&\
+	echo 	"export CARBON_TARGET_ARCH=Linux64"  >> /init.sh	&&\
+	echo 	"source /arm-tools/$CMS_INSTALL/etc/setup.sh"  >> /init.sh	&&\
+	echo 	"source /arm-tools/$CMS_SYSC_INSTALL/ARM/ThirdPartyIP/Accellera/SystemC/2.3.1/etc/setup.sh"  >> /init.sh

--- a/docker/arm-tool-base-cms/Makefile
+++ b/docker/arm-tool-base-cms/Makefile
@@ -1,0 +1,40 @@
+
+# Edit here or specify in command-line
+CMS_TAR:=$(PWD)/../../../../ARM/cycle\ model\ studio/Arm-CycleModel-release-v11_0_4.tgz
+CMS_SYSC_TAR:=$(PWD)/../../../../ARM/cycle\ model\ studio/Arm-CycleModelSystemC-Runtime-files-Linux64-v11.0.1.tgz
+
+ARMLMD_LICENSE_PATH:=0000@000.00.00.00
+
+  
+.PHONY: info prepare clean
+
+
+info:
+	@echo "   "
+	@echo "==INFORMATION=================================="
+	@echo "   "
+	@echo "ARMLMD_LICENSE_PATH = $(ARMLMD_LICENSE_PATH)   "
+	@echo " "
+	ls -ltrh $(cMs_TAR)
+	@echo " "
+
+
+prepare_makefile:
+	mkdir -p ./arm-tool-base-cms-repo ;
+	cp ./Dockerfile ./arm-tool-base-cms-repo/ ;
+
+
+prepare: prepare_makefile
+	cp ./Dockerfile ./arm-tool-base-cms-repo/ ;
+	cp $(CMS_TAR) ./arm-tool-base-cms-repo/ ;
+	cp $(CMS_SYSC_TAR) ./arm-tool-base-cms-repo/ ;
+
+
+image:
+	cd ./arm-tool-base-repo ; 
+	docker build -t arm-tool-base-cms:latest --build-arg license_path=$(ARMLMD_LICENSE_PATH) . ;
+
+
+clean:
+	rm -rf ./arm-tool-base-repo
+

--- a/docker/arm-tool-base-cms/README.md
+++ b/docker/arm-tool-base-cms/README.md
@@ -7,17 +7,16 @@ NOTE: Before installing Arm tools from the command line with the "--i-accept-the
 ## Usage instructions
 In order to properly build and run this image, follow these steps:
 
-  1. Create a new directory, for example called 'arm-tool-base-repo'.
-  2. Download the most recent versions  of Arm tools and place the tar files in the 'arm-tool-base-repo'. 
-     - [Fast Models](https://developer.arm.com/products/system-design/fast-models)
-     - [DS-5](https://developer.arm.com/products/software-development-tools/ds-5-development-studio)
-  3. Download this dockerfile and place it in 'arm-tool-base-repo'
-  4. Enter the 'arm-tool-base-repo' and build the dockerfile with the following syntax from the command line or terminal:
-     - ```docker build -t arm-tool-base:latest --build-arg license_path=${ARMLMD_LICENSE_PATH} .```
+  1. Create a new directory, for example called 'arm-tool-base-cms-repo'.
+  2. Download the most recent versions  of Arm tools and place the tar files in the 'arm-tool-base-cms-repo'. 
+     - [Cycle Models](https://developer.arm.com/products/system-design/cycle-models)
+  3. Download this dockerfile and place it in 'arm-tool-base-cms-repo'
+  4. Enter the 'arm-tool-base-cms-repo' and build the dockerfile with the following syntax from the command line or terminal:
+     - ```docker build -t arm-tool-base-cms:latest --build-arg license_path=${ARMLMD_LICENSE_PATH} .```
      - **NOTE:** This assumes that the environmental variable 'ARMLMD_LICENSE_PATH' is set to a floating license on a server.
      - Wait until the build completes; this will take some time.
   5. Run the docker image
-     - ```docker run -it arm-tool-base:latest```
+     - ```docker run -it arm-tool-base-cms:latest bash```
      - This will run an interactive container of the arm-tool-base image.
   6. In the docker container, source the setup script to initialize all Arm tools
      - ```source /init.sh```

--- a/docker/arm-tool-base-cms/README.md
+++ b/docker/arm-tool-base-cms/README.md
@@ -1,0 +1,25 @@
+# Docker image: arm-tool-base
+This dockerfile creates an image with Arm tools pre-installed on it for ease of use. 
+
+## Legal Note
+NOTE: Before installing Arm tools from the command line with the "--i-accept-the-license-agreement" option or similar option, you will be required to agree to be bound by and automatically accept the included the terms and conditions of the relevant Arm End User License Agreement (EULA) and agree to the terms and conditions detailed therein. This condition applies to installation and use of any product updates or new versions of the product will be subject to as the terms and conditions of the relevant Arm EULA that applies at the time of install. 
+
+## Usage instructions
+In order to properly build and run this image, follow these steps:
+
+  1. Create a new directory, for example called 'arm-tool-base-repo'.
+  2. Download the most recent versions  of Arm tools and place the tar files in the 'arm-tool-base-repo'. 
+     - [Fast Models](https://developer.arm.com/products/system-design/fast-models)
+     - [DS-5](https://developer.arm.com/products/software-development-tools/ds-5-development-studio)
+  3. Download this dockerfile and place it in 'arm-tool-base-repo'
+  4. Enter the 'arm-tool-base-repo' and build the dockerfile with the following syntax from the command line or terminal:
+     - ```docker build -t arm-tool-base:latest --build-arg license_path=${ARMLMD_LICENSE_PATH} .```
+     - **NOTE:** This assumes that the environmental variable 'ARMLMD_LICENSE_PATH' is set to a floating license on a server.
+     - Wait until the build completes; this will take some time.
+  5. Run the docker image
+     - ```docker run -it arm-tool-base:latest```
+     - This will run an interactive container of the arm-tool-base image.
+  6. In the docker container, source the setup script to initialize all Arm tools
+     - ```source /init.sh```
+     
+Now you are inside a docker container with Arm tools installed and ready to use.

--- a/docker/arm-tool-base/Dockerfile
+++ b/docker/arm-tool-base/Dockerfile
@@ -9,7 +9,6 @@
 
 FROM ubuntu:16.04
 
-MAINTAINER Zach
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update -y
@@ -65,6 +64,9 @@ RUN mkdir /arm-tools/		&&\
 ARG FM_INSTALL=FastModels_11-9-041_Linux64
 ARG FM_DIR=FastModelsTools_11.9
 
+ARG TP_INSTALL=FastModels_ThirdParty_IP_11-9_b41_Linux64
+ARG TP_DIR=FastModels_ThirdParty_IP_11.9
+
 ARG ArmDS_INSTALL=DS000-BN-00001-r19p1-00rel1
 ARG ArmDS_VERSION=2019.1
 ARG ArmDS_DIR=ArmDS
@@ -104,6 +106,26 @@ RUN 	mkdir /$ArmDS_INSTALL/ 					&&\
 		./armds-$ArmDS_VERSION.sh --i-agree-to-the-contained-eula --no-interactive -d /arm-tools/$ArmDS_DIR/ 	&&\
 		rm /home/$ArmDS_INSTALL.tgz 			&&\
 		rm -r /$ArmDS_INSTALL/
+
+
+
+
+### 	Install Fast Models Third Party IP	###
+
+COPY 	$TP_INSTALL.tgz /home/
+
+# # install program and delete artifacts
+RUN 	mkdir /$TP_INSTALL/											&&\
+		tar xvzf /home/$TP_INSTALL.tgz --directory /$TP_INSTALL/ 	&&\
+		cd /$TP_INSTALL/FastModels_ThirdParty_IP_11-9_Linux64/		&&\
+		./setup.bin --i-accept-the-license-agreement --basepath /arm-tools/$TP_DIR/		&&\
+		rm -rf /home/$TP_INSTALL.tgz								&&\
+		rm -rf /$TP_INSTALL/
+
+
+
+
+
 
 # # add setup to /init.sh 
 RUN	echo 	"export PATH=$PATH:/arm-tools/$ArmDS_DIR/sw/ARMCompiler6.9/bin:/arm-tools/$ArmDS_DIR/bin:/arm-tools/$ArmDS_DIR/sw/java/bin"    >> /init.sh &&\

--- a/docker/arm-tool-base/Dockerfile
+++ b/docker/arm-tool-base/Dockerfile
@@ -20,7 +20,8 @@ RUN apt-get update -y
 
 RUN apt-get install -y apt-utils 	\
     iputils-ping 					\
-	python2.7
+	python2.7						\
+	vim
 
 RUN apt-get install -y 	\
  # Python
@@ -61,11 +62,11 @@ RUN mkdir /arm-tools/		&&\
 
 ### 	Tool Version Select 	###
 
-ARG FM_INSTALL=FastModels_11-5-033_Linux64
-ARG FM_DIR=FastModelsTools_11.5
+ARG FM_INSTALL=FastModels_11-9-041_Linux64
+ARG FM_DIR=FastModelsTools_11.9
 
-ARG ArmDS_INSTALL=DS000-BN-00001-r18p0-00rel0
-ARG ArmDS_VERSION=2018.0
+ARG ArmDS_INSTALL=DS000-BN-00001-r19p1-00rel1
+ARG ArmDS_VERSION=2019.1
 ARG ArmDS_DIR=ArmDS
 
 #ARG DS5_INSTALL=DS500-BN-00019-r5p0-28rel1
@@ -99,7 +100,7 @@ COPY $ArmDS_INSTALL.tgz /home/
 # # install program and delete artifacts
 RUN 	mkdir /$ArmDS_INSTALL/ 					&&\
     	tar xvzf /home/$ArmDS_INSTALL.tgz --directory /$ArmDS_INSTALL/ &&\
-		cd $ArmDS_INSTALL/ 						&&\
+		cd $ArmDS_INSTALL/$ArmDS_INSTALL/		&&\
 		./armds-$ArmDS_VERSION.sh --i-agree-to-the-contained-eula --no-interactive -d /arm-tools/$ArmDS_DIR/ 	&&\
 		rm /home/$ArmDS_INSTALL.tgz 			&&\
 		rm -r /$ArmDS_INSTALL/

--- a/docker/arm-tool-base/Makefile
+++ b/docker/arm-tool-base/Makefile
@@ -1,0 +1,37 @@
+
+# Edit here or specify in command-line
+FM_TAR:=$(PWD)/../../../../ARM/FastModels_11-9-041_Linux64.tgz
+DS_TAR:=$(PWD)/../../../../ARM/ARM\ DS\ 2019.1/Linux/DS000-BN-00001-r19p1-00rel1.tgz
+
+ARMLMD_LICENSE_PATH:=0000@000.00.00.00
+
+  
+.PHONY: info prepare docker clean
+
+
+info:
+	@echo "   "
+	@echo "==INFORMATION=================================="
+	@echo "   "
+	@echo "ARMLMD_LICENSE_PATH = $(ARMLMD_LICENSE_PATH)   "
+	@echo " "
+	ls -ltrh $(FM_TAR)
+	@echo " "
+	ls -ltrh $(DS_TAR)
+	@echo " "
+
+
+prepare:
+	mkdir -p ./arm-tool-base-repo ;
+	cp ./Dockerfile ./arm-tool-base-repo/ ;
+	cp $(FM_TAR) ./arm-tool-base-repo/ ;
+	cp $(DS_TAR) ./arm-tool-base-repo/ ;
+
+
+image:
+	cd ./arm-tool-base-repo ; 
+	docker build -t arm-tool-base:latest --build-arg license_path=$(ARMLMD_LICENSE_PATH) . ;
+
+
+clean:
+	rm -rf ./arm-tool-base-repo

--- a/docker/arm-tool-base/Makefile
+++ b/docker/arm-tool-base/Makefile
@@ -1,12 +1,13 @@
 
 # Edit here or specify in command-line
 FM_TAR:=$(PWD)/../../../../ARM/FastModels_11-9-041_Linux64.tgz
+TP_TAR:=$(PWD)/../../../../ARM/FastModels_ThirdParty_IP_11-9_b41_Linux64.tgz
 DS_TAR:=$(PWD)/../../../../ARM/ARM\ DS\ 2019.1/Linux/DS000-BN-00001-r19p1-00rel1.tgz
 
 ARMLMD_LICENSE_PATH:=0000@000.00.00.00
 
   
-.PHONY: info prepare docker clean
+.PHONY: info prepare_files prepare image clean
 
 
 info:
@@ -21,16 +22,18 @@ info:
 	@echo " "
 
 
-prepare:
+prepare_files:
 	mkdir -p ./arm-tool-base-repo ;
 	cp ./Dockerfile ./arm-tool-base-repo/ ;
+
+prepare: prepare_files
 	cp $(FM_TAR) ./arm-tool-base-repo/ ;
+	cp $(TP_TAR) ./arm-tool-base-repo/ ;
 	cp $(DS_TAR) ./arm-tool-base-repo/ ;
 
 
 image:
-	cd ./arm-tool-base-repo ; 
-	docker build -t arm-tool-base:latest --build-arg license_path=$(ARMLMD_LICENSE_PATH) . ;
+	cd ./arm-tool-base-repo && docker build -t arm-tool-base:latest --build-arg license_path=$(ARMLMD_LICENSE_PATH) . ;
 
 
 clean:

--- a/docker/arm-tool-base/README.md
+++ b/docker/arm-tool-base/README.md
@@ -20,6 +20,6 @@ In order to properly build and run this image, follow these steps:
      - ```docker run -it arm-tool-base:latest```
      - This will run an interactive container of the arm-tool-base image.
   6. In the docker container, source the setup script to initialize all Arm tools
-     - ```. /init.sh```
+     - ```source /init.sh```
      
 Now you are inside a docker container with Arm tools installed and ready to use.


### PR DESCRIPTION
- Added Makefile for commands dispatching
- Install vim in image for text editing capabilities
- Bump up version numbers in dockerfile to work with recent FM and DS tools.
- Add Fast Models Third Party IP installation.

Image generates fine.  Supplied examples in the FastModelsPortfolio_11.9 compile and run as expected.