### PR TITLE
Fix build errors and failing tests

### DIFF
--- a/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/cmsis.inc
+++ b/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/cmsis.inc
@@ -4,16 +4,10 @@ ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
         # CMSIS-NN optimizations not supported
     endif
 
-    # Setup CMSIS-NN lib and add required header files to microlite lib INCLUDE
-    THIRD_PARTY_DOWNLOADS += \
-      $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
-
     ifneq (,$(filter $(TARGET_ARCH), cortex-m55))
       CCFLAGS += -DARM_MATH_MVEI
       CXXFLAGS += -DARM_MATH_MVEI
     endif
-
-    CMSIS_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
 
     # Include CMSIS-NN files
     THIRD_PARTY_CC_SRCS += \

--- a/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/cmsis.inc
+++ b/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/cmsis.inc
@@ -31,7 +31,7 @@ ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
 
     INCLUDES += -I$(CMSIS_PATH)/CMSIS/Core/Include \
                 -I$(CMSIS_PATH)/CMSIS/NN/Include \
-                -I$(CMSIS_PATH)/CMSIS/DSP/Include 
+                -I$(CMSIS_PATH)/CMSIS/DSP/Include
 
     GENERATED_PROJECT_INCLUDES += -I$(CMSIS_PATH)/CMSIS/Core/Include \
                                   -I$(CMSIS_PATH)/CMSIS/NN/Include \

--- a/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/cmsis.inc
+++ b/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/cmsis.inc
@@ -9,6 +9,15 @@ ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
       CXXFLAGS += -DARM_MATH_MVEI
     endif
 
+    # You can use the tensorflow defined CMSIS if you do not define CMSIS_PATH
+    ifeq ($(CMSIS_PATH),) 
+      # Setup CMSIS-NN lib and add required header files to microlite lib INCLUDE
+      THIRD_PARTY_DOWNLOADS += \
+      $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
+
+      CMSIS_PATH = $(MAKEFILE_DIR)/downloads/cmsis/
+    endif
+
     # Include CMSIS-NN files
     THIRD_PARTY_CC_SRCS += \
       $(call recursive_find,$(CMSIS_PATH)/CMSIS/NN/Source,*.c)
@@ -22,9 +31,10 @@ ifneq ($(filter cmsis-nn,$(ALL_TAGS)),)
 
     INCLUDES += -I$(CMSIS_PATH)/CMSIS/Core/Include \
                 -I$(CMSIS_PATH)/CMSIS/NN/Include \
-                -I$(CMSIS_PATH)/CMSIS/DSP/Include
+                -I$(CMSIS_PATH)/CMSIS/DSP/Include 
 
-GENERATED_PROJECT_INCLUDES += -I$(CMSIS_PATH)/CMSIS/Core/Include \
+    GENERATED_PROJECT_INCLUDES += -I$(CMSIS_PATH)/CMSIS/Core/Include \
                                   -I$(CMSIS_PATH)/CMSIS/NN/Include \
-                                  -I$(CMSIS_PATH)/CMSIS/DSP/Include
+                                  -I$(CMSIS_PATH)/CMSIS/DSP/Include \
+                                  -I$(CMSIS_PATH)/../ 
 endif

--- a/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/ipss_makefile.inc
+++ b/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/ipss_makefile.inc
@@ -29,7 +29,7 @@ ifeq ($(TARGET),$(filter $(TARGET),ipss model))
         $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/core_armv81mml.h \
         $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/mpu_armv8.h
     LDFLAGS+=--cpu=8.1-M.Main.dsp -Omax --entry=__start
-    TARGET_SPECIFIC_FLAGS=-D__DSP_PRESENT=1
+    TARGET_SPECIFIC_FLAGS=
     FLOAT=hard
   else ifeq ($(TARGET_ARCH), cortex-m33+nodsp)
     CORE=M33

--- a/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/ipss_makefile.inc
+++ b/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/ipss_makefile.inc
@@ -18,15 +18,15 @@ ifeq ($(TARGET),$(filter $(TARGET),ipss model))
       OPTIMIZATION := -O3
     endif
   endif
-
+  
   FLOAT := soft
 
   ifeq ($(TARGET_ARCH), cortex-m55)
     CORE=M55
     THIRD_PARTY_CC_HDRS += \
