### PR TITLE
README file fix

### DIFF
--- a/fast-models-examples/cortex-m33-subsystem/README.md
+++ b/fast-models-examples/cortex-m33-subsystem/README.md
@@ -45,6 +45,6 @@ $ ./Cortex-M33-example.x -a ../../software/test.axf
 ```
 on windows
 ```
-$ ./Cortex-M33-example.exe -a ../../software/test.axf
+$ Cortex-M33-example.exe -a ..\..\software\test.axf
 ```
 

--- a/fast-models-examples/cortex-m33-subsystem/README.md
+++ b/fast-models-examples/cortex-m33-subsystem/README.md
@@ -39,11 +39,12 @@ The build scripts first call the Fast Models "simgen" command to generate the Co
 ## Executing the platform with RTX App
 
 1. Change directory to "system/systemc-plt" and execute the platform binary as follows:
-on linux
+
+on Linux
 ```bash
 $ ./Cortex-M33-example.x -a ../../software/test.axf
 ```
-on windows
+on Windows
 ```
 $ Cortex-M33-example.exe -a ..\..\software\test.axf
 ```

--- a/fast-models-examples/cortex-m33-subsystem/README.md
+++ b/fast-models-examples/cortex-m33-subsystem/README.md
@@ -39,7 +39,12 @@ The build scripts first call the Fast Models "simgen" command to generate the Co
 ## Executing the platform with RTX App
 
 1. Change directory to "system/systemc-plt" and execute the platform binary as follows:
+on linux
 ```bash
-$ ./plt -a ../../software/test.axf
+$ ./Cortex-M33-example.x -a ../../software/test.axf
+```
+on windows
+```
+$ ./Cortex-M33-example.exe -a ../../software/test.axf
 ```
 


### PR DESCRIPTION
Odin spotted that I hadn't changed the name of the executable at the end of the README to be consistent with the changes in the build flow.  this is now fixed,