### PR TITLE
Adding patches to support linking of Tensorflow2.x to oneDNN1.x. 

### DIFF
--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -96,14 +96,18 @@ RUN chown $DOCKER_USER:$DOCKER_USER /home/$DOCKER_USER/.bash_profile
 # ========
 FROM tensorflow-base AS tensorflow-libs
 ARG njobs
-ARG dnnl_opt
+ARG onednn_opt
+ARG onednn_version
+ARG tf_id
+
 ENV NP_MAKE="${njobs}" \
-    DNNL_BUILD="${dnnl_opt}"
+    ONEDNN_BUILD="${onednn_opt}" \
+    ONEDNN_VERSION="${onednn_version}" \
+    TF_VERSION_ID="${tf_id}"
 
 # Key version numbers
 ENV PY_VERSION=3.7.0 \
-    OPENBLAS_VERSION=0.3.7 \
-    DNNL_VERSION=0.21.3
+    OPENBLAS_VERSION=0.3.9
 
 # Package build parameters
 ENV PROD_DIR=/opt \
@@ -139,15 +143,15 @@ RUN $PACKAGE_DIR/build-openblas.sh
 ENV OPENBLAS_DIR=$PROD_DIR/openblas/$OPENBLAS_VERSION
 ENV LD_LIBRARY_PATH=$OPENBLAS_DIR/lib:$LD_LIBRARY_PATH
 
-# Build DNNL from source
-COPY scripts/build-dnnl.sh $PACKAGE_DIR/.
-# Patch for MKL-DNN, v0.21.3
+# Build oneDNN from source
+COPY scripts/build-onednn.sh $PACKAGE_DIR/.
+# Patch for oneDNN (MKL-DNN), v0.21.3
 COPY patches/mkldnn.patch $PACKAGE_DIR/mkldnn.patch
-# Patch for DNNL  v1.1.2
-#COPY patches/dnnl.patch $PACKAGE_DIR/dnnl.patch
-RUN $PACKAGE_DIR/build-dnnl.sh
-ENV DNNL_DIR=$PROD_DIR/dnnl/$DNNL_VERSION
-ENV LD_LIBRARY_PATH=$DNNL_DIR/lib:$LD_LIBRARY_PATH
+# Patch for oneDNN  v1.4
+COPY patches/onednn.patch $PACKAGE_DIR/onednn.patch
+RUN $PACKAGE_DIR/build-onednn.sh
+ENV ONEDNN_DIR=$PROD_DIR/onednn/$ONEDNN_VERSION
+ENV LD_LIBRARY_PATH=$ONEDNN_DIR/lib:$LD_LIBRARY_PATH
 
 # ========
 # Stage 3: install essential python dependencies into a venv
@@ -206,14 +210,14 @@ CMD ["bash", "-l"]
 FROM tensorflow-libs AS tensorflow-dev
 ARG njobs
 ARG bazel_mem
-ARG dnnl_opt
+ARG onednn_opt
 ARG tf_version
 ARG tf_id
 ARG bazel_version
 
 ENV NP_MAKE="${njobs}" \
     BZL_RAM="${bazel_mem}" \
-    DNNL_BUILD="${dnnl_opt}"
+    ONEDNN_BUILD="${onednn_opt}"
 
 # Key version numbers
 ENV BZL_VERSION="${bazel_version}" \
@@ -239,9 +243,11 @@ ENV PATH=$PACKAGE_DIR/bazel/output:$PATH
 # Build TensorFlow
 COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 COPY patches/tf_dnnl_decoupling.patch $PACKAGE_DIR/tf_dnnl_decoupling.patch
-COPY patches/tf2_dnnl_decoupling.patch $PACKAGE_DIR/tf2_dnnl_decoupling.patch
+COPY patches/tf2_onednn_decoupling.patch $PACKAGE_DIR/tf2_onednn_decoupling.patch
 COPY patches/tensorflow.patch $PACKAGE_DIR/tensorflow.patch
 COPY patches/tensorflow2.patch $PACKAGE_DIR/tensorflow2.patch