-        $(CMSIS_PATH)/CMSIS/Core/Include/core_cm55.h \
+        $(CMSIS_PATH)/CMSIS/Core/Include/core_armv81mml.h \
         $(CMSIS_PATH)/CMSIS/Core/Include/mpu_armv8.h
-    LDFLAGS+=--cpu=Cortex-M55 -Omax --entry=__start
+    LDFLAGS+=--cpu=8.1-M.Main.dsp -Omax --entry=__start
     TARGET_SPECIFIC_FLAGS=
     FLOAT=hard
   else ifeq ($(TARGET_ARCH), cortex-m33+nodsp)
@@ -82,18 +82,11 @@ ifeq ($(TARGET),$(filter $(TARGET),ipss model))
     $(OPTIMIZATION)
 
   INCLUDES += \
-    -I$(MAKEFILE_DIR)/targets/ipss \
-    -I$(CMSIS_PATH)/CMSIS/Core/Include/ \
-    -I$(CMSIS_PATH)/CMSIS/DSP/Include/ \
-    -I$(CMSIS_PATH)/CMSIS/NN/Include/
+    -I$(MAKEFILE_DIR)/targets/ipss 
 
   GENERATED_PROJECT_INCLUDES += \
     -I$(MAKEFILE_DIR)/targets/ipss \
-    -I$(MAKEFILE_DIR)/downloads/ \
-    -I$(CMSIS_PATH)/../ \
-    -I$(CMSIS_PATH)/CMSIS/Core/Include/ \
-    -I$(CMSIS_PATH)/CMSIS/DSP/Include/ \
-    -I$(CMSIS_PATH)/CMSIS/NN/Include/
+    -I$(MAKEFILE_DIR)/downloads/
 
   THIRD_PARTY_CC_SRCS += \
     $(MAKEFILE_DIR)/targets/ipss/flatbuffer_version_dummy.cc \

--- a/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/ipss_makefile.inc
+++ b/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/ipss_makefile.inc
@@ -19,51 +19,49 @@ ifeq ($(TARGET),$(filter $(TARGET),ipss model))
     endif
   endif
 
-  $(eval $(call add_third_party_download,$(CMSIS_URL),$(CMSIS_MD5),cmsis,))
-
   FLOAT := soft
 
   ifeq ($(TARGET_ARCH), cortex-m55)
     CORE=M55
     THIRD_PARTY_CC_HDRS += \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/core_armv81mml.h \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/mpu_armv8.h
-    LDFLAGS+=--cpu=8.1-M.Main.dsp -Omax --entry=__start
+        $(CMSIS_PATH)/CMSIS/Core/Include/core_cm55.h \
+        $(CMSIS_PATH)/CMSIS/Core/Include/mpu_armv8.h
+    LDFLAGS+=--cpu=Cortex-M55 -Omax --entry=__start
     TARGET_SPECIFIC_FLAGS=
     FLOAT=hard
   else ifeq ($(TARGET_ARCH), cortex-m33+nodsp)
     CORE=M33
     NO_DSP=.no_dsp
     THIRD_PARTY_CC_HDRS += \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/core_cm33.h \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/mpu_armv8.h
+        $(CMSIS_PATH)/CMSIS/Core/Include/core_cm33.h \
+        $(CMSIS_PATH)/CMSIS/Core/Include/mpu_armv8.h
     LDFLAGS+=--cpu=Cortex-M33.no_dsp.no_fp -Omax
     TARGET_SPECIFIC_FLAGS=
   else ifeq ($(TARGET_ARCH), cortex-m0)
     CORE=M0
     THIRD_PARTY_CC_HDRS += \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/core_cm0.h
+        $(CMSIS_PATH)/CMSIS/Core/Include/core_cm0.h
     LDFLAGS+=--cpu=Cortex-M0 -Omax
     TARGET_SPECIFIC_FLAGS=
   else ifeq ($(TARGET_ARCH), cortex-m3)
     CORE=M3
     THIRD_PARTY_CC_HDRS += \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/core_cm3.h \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/mpu_armv7.h
+        $(CMSIS_PATH)/CMSIS/Core/Include/core_cm3.h \
+        $(CMSIS_PATH)/CMSIS/Core/Include/mpu_armv7.h
     LDFLAGS+=--cpu=Cortex-M3 -Omax
     TARGET_SPECIFIC_FLAGS=
   else ifeq ($(TARGET_ARCH), cortex-m4)
     CORE=M4
     THIRD_PARTY_CC_HDRS += \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/core_cm4.h \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/mpu_armv7.h
+        $(CMSIS_PATH)/CMSIS/Core/Include/core_cm4.h \
+        $(CMSIS_PATH)/CMSIS/Core/Include/mpu_armv7.h
     LDFLAGS+=--cpu=Cortex-M4.no_fp -Omax
     TARGET_SPECIFIC_FLAGS=
   else ifeq ($(TARGET_ARCH), cortex-m7)
     CORE=M7
     THIRD_PARTY_CC_HDRS += \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/core_cm7.h \
-        $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/mpu_armv7.h
+        $(CMSIS_PATH)/CMSIS/Core/Include/core_cm7.h \
+        $(CMSIS_PATH)/CMSIS/Core/Include/mpu_armv7.h
     LDFLAGS+=--cpu=Cortex-M7.no_fp -Omax
     TARGET_SPECIFIC_FLAGS=
   endif
@@ -85,16 +83,17 @@ ifeq ($(TARGET),$(filter $(TARGET),ipss model))
 
   INCLUDES += \
     -I$(MAKEFILE_DIR)/targets/ipss \
-    -I$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/ \
-    -I$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/ \
-    -I$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/NN/Include/
+    -I$(CMSIS_PATH)/CMSIS/Core/Include/ \
+    -I$(CMSIS_PATH)/CMSIS/DSP/Include/ \
+    -I$(CMSIS_PATH)/CMSIS/NN/Include/
 
   GENERATED_PROJECT_INCLUDES += \
     -I$(MAKEFILE_DIR)/targets/ipss \
     -I$(MAKEFILE_DIR)/downloads/ \
-    -I$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/ \
-    -I$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/ \
-    -I$(MAKEFILE_DIR)/downloads/cmsis/CMSIS/NN/Include/
+    -I$(CMSIS_PATH)/../ \
+    -I$(CMSIS_PATH)/CMSIS/Core/Include/ \
+    -I$(CMSIS_PATH)/CMSIS/DSP/Include/ \
+    -I$(CMSIS_PATH)/CMSIS/NN/Include/
 
   THIRD_PARTY_CC_SRCS += \
     $(MAKEFILE_DIR)/targets/ipss/flatbuffer_version_dummy.cc \
@@ -106,19 +105,19 @@ ifeq ($(TARGET),$(filter $(TARGET),ipss model))
     $(MAKEFILE_DIR)/targets/ipss/uart_stdout.h \
     $(MAKEFILE_DIR)/targets/ipss/app.scatter \
     $(MAKEFILE_DIR)/targets/ipss/cmsis.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/cmsis_compiler.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/cmsis_armclang.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/Core/Include/cmsis_version.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/NN/Include/arm_nnfunctions.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/NN/Include/arm_nnsupportfunctions.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/NN/Include/arm_nn_tables.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/NN/Include/arm_nn_types.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/arm_common_tables.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/arm_const_structs.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/arm_helium_utils.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/arm_math.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/arm_mve_tables.h \
-    $(MAKEFILE_DIR)/downloads/cmsis/CMSIS/DSP/Include/arm_vec_math.h
+    $(CMSIS_PATH)/CMSIS/Core/Include/cmsis_compiler.h \
+    $(CMSIS_PATH)/CMSIS/Core/Include/cmsis_armclang.h \
+    $(CMSIS_PATH)/CMSIS/Core/Include/cmsis_version.h \
+    $(CMSIS_PATH)/CMSIS/NN/Include/arm_nnfunctions.h \
+    $(CMSIS_PATH)/CMSIS/NN/Include/arm_nnsupportfunctions.h \
+    $(CMSIS_PATH)/CMSIS/NN/Include/arm_nn_tables.h \
+    $(CMSIS_PATH)/CMSIS/NN/Include/arm_nn_types.h \
+    $(CMSIS_PATH)/CMSIS/DSP/Include/arm_common_tables.h \
+    $(CMSIS_PATH)/CMSIS/DSP/Include/arm_const_structs.h \
+    $(CMSIS_PATH)/CMSIS/DSP/Include/arm_helium_utils.h \
+    $(CMSIS_PATH)/CMSIS/DSP/Include/arm_math.h \
+    $(CMSIS_PATH)/CMSIS/DSP/Include/arm_mve_tables.h \
+    $(CMSIS_PATH)/CMSIS/DSP/Include/arm_vec_math.h
     
 
   CXXFLAGS += $(PLATFORM_FLAGS)