+# Patches to unlink MKL-ML header files for TensorFlow 2.x - oneDNN 1.x builds
+COPY patches/oneDNN-header.patch $PACKAGE_DIR/oneDNN-header.patch
 RUN $PACKAGE_DIR/build-tensorflow.sh
 
 CMD ["bash", "-l"]

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -1,13 +1,13 @@
 # Build TensorFlow (1.x or 2.x) for AArch64 using Docker
 
-A script to build a Docker image containing [TensorFlow](https://www.tensorflow.org/) and dependencies for the [Armv8-A architecture](https://developer.arm.com/architectures/cpu-architecture/a-profile) with AArch64 execution. 
+A script to build a Docker image containing [TensorFlow](https://www.tensorflow.org/) and dependencies for the [Armv8-A architecture](https://developer.arm.com/architectures/cpu-architecture/a-profile) with AArch64 execution.
 For more information, see this Arm Developer Community [blog post](https://community.arm.com/developer/tools-software/tools/b/tools-software-ides-blog/posts/aarch64-docker-images-for-pytorch-and-tensorflow).
 
 Before using this project run the uname command to confirm the machine is aarch64. Other architectures will not work.
 
-``` 
-> uname -m 
-aarch64 
+```
+> uname -m
+aarch64
 ```
 
 
@@ -15,13 +15,13 @@ aarch64
   * OS: Ubuntu 18.04
   * Compiler: GCC 9.2
   * Maths libraries: [Arm Optimized Routines](https://github.com/ARM-software/optimized-routines) and [OpenBLAS](https://www.openblas.net/) 0.3.9
-  * [oneDNN](https://github.com/oneapi-src/oneDNN) 0.21.3
+  * [oneDNN](https://github.com/oneapi-src/oneDNN) 0.21.3 or 1.4. Previously known as (MKL-DNN/DNNL).
   * Python3 environment built from CPython 3.7 and containing:
     - NumPy 1.17.1
     - TensorFlow 1.15.2 or TensorFlow 2.2.0
   * TensorFlow Benchmarks
 
-A user account with username 'ubuntu' is created with sudo privaleges and password of 'Arm2020'. 
+A user account with username 'ubuntu' is created with sudo privaleges and password of 'Arm2020'.
 
 The TensorFlow Benchmarks repository are installed into the user home directory.
 
@@ -31,13 +31,13 @@ For example, to run the tf_cnn_benchmark for ResNet50:
 
 ``` > python tf_cnn_benchmarks.py --device=CPU --batch_size=64 --model=resnet50 --variable_update=parameter_server --data_format=NHWC ```
 
-In addition to the Dockerfile, please look at the files in the scripts/ directory and the patches/ directory too see how the software is built. 
+In addition to the Dockerfile, please look at the files in the scripts/ directory and the patches/ directory too see how the software is built.
 
 
 ## Installing Docker
 The [Docker Community Engine](https://docs.docker.com/install/) is used. Instructions on how to install Docker CE are available for various Linux distributions such as [CentOS](https://docs.docker.com/install/linux/docker-ce/centos/) and [Ubuntu](https://docs.docker.com/install/linux/docker-ce/ubuntu/).
 
-Confirm Docker is working: 
+Confirm Docker is working:
 
 ``` > docker run hello-world ```
 
@@ -61,7 +61,7 @@ Use the build.sh script to build the image. This script implements a multi-stage
   * Stage 3: 'tools' image, including a Python3 virtual environment in userspace and a build of NumPy against OpenBLAS, as well as other Python essentials.
   * Stage 4: 'dev' image, including Bazel and TensorFlow and the source code
   * Stage 5: 'tensorflow' image, including only the Python3 virtual environment, the TensorFlow module, and the basic benchmarks. Bazel and TensorFlow sources are not included in this image.
-      
+
 To see the command line options for build.sh use:
 
 ``` > ./build.sh -h ```
@@ -83,13 +83,14 @@ For example:
     ```  > ./build.sh --build-type base ```
 
   * To choose between the different tensorflow versions use '--tf_version 1' for TensorFlow 1.15.2 or '--tf_version 2' for TensorFlow 2.2.0. The default value is set to tf_version=1.
-    For the base build: This will generate an image named 'DockerTest/ubuntu/base-v$tf_version', hyphenated with the version of TensorFlow chosen. 
+    For the base build: This will generate an image named 'DockerTest/ubuntu/base-v$tf_version', hyphenated with the version of TensorFlow chosen.
 
-TensorFlow can optionally be built with DNNL, using the '--dnnl' flag, either using the C++ reference kernels throughout,
-'--dnnl reference', or with the addition of OpenBLAS for BLAS calls '--dnnl openblas'.
+TensorFlow can optionally be built with oneDNN, using the '--onednn' or '--dnnl' flag, either using the C++ reference kernels throughout,
+'--onednn reference', or with the addition of OpenBLAS for BLAS calls '--onednn openblas'. Tensorflow 1.x is built with oneDNN 0.21.3 (MKL-DNN) and Tensorflow 2.x is built with oneDNN 1.4.
+Without the '--onednn' flag, the default Eigen backend of Tensorflow is chosen. For the final TensorFlow image with oneDNN: This will generate an image 'tensorflow-v$tf_version$onednn_blas with the type of onednn backend chosen.
 
 Memory requirements for building TensorFlow can be singificant, and may exceed the available
-memory, paricuarly for parallel builds (the default). There are two flags which can be used to 
+memory, particularly for parallel builds (the default). There are two flags which can be used to
 control the resources Bazel consumes:
 
   * --jobs sets the number of jobs to run in parallel during the build, this will apply to all parallel builds/

--- a/docker/tensorflow-aarch64/patches/oneDNN-header.patch
+++ b/docker/tensorflow-aarch64/patches/oneDNN-header.patch
@@ -1,0 +1,96 @@
+ *******************************************************************************
+ Copyright 2020 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+
+--- a/tensorflow/core/kernels/mkl_batch_matmul_op.cc	2020-07-02 18:52:22.615849143 +0100
++++ b/tensorflow/core/kernels/mkl_batch_matmul_op.cc	2020-07-02 18:56:20.805094932 +0100
+@@ -25,7 +25,7 @@
+ 
+ #define EIGEN_USE_THREADS
+ 
+-#if defined(INTEL_MKL) && !defined(INTEL_MKL_DNN_ONLY)
++#if defined(INTEL_MKL) && !defined(ENABLE_MKLDNN_V1)
+ #include <vector>
+ 
+ #include "mkl_cblas.h"
+--- a/tensorflow/core/kernels/mkl_transpose_op.cc	2020-07-02 19:04:36.013531269 +0100
++++ b/tensorflow/core/kernels/mkl_transpose_op.cc	2020-07-02 19:09:48.412553051 +0100
+@@ -19,7 +19,7 @@
+ 
+ #define EIGEN_USE_THREADS
+ 
+-#if !defined(INTEL_MKL_DNN_ONLY)
++#if !defined(ENABLE_MKLDNN_V1)
+ #include "mkl_trans.h"
+ #endif
+ 
+@@ -50,7 +50,7 @@
+ // REQUIRES: perm is a permutation.
+ 
+ namespace {
+-#if !defined(INTEL_MKL_DNN_ONLY)
++#if !defined(ENABLE_MKLDNN_V1)
+ template <typename T>
+ Status MKLTranspose2D(const char trans, const Tensor& in, Tensor* out);
+ 
+@@ -104,7 +104,7 @@
+ static const char kMKLTranspose = 'T';
+ static const char kMKLConjugateTranspose = 'C';
+ 
+-#endif  // if !defined(INTEL_MKL_DNN_ONLY)
++#endif  // #if !defined(ENABLE_MKLDNN_V1)
+ 
+ // MKL-DNN based Transpose implementation
+ template <typename T>
+@@ -171,7 +171,7 @@
+ Status MklTransposeCpuOp::DoTranspose(OpKernelContext* ctx, const Tensor& in,
+                                       gtl::ArraySlice<int32> perm,
+                                       Tensor* out) {
+-#if !defined(INTEL_MKL_DNN_ONLY)
++#if !defined(ENABLE_MKLDNN_V1)
+   if (in.dims() == 2) {
+     if (perm[0] == 0 && perm[1] == 1) {
+       return Status::OK();
+@@ -217,7 +217,7 @@
+                                                const Tensor& in,
+                                                gtl::ArraySlice<int32> perm,
+                                                Tensor* out) {
+-#if !defined(INTEL_MKL_DNN_ONLY)
++#if !defined(ENABLE_MKLDNN_V1)
+   if (in.dims() == 2 && perm[0] == 1 && perm[1] == 0) {
+     // TODO(rmlarsen): By setting lda and ldb, we could use the MKL kernels
+     // for any transpose that can be reduced to swapping the last two
+--- a/tensorflow/core/common_runtime/mkl_cpu_allocator.h	2020-07-02 19:00:22.934328245 +0100
++++ b/tensorflow/core/common_runtime/mkl_cpu_allocator.h	2020-07-02 19:02:32.083919332 +0100
+@@ -29,7 +29,7 @@
+ #include "tensorflow/core/platform/mem.h"
+ #include "tensorflow/core/platform/numa.h"
+ 
+-#ifndef INTEL_MKL_DNN_ONLY
++#ifndef ENABLE_MKLDNN_V1
+ #include "i_malloc.h"
+ #endif
+ 
+@@ -186,7 +186,7 @@
+         new MklSmallSizeAllocator(sub_allocator_, max_mem_bytes, kName);
+     large_size_allocator_ =
+         new BFCAllocator(sub_allocator_, max_mem_bytes, kAllowGrowth, kName);
+-#ifndef INTEL_MKL_DNN_ONLY
++#ifndef ENABLE_MKLDNN_V1
+     // For redirecting all allocations from MKL to this allocator
+     // From: http://software.intel.com/en-us/node/528565
+     i_malloc = MallocHook;

--- a/docker/tensorflow-aarch64/patches/onednn.patch
+++ b/docker/tensorflow-aarch64/patches/onednn.patch
@@ -16,21 +16,15 @@
  *******************************************************************************
 
 
-diff --git a/cmake/platform.cmake b/cmake/platform.cmake
-index a12090e5e..e756b4ceb 100644
---- a/cmake/platform.cmake
-+++ b/cmake/platform.cmake
-@@ -130,7 +130,12 @@ elseif(UNIX OR MINGW)
-             append(CMAKE_CCXX_SANITIZER_FLAGS "-g -fno-omit-frame-pointer")
-         endif()
+--- a/cmake/platform.cmake	2020-06-11 13:53:30.730815324 +0100
++++ b/cmake/platform.cmake	2020-06-11 13:53:39.630778444 +0100
+@@ -141,7 +141,8 @@
      elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
--        set(DEF_ARCH_OPT_FLAGS "-msse4.1")
-+        if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
-+            set(DEF_ARCH_OPT_FLAGS "-O3 -mcpu=native")
-+            list(APPEND EXTRA_SHARED_LIBS "-L$ENV{OPENBLAS_DIR}/lib -lopenblas")
-+        else()
-+            set(DEF_ARCH_OPT_FLAGS "-msse4.1")
-+        endif()
-         # suppress warning on assumptions made regarding overflow (#146)
-         append(CMAKE_CCXX_NOWARN_FLAGS "-Wno-strict-overflow")
-     elseif(CMAKE_CXX_COMPILER_ID STREQUAL "Intel")
+         if(TARGET_ARCH STREQUAL "AARCH64")
+              set(DEF_ARCH_OPT_FLAGS "-O3 -mcpu=native")
+-             set(DNNL_ENABLE_JIT_PROFILING CACHE BOOL "OFF" FORCE)
++             list(APPEND EXTRA_SHARED_LIBS "-L$ENV{OPENBLAS_DIR}/lib -lopenblas")
++	      set(DNNL_ENABLE_JIT_PROFILING CACHE BOOL "OFF" FORCE)
+              message(WARNING "AArch64 build, DNNL_ENABLE_JIT_PROFILING is OFF")
+         else()
+              set(DEF_ARCH_OPT_FLAGS "-msse4.1")

--- a/docker/tensorflow-aarch64/patches/tensorflow2.patch
+++ b/docker/tensorflow-aarch64/patches/tensorflow2.patch
@@ -24,7 +24,7 @@
      ctx.actions.run(
 -        executable = ctx.executable._swig,
 +        use_default_shell_env = True,
-+	executable = ctx.executable._swig,
++        executable = ctx.executable._swig,
          arguments = args,
          inputs = inputs,
          outputs = outputs,

--- a/docker/tensorflow-aarch64/patches/tf2_onednn_decoupling.patch
+++ b/docker/tensorflow-aarch64/patches/tf2_onednn_decoupling.patch
@@ -15,24 +15,10 @@
  limitations under the License.
  *******************************************************************************
 
-
---- a/tensorflow/workspace.bzl	2020-05-27 16:13:18.391287600 +0100
-+++ b/tensorflow/workspace.bzl	2020-05-27 16:16:01.170799341 +0100
-@@ -161,26 +161,16 @@
-     # MKL-DNN might require upgrading MKL ML libraries also. If they need to be
-     # upgraded then update the version numbers on all three versions above
-     # (Linux, Mac, Windows).
--    tf_http_archive(
-+    native.new_local_repository(
-         name = "mkl_dnn",
-         build_file = clean_dep("//third_party/mkl_dnn:mkldnn.BUILD"),
--        sha256 = "31e78581e59d7e60d4becaba3834fc6a5bf2dccdae3e16b7f70d89ceab38423f",
--        strip_prefix = "mkl-dnn-0.21.3",
--        urls = [
--            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/intel/mkl-dnn/archive/v0.21.3.tar.gz",
--            "https://github.com/intel/mkl-dnn/archive/v0.21.3.tar.gz",
--        ],
-+    	path = '/opt/dnnl/0.21.3'
+--- a/tensorflow/workspace.bzl	2020-07-02 17:26:44.891394118 +0100
++++ b/tensorflow/workspace.bzl	2020-07-02 17:29:52.660850305 +0100
+@@ -172,15 +172,10 @@
+         ],
      )
  
 -    tf_http_archive(
@@ -45,42 +31,44 @@
 -            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/intel/mkl-dnn/archive/v1.2.2.tar.gz",
 -            "https://github.com/intel/mkl-dnn/archive/v1.2.2.tar.gz",
 -        ],
-+        path = '/opt/dnnl/1.1.2'
++    	path = '/opt/onednn/1.4'
      )
  
      tf_http_archive(
---- a/third_party/mkl_dnn/mkldnn.BUILD	2020-05-27 16:07:07.902398888 +0100
-+++ b/third_party/mkl_dnn/mkldnn.BUILD	2020-05-27 16:11:36.971591810 +0100
-@@ -18,16 +18,6 @@
+--- a/third_party/mkl_dnn/mkldnn_v1.BUILD	2020-07-02 18:44:14.727373197 +0100
++++ b/third_party/mkl_dnn/mkldnn_v1.BUILD	2020-07-02 18:50:31.006202548 +0100
+@@ -18,18 +18,6 @@
      },
  )
  
 -template_rule(
--    name = "mkldnn_config_h",
--    src = "include/mkldnn_config.h.in",
--    out = "include/mkldnn_config.h",
+-    name = "dnnl_config_h",
+-    src = "include/dnnl_config.h.in",
+-    out = "include/dnnl_config.h",
 -    substitutions = {
--        "#cmakedefine MKLDNN_CPU_BACKEND MKLDNN_BACKEND_${MKLDNN_CPU_BACKEND}": "#define MKLDNN_CPU_BACKEND MKLDNN_BACKEND_NATIVE",
--        "#cmakedefine MKLDNN_GPU_BACKEND MKLDNN_BACKEND_${MKLDNN_GPU_BACKEND}": "#define MKLDNN_GPU_BACKEND MKLDNN_BACKEND_NONE",
+-        "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_OMP",
+-        "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_OMP",
+-        "#cmakedefine DNNL_GPU_RUNTIME DNNL_RUNTIME_${DNNL_GPU_RUNTIME}": "#define DNNL_GPU_RUNTIME DNNL_RUNTIME_NONE",
 -    },
 -)
 -
- # Create the file mkldnn_version.h with MKL-DNN version numbers.
+-# Create the file mkldnn_version.h with MKL-DNN version numbers.
  # Currently, the version numbers are hard coded here. If MKL-DNN is upgraded then
  # the version numbers have to be updated manually. The version numbers can be
-@@ -38,61 +28,25 @@
- # TODO(bhavanis): MKL-DNN minor version needs to be updated for MKL-DNN v1.x.
- # The current version numbers will work only if MKL-DNN v0.21 is used.
+ # obtained from the PROJECT_VERSION settings in CMakeLists.txt. The variable is
+@@ -37,61 +25,24 @@
+ # be set to NA.
+ # TODO(agramesh1) Automatically get the version numbers from CMakeLists.txt.
  
 -template_rule(
--    name = "mkldnn_version_h",
--    src = "include/mkldnn_version.h.in",
--    out = "include/mkldnn_version.h",
+-    name = "dnnl_version_h",
+-    src = "include/dnnl_version.h.in",
+-    out = "include/dnnl_version.h",
 -    substitutions = {
--        "@MKLDNN_VERSION_MAJOR@": "0",
--        "@MKLDNN_VERSION_MINOR@": "21",
--        "@MKLDNN_VERSION_PATCH@": "3",
--        "@MKLDNN_VERSION_HASH@": "N/A",
+-        "@DNNL_VERSION_MAJOR@": "1",
+-        "@DNNL_VERSION_MINOR@": "2",
+-        "@DNNL_VERSION_PATCH@": "0",
+-        "@DNNL_VERSION_HASH@": "N/A",
 -    },
 +cc_library(
 +    name = "mkldnn_headers",
@@ -88,14 +76,14 @@
 +    includes = ["include"],
 +    visibility = ["//visibility:public"],
  )
- 
- cc_library(
+-
++cc_library(
 +    name = "mkldnn_libs",
 +    srcs = glob(["lib/*"]),
 +    visibility = ["//visibility:public"],
-+ )
-+
-+cc_library(
++)
++ 
+ cc_library(
      name = "mkl_dnn",
 -    srcs = glob([
 -        "src/common/*.cpp",
@@ -106,8 +94,8 @@
 -        "src/cpu/**/*.hpp",
 -        "src/cpu/xbyak/*.h",
 -    ]) + if_mkl_v1_open_source_only([
--        ":mkldnn_config_h",
--    ]) + [":mkldnn_version_h"],
+-        ":dnnl_config_h",
+-    ]) + [":dnnl_version_h"],
 -    hdrs = glob(["include/*"]),
 -    copts = [
 -        "-fexceptions",
@@ -138,9 +126,9 @@
 -    ],
      visibility = ["//visibility:public"],
 -    deps = select({
-+    deps = ["@mkl_dnn//:mkldnn_headers",
-+            "@mkl_dnn//:mkldnn_libs",
-+           ] +  select({
++    deps = ["@mkl_dnn_v1//:mkldnn_headers",
++	    "@mkl_dnn_v1//:mkldnn_libs",
++ 	] + select({
          "@org_tensorflow//tensorflow:linux_x86_64": [
              "@mkl_linux//:mkl_headers",
              "@mkl_linux//:mkl_libs_linux",

--- a/docker/tensorflow-aarch64/patches/tf_dnnl_decoupling.patch
+++ b/docker/tensorflow-aarch64/patches/tf_dnnl_decoupling.patch
@@ -16,11 +16,9 @@
  *******************************************************************************
 
 
-diff --git a/tensorflow/workspace.bzl b/tensorflow/workspace.bzl
-index 25484734fc..1840ea944d 100755
---- a/tensorflow/workspace.bzl
-+++ b/tensorflow/workspace.bzl
-@@ -132,26 +132,16 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
+--- a/tensorflow/workspace.bzl	2020-07-08 10:24:27.672149000 +0100
++++ b/tensorflow/workspace.bzl	2020-07-08 10:24:41.020335000 +0100
+@@ -132,15 +132,10 @@
      # MKL-DNN might require upgrading MKL ML libraries also. If they need to be
      # upgraded then update the version numbers on all three versions above
      # (Linux, Mac, Windows).
@@ -34,32 +32,16 @@ index 25484734fc..1840ea944d 100755
 -            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/intel/mkl-dnn/archive/v0.20.6.tar.gz",
 -            "https://github.com/intel/mkl-dnn/archive/v0.20.6.tar.gz",
 -        ],
--    )
-+        path = '/opt/dnnl/0.21.3'
-+    ) 
- 
--    tf_http_archive(
-+    native.new_local_repository(
-         name = "mkl_dnn_v1",
-         build_file = clean_dep("//third_party/mkl_dnn:mkldnn.BUILD"),
--        sha256 = "fcc2d951f7170eade0cfdd0d8d1d58e3e7785bd326bca6555f3722f8cba71811",
--        strip_prefix = "mkl-dnn-1.0-pc2",
--        urls = [
--            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/intel/mkl-dnn/archive/v1.0-pc2.tar.gz",
--            "https://github.com/intel/mkl-dnn/archive/v1.0-pc2.tar.gz",
--        ],
-+        path = '/opt/dnnl/1.1.2'
++        path = '/opt/onednn/0.21.3'
      )
  
      tf_http_archive(
-diff --git a/third_party/mkl_dnn/mkldnn.BUILD b/third_party/mkl_dnn/mkldnn.BUILD
-index 35832ffcef..03f7645a1a 100644
---- a/third_party/mkl_dnn/mkldnn.BUILD
-+++ b/third_party/mkl_dnn/mkldnn.BUILD
-@@ -18,16 +18,6 @@ config_setting(
+--- a/third_party/mkl_dnn/mkldnn.BUILD	2020-07-08 10:25:04.878131000 +0100
++++ b/third_party/mkl_dnn/mkldnn.BUILD	2020-07-08 10:31:41.261234000 +0100
+@@ -18,16 +18,6 @@
      },
  )
-
+ 
 -template_rule(
 -    name = "mkldnn_config_h",
 -    src = "include/mkldnn_config.h.in",
@@ -73,10 +55,10 @@ index 35832ffcef..03f7645a1a 100644
  # Create the file mkldnn_version.h with MKL-DNN version numbers.
  # Currently, the version numbers are hard coded here. If MKL-DNN is upgraded then
  # the version numbers have to be updated manually. The version numbers can be
-@@ -38,61 +28,25 @@ template_rule(
+@@ -38,61 +28,25 @@
  # TODO(bhavanis): MKL-DNN minor version needs to be updated for MKL-DNN v1.x.
  # The current version numbers will work only if MKL-DNN v0.20 is used.
-
+ 
 -template_rule(
 -    name = "mkldnn_version_h",
 -    src = "include/mkldnn_version.h.in",
@@ -99,7 +81,7 @@ index 35832ffcef..03f7645a1a 100644
 +    srcs = glob(["lib/*"]),
 +    visibility = ["//visibility:public"],
  )
-
+ 
  cc_library(
      name = "mkl_dnn",
 -    srcs = glob([


### PR DESCRIPTION
- Changes include renaming of previous --dnnl flags to --onednn.
- New oneDNN-header patches to address: https://github.com/tensorflow/tensorflow/issues/40771
- Build log files for each flavour of Tensorflow build.