--- a/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/ipss_makefile.inc
+++ b/docker/tensorflow-lite-micro-models/TFLite_micro_IPSS_Support/ipss_makefile.inc
@@ -27,7 +27,7 @@ ifeq ($(TARGET),$(filter $(TARGET),ipss model))
         $(CMSIS_PATH)/CMSIS/Core/Include/core_armv81mml.h \
         $(CMSIS_PATH)/CMSIS/Core/Include/mpu_armv8.h
     LDFLAGS+=--cpu=8.1-M.Main.dsp -Omax --entry=__start
-    TARGET_SPECIFIC_FLAGS=
+    TARGET_SPECIFIC_FLAGS=-D__DSP_PRESENT=1
     FLOAT=hard
   else ifeq ($(TARGET_ARCH), cortex-m33+nodsp)
     CORE=M33
@@ -82,11 +82,17 @@ ifeq ($(TARGET),$(filter $(TARGET),ipss model))
     $(OPTIMIZATION)
 
   INCLUDES += \
-    -I$(MAKEFILE_DIR)/targets/ipss 
+    -I$(MAKEFILE_DIR)/targets/ipss \
+    -I$(CMSIS_PATH)/CMSIS/Core/Include/ \
+    -I$(CMSIS_PATH)/CMSIS/DSP/Include/ \
+    -I$(CMSIS_PATH)/CMSIS/CMSIS/NN/Include/
 
   GENERATED_PROJECT_INCLUDES += \
     -I$(MAKEFILE_DIR)/targets/ipss \
-    -I$(MAKEFILE_DIR)/downloads/
+    -I$(MAKEFILE_DIR)/downloads/ \
+    -I$(CMSIS_PATH)/CMSIS/Core/Include/ \
+    -I$(CMSIS_PATH)/CMSIS/DSP/Include/ \
+    -I$(CMSIS_PATH)/CMSIS/CMSIS/NN/Include/
 
   THIRD_PARTY_CC_SRCS += \
     $(MAKEFILE_DIR)/targets/ipss/flatbuffer_version_dummy.cc \

--- a/docker/tensorflow-lite-micro-models/build_tflite_micro_test.sh
+++ b/docker/tensorflow-lite-micro-models/build_tflite_micro_test.sh
@@ -17,7 +17,7 @@ usage() {
 mydir="$(dirname $0)"
 
 # Location of CMSIS
-CMSIS_DIR=$mydir/../CMSIS_REPO/CMSIS_5
+CMSIS_DIR=$mydir/../CMSIS_REPO/cmsis
 
 #Currently only CPU supported is M55
 CPU=M55

--- a/docker/tensorflow-lite-micro-models/build_tflite_micro_test.sh
+++ b/docker/tensorflow-lite-micro-models/build_tflite_micro_test.sh
@@ -47,7 +47,7 @@ mkdir -p $SW
 
 # Build the make files for the tflite-micro example selected
 cd tensorflow/
-make -f tensorflow/lite/micro/tools/make/Makefile TARGET=ipss TARGET_ARCH=cortex-m55 TAGS="armclang cmsis-nn" CMSIS_PATH=$CMSIS_DIR generate_"$APP"_test_make_project
+make -f tensorflow/lite/micro/tools/make/Makefile TARGET=ipss TARGET_ARCH=cortex-m55 TAGS="armclang cmsis-nn"  generate_"$APP"_test_make_project
 
 pushd tensorflow/lite/micro/tools/make/gen/ipss_cortex-m55/prj/"$APP"_test/make
 make -j8 

--- a/docker/tensorflow-lite-micro-models/build_tflite_micro_test.sh
+++ b/docker/tensorflow-lite-micro-models/build_tflite_micro_test.sh
@@ -47,7 +47,7 @@ mkdir -p $SW
 
 # Build the make files for the tflite-micro example selected
 cd tensorflow/
-make -f tensorflow/lite/micro/tools/make/Makefile TARGET=ipss TARGET_ARCH=cortex-m55 TAGS="armclang cmsis-nn"  generate_"$APP"_test_make_project
+make -f tensorflow/lite/micro/tools/make/Makefile TARGET=ipss TARGET_ARCH=cortex-m55 TAGS="armclang cmsis-nn" CMSIS_PATH=$CMSIS_DIR generate_"$APP"_test_make_project
 
 pushd tensorflow/lite/micro/tools/make/gen/ipss_cortex-m55/prj/"$APP"_test/make
 make -j8 

--- a/docker/tensorflow-lite-micro-models/download_tflow_cmsis.sh
+++ b/docker/tensorflow-lite-micro-models/download_tflow_cmsis.sh
@@ -40,20 +40,3 @@ sed -i '/fc_params.input_offset = -data.input_zero_point;/\,/fc_params.output_of
     fc_params.filter_offset = -data.filter_zero_point;\
     fc_params.output_offset = data.output_zero_point;' \
     ${TFLM_ROOT}/kernels/cmsis-nn/fully_connected.cc
-
-# Fix double-promotion warning in mul.cc
-sed -i -E 's#input1->params.scale \* input2->params.scale \/ output->params.scale;#static_cast<double>\(input1->params.scale\) \*\
-        static_cast<double>\(input2->params.scale\) \/\
-        static_cast<double>\(output->params.scale\);#' \
-        ${TFLM_ROOT}/kernels/cmsis-nn/mul.cc
-
-# Fix missing-field-initializers warning in mul.cc
-sed -i -E 's#return \{mul::Init, nullptr \/\* Free \*\/, mul::Prepare, mul::Eval\};#return \{mul::Init,\
-        nullptr \/\* Free \*\/,\
-        mul::Prepare,\
-        mul::Eval, \
-        \/\*profiling_string=\*\/nullptr,\
-        \/\*builtin_code=\*\/0,\
-        \/\*custom_name=\*\/nullptr,\
-        \/\*version=\*\/0\};#' \
-        ${TFLM_ROOT}/kernels/cmsis-nn/mul.cc

--- a/docker/tensorflow-lite-micro-models/download_tflow_cmsis.sh
+++ b/docker/tensorflow-lite-micro-models/download_tflow_cmsis.sh
@@ -30,6 +30,16 @@ cp -r $PWD/TFLite_micro_IPSS_Support/armclang ${TFLM_ROOT}/tools/make/templates
 cp -r $PWD/TFLite_micro_IPSS_Support/ipss* ${TFLM_ROOT}/tools/make/targets/
 cp -r $PWD/TFLite_micro_IPSS_Support/cmsis.inc ${TFLM_ROOT}/tools/make/ext_libs/
 
+# Removing -Werror from armclang option, making the build fail
+sed -i -E 's#-Werror # #' ${TFLM_ROOT}/tools/make/Makefile
+
+# A fix for fully_connected.cc, making the tests fail. 
+# A line was removed in tensorflow commit 88461053262f02bbc15887daa172c02db7419780
+sed -i '/fc_params.input_offset = -data.input_zero_point;/\,/fc_params.output_offset = data.output_zero_point;/c\
+    fc_params.input_offset = -data.input_zero_point;\
+    fc_params.filter_offset = -data.filter_zero_point;\
+    fc_params.output_offset = data.output_zero_point;' \
+    ${TFLM_ROOT}/kernels/cmsis-nn/fully_connected.cc
 
 # Fix double-promotion warning in mul.cc
 sed -i -E 's#input1->params.scale \* input2->params.scale \/ output->params.scale;#static_cast<double>\(input1->params.scale\) \*\
@@ -45,6 +55,5 @@ sed -i -E 's#return \{mul::Init, nullptr \/\* Free \*\/, mul::Prepare, mul::Eval
         \/\*profiling_string=\*\/nullptr,\
         \/\*builtin_code=\*\/0,\
         \/\*custom_name=\*\/nullptr,\
-        \/\*version=\*\/0};#' \
+        \/\*version=\*\/0\};#' \
         ${TFLM_ROOT}/kernels/cmsis-nn/mul.cc
-

--- a/docker/tensorflow-lite-micro-models/download_tflow_cmsis.sh
+++ b/docker/tensorflow-lite-micro-models/download_tflow_cmsis.sh
@@ -2,6 +2,7 @@
 
 #CMSIS-repo location
 CMSIS_DIR=./CMSIS_REPO
+TFLM_ROOT=$PWD/tensorflow/tensorflow/lite/micro
 
 #Clone the tensorflow git repo if you haven't already
 if [ ! -d "tensorflow" ]
@@ -25,9 +26,26 @@ fi
 
 
 #Copy the files to the right locations
-cp -r $PWD/TFLite_micro_IPSS_Support/helper_functions.inc $PWD/tensorflow/tensorflow/lite/micro/tools/make/
-cp -r $PWD/TFLite_micro_IPSS_Support/armclang $PWD/tensorflow/tensorflow/lite/micro/tools/make/templates
-cp -r $PWD/TFLite_micro_IPSS_Support/ipss* $PWD/tensorflow/tensorflow/lite/micro/tools/make/targets/
-cp -r $PWD/TFLite_micro_IPSS_Support/cmsis.inc $PWD/tensorflow/tensorflow/lite/micro/tools/make/ext_libs/
+cp -r $PWD/TFLite_micro_IPSS_Support/helper_functions.inc ${TFLM_ROOT}/tools/make/
+cp -r $PWD/TFLite_micro_IPSS_Support/armclang ${TFLM_ROOT}/tools/make/templates
+cp -r $PWD/TFLite_micro_IPSS_Support/ipss* ${TFLM_ROOT}/tools/make/targets/
+cp -r $PWD/TFLite_micro_IPSS_Support/cmsis.inc ${TFLM_ROOT}/tools/make/ext_libs/
 
+
+# Fix double-promotion warning in mul.cc
+sed -i -E 's#input1->params.scale \* input2->params.scale \/ output->params.scale;#static_cast<double>\(input1->params.scale\) \*\
+        static_cast<double>\(input2->params.scale\) \/\
+        static_cast<double>\(output->params.scale\);#' \
+        ${TFLM_ROOT}/kernels/cmsis-nn/mul.cc
+
+# Fix missing-field-initializers warning in mul.cc
+sed -i -E 's#return \{mul::Init, nullptr \/\* Free \*\/, mul::Prepare, mul::Eval\};#return \{mul::Init,\
+        nullptr \/\* Free \*\/,\
+        mul::Prepare,\
+        mul::Eval, \
+        \/\*profiling_string=\*\/nullptr,\
+        \/\*builtin_code=\*\/0,\
+        \/\*custom_name=\*\/nullptr,\
+        \/\*version=\*\/0};#' \
+        ${TFLM_ROOT}/kernels/cmsis-nn/mul.cc
 

--- a/docker/tensorflow-lite-micro-models/download_tflow_cmsis.sh
+++ b/docker/tensorflow-lite-micro-models/download_tflow_cmsis.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 
 #CMSIS-repo location
-CMSIS_DIR=./CMSIS_REPO
+CMSIS_DIR=./CMSIS_REPO/cmsis
+#TensorFlow Lite Micro location
 TFLM_ROOT=$PWD/tensorflow/tensorflow/lite/micro
 
 #Clone the tensorflow git repo if you haven't already
@@ -14,15 +15,13 @@ fi
 
 
 #Clone CMSIS repo if you haven't already
-if [ ! -d "./CMSIS_REPO/CMSIS_5" ]
+if [ ! -d $CMSIS_DIR ]
 then
-    mkdir $CMSIS_DIR
-    pushd $CMSIS_DIR
-    git clone https://github.com/ARM-software/CMSIS_5.git
-    popd
+    git clone https://github.com/ARM-software/CMSIS_5.git $CMSIS_DIR
 else
     echo "CMSIS repo already cloned"
 fi
+
 
 
 #Copy the files to the right locations


### PR DESCRIPTION
The example builds generated some warnings, which were treated as errors in the build. 
I fix this by removing the -Werror flag in the TFL-m Makefile when running the download script.

The tests wouldn't run successfully because of this commit: https://github.com/tensorflow/tensorflow/commit/88461053262f02bbc15887daa172c02db7419780
Three was an error in the "fully_connected.cc" file, where a line seems to have been removed by mistake.
I insert the line with the download script.

I also changed so that the latest version of CMSIS is used for the build. Tensorflow has pinned an older version of CMSIS, so there were some mismatches between the CMSIS that TF includes, and the one that was downloaded with the download script and used as source. If we want to use the latest CMSIS, we don't need tensorflow to download an older version, that may create build errors. 