### PR TITLE
Add MLPerf/MLCommons benchmarks

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -248,7 +248,7 @@ RUN pip install git+https://github.com/pytorch/vision@$VISION_VERSION
 CMD ["bash", "-l"]
 
 # ========
-# Stage 5: install pytorch benchmarks
+# Stage 5: Install benchmarks
 # ========
 FROM pytorch-libs AS pytorch
 ARG njobs
@@ -264,5 +264,12 @@ ENV PATH="$VENV_DIR/bin:$PATH"
 # Clone PyTorch examples
 # NOTE: these examples are included as a startiing point
 RUN  git clone https://github.com/pytorch/examples.git
+
+# Clone and install  MLCommons (MLPerf)
+COPY scripts/build-mlcommons.sh $PACKAGE_DIR/.
+RUN $PACKAGE_DIR/build-mlcommons.sh
+# Copy scripts to download dataset and models
+COPY scripts/download-dataset.sh $PACKAGE_DIR/.
+COPY scripts/download-model.sh $PACKAGE_DIR/.
 
 CMD ["bash", "-l"]

--- a/docker/pytorch-aarch64/README.md
+++ b/docker/pytorch-aarch64/README.md
@@ -22,7 +22,7 @@ aarch64
     - SciPy 1.5.2
     - PyTorch 1.6
   * PyTorch examples, and some key dependencies such as Matplolib.
-
+  * [MLCommons (MLPerf)](https://mlperf.org/)
 A user account with username 'ubuntu' is created with sudo privaleges and password of 'Arm2020'.
 
 In addition to the Dockerfile, please look at the files in the scripts/ directory and the patches/ directory too see how the software is built.
@@ -93,4 +93,11 @@ To display available images use the Docker command:
 
   ``` > docker images ```
 
+## Running MLCommons benchmark
+Please refer to (https://github.com/mlperf/inference/tree/master/vision/classification_and_detection) for instructions to download datasets and models. Examples scripts are provided in the $HOME directory of the final image.
+To run resnet34 on coco dataset for object detection:
+  ``` export DATA_DIR=${HOME}/CK-TOOLS/dataset-coco-2017-val ```
+  ``` export MODEL_DIR=$(pwd) ```
+  ``` ./run_local.sh pytorch ssd-resnet34 cpu ```
 
+Use MKLDNN_VERBOSE=1 to verify the build uses oneDNN when running the benchmarks.

--- a/docker/pytorch-aarch64/scripts/build-mlcommons.sh
+++ b/docker/pytorch-aarch64/scripts/build-mlcommons.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+# *******************************************************************************
+# Copyright 2020 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+source python3-venv/bin/activate
+pip install cython
+pip install absl-py pillow pycocotools
+pip install ck
+ck pull repo:ck-env
+pip install scikit-build
+sudo apt-get -y install protobuf-compiler libprotoc-dev
+git clone https://github.com/mlcommons/inference.git --recursive
+cd inference
+git checkout master
+cd loadgen
+CFLAGS="-std=c++14" python setup.py develop
+cd ../vision/classification_and_detection
+python setup.py develop

--- a/docker/pytorch-aarch64/scripts/download-dataset.sh
+++ b/docker/pytorch-aarch64/scripts/download-dataset.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# This script is based on the upstream MLCommon's instructions to download datasets.
+# https://github.com/mlperf/inference/tree/master/vision/classification_and_detection
+
+# Download coco dataset
+ck install package --tags=object-detection,dataset,coco,2017,val,original

--- a/docker/pytorch-aarch64/scripts/download-model.sh
+++ b/docker/pytorch-aarch64/scripts/download-model.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# This script is  based on the upstream MLCommon's instructions to download models.
+# https://github.com/mlperf/inference/tree/master/vision/classification_and_detection
+
+cd vision/classification_and_detection
+# ssd-resnet34
+wget https://zenodo.org/record/3236545/files/resnet34-ssd1200.pytorch

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -207,9 +207,20 @@ RUN pip install --no-cache-dir keras_preprocessing==1.1.0 --no-deps
 RUN pip uninstall enum34 -y
 RUN HDF5_DIR=/usr/lib/aarch64-linux-gnu/hdf5/serial pip install h5py
 RUN pip install --no-cache-dir ck absl-py pycocotools
+
 # Install OpenCV into our venv,
-COPY scripts/build-opencv.sh $PACKAGE_DIR/.
-RUN $PACKAGE_DIR/build-opencv.sh
+# Note: Scripts are provided to build and install OpenCV from the
+# GitHub repository. These are no longer used by default in favour of the
+# opencv-python package, in this case opencv-python-headless.
+# Uncomment code block '1' below, and comment out code block '2' to build
+# from the GitHub sources.
+# --
+# 1 - build from GitHub sources:
+#COPY scripts/build-opencv.sh $PACKAGE_DIR/.
+#RUN $PACKAGE_DIR/build-opencv.sh
+# --
+# 2 - install opencv-python-headless
+RUN pip install --no-cache-dir --no-binary :all: opencv-python-headless
 
 CMD ["bash", "-l"]
 
@@ -265,7 +276,7 @@ RUN $PACKAGE_DIR/build-tensorflow.sh
 CMD ["bash", "-l"]
 
 # ========
-# Stage 5: install tensorflow benchmarks
+# Stage 5: Install benchmarks
 # ========
 FROM tensorflow-libs AS tensorflow
 
@@ -280,6 +291,13 @@ ENV PATH="$VENV_DIR/bin:$PATH"
 # Clone Tensorflow benchmarks
 RUN git clone https://github.com/tensorflow/benchmarks.git
 
+COPY patches/optional-mlcommons-changes.patch /home/$DOCKER_USER/optional-mlcommons-changes.patch
+# Clone and install  MLCommons (MLPerf)
+COPY scripts/build-mlcommons.sh /home/$DOCKER_USER/.
+RUN /home/$DOCKER_USER/build-mlcommons.sh
+
+# Copy scripts to download dataset and models
+COPY scripts/download-dataset.sh /home/$DOCKER_USER/.
+COPY scripts/download-model.sh /home/$DOCKER_USER/.
+
 CMD ["bash", "-l"]
-
-

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -20,7 +20,7 @@ aarch64
     - NumPy 1.17.1
     - TensorFlow 1.15.2 or TensorFlow 2.3.0
   * TensorFlow Benchmarks
-
+  * [MLCommons (MLPerf)](https://mlperf.org/) benchmarks with an optional patch to support benchmarking for TF oneDNN builds.
 **Note: Arm Performance Libraries provides optimized standard core math libraries for high-performance computing applications on Arm processors. This free version of the libraries provides optimized libraries for Arm Neoverse N1-based Armv8 AArch64 implementations that are compatible with various versions of GCC.
 
 Use of the free of charge version of Arm Performance Libraries is subject to the terms and conditions of the applicable End User License Agreement (“EULA”).
@@ -129,4 +129,26 @@ To display available images use the Docker command:
 
   ``` > docker images ```
 
+## Running MLCommons benchmark
+Please refer to (https://github.com/mlperf/inference/tree/master/vision/classification_and_detection) to download datasets and models. Examples scripts are provided in the $HOME directory of the final image.
+To run resnet50 on ImageNet min-validation dataset for image classification:
+  ``` export DATA_DIR=${HOME}/CK-TOOLS/dataset-imagenet-ilsvrc2012-val-min ```
+  ``` export MODEL_DIR=$(pwd) ```
+  ``` ./run_local.sh tf resnet50 cpu ```
 
+Use MKLDNN_VERBOSE=1 to verify the build uses oneDNN when running the benchmarks
+
+## Running MLCommons benchmark with the (optional) run_cnn.py wrapper script provided.
+
+# To find out the usages and default settings
+  ``` ./run_cnn.py --help ```
+
+# To run benchmarks in the multiprogrammed mode
+  ``` DATA_DIR=$abc MODEL_DIR=$def OMP_NUM_THREADS=$ghi ./run_cnn.py --processes $(nproc) --threads 1 ```
+
+# To run benchmarks in the multithreaded mode
+  ``` DATA_DIR=$abc MODEL_DIR=$def OMP_NUM_THREADS=$ghi ./run_cnn.py --processes 1 --threads $(nproc) ```
+
+# To run benchmarks in the hybrid mode
+# e.g., run 8 processes each of which has 8 threads on a 64-core machine
+  ``` DATA_DIR=$abc MODEL_DIR=$def OMP_NUM_THREADS=$ghi ./run_cnn.py --processes 8 --threads 8 ```

--- a/docker/tensorflow-aarch64/build.sh
+++ b/docker/tensorflow-aarch64/build.sh
@@ -260,11 +260,11 @@ if [[ $build_tools_image ]]; then
 fi
 
 if [[ $build_dev_image ]]; then
-  # Stage 4: Adds bazel and TensorFlow builds with sources. Installs Tensorflow from whl.
+  # Stage 4: Adds bazel and TensorFlow builds with sources and creates a whl.
   docker build $extra_args --target tensorflow-dev -t tensorflow-dev-v$tf_version$onednn:latest .
 fi
 
 if [[ $build_tensorflow_image ]]; then
-  # Stage 5: Clone Tensorflow benchmarks with Tensorflow installed.
+  # Stage 5: Clone benchmarks with TensorFlow installed.
   docker build $extra_args --target tensorflow -t tensorflow-v$tf_version$onednn:latest .
 fi

--- a/docker/tensorflow-aarch64/patches/optional-mlcommons-changes.patch
+++ b/docker/tensorflow-aarch64/patches/optional-mlcommons-changes.patch
@@ -1,0 +1,187 @@
+ *******************************************************************************
+ Copyright 2020 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/vision/classification_and_detection/python/main.py b/vision/classification_and_detection/python/main.py
+index cd6825f..282448b 100755
+--- a/vision/classification_and_detection/python/main.py
++++ b/vision/classification_and_detection/python/main.py
+@@ -202,6 +202,7 @@ def get_args():
+     parser.add_argument("--count", type=int, help="dataset items to use")
+     parser.add_argument("--max-latency", type=float, help="mlperf max latency in pct tile")
+     parser.add_argument("--samples-per-query", type=int, help="mlperf multi-stream sample per query")
++    parser.add_argument("--initialize-dataset", type=bool, default=False, help="initialize the dataset")
+     args = parser.parse_args()
+ 
+     # don't use defaults in argparser. Instead we default to a dict, override that with a profile
+@@ -428,6 +429,8 @@ def main():
+                         pre_process=pre_proc,
+                         use_cache=args.cache,
+                         count=count, **kwargs)
++    if args.initialize_dataset:
++        return
+     # load model to backend
+     model = backend.load(args.model, inputs=args.inputs, outputs=args.outputs)
+     final_results = {
+diff --git a/vision/classification_and_detection/run_cnn.py b/vision/classification_and_detection/run_cnn.py
+new file mode 100755
+index 0000000..5f12f1e
+--- /dev/null
++++ b/vision/classification_and_detection/run_cnn.py
+@@ -0,0 +1,143 @@
++"""
++ Copyright 2020 Arm Limited and affiliates.
++ SPDX-License-Identifier: Apache-2.0
++
++ Licensed under the Apache License, Version 2.0 (the "License");
++ you may not use this file except in compliance with the License.
++ You may obtain a copy of the License at
++
++     http://www.apache.org/licenses/LICENSE-2.0
++
++ Unless required by applicable law or agreed to in writing, software
++ distributed under the License is distributed on an "AS IS" BASIS,
++ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ See the License for the specific language governing permissions and
++ limitations under the License.
++"""
++
++#!/bin/python3
++
++import os
++import sh
++import sys
++import argparse
++import shutil
++from itertools import chain
++if sys.version_info[0] < 3:
++    from itertools import izip_longest as zip_longest
++else:
++    from itertools import zip_longest
++
++
++def num(value):
++    try:
++        return int(value)
++    except ValueError:
++        return float(value)
++
++
++def get_args():
++    """Parse commandline."""
++    parser = argparse.ArgumentParser()
++    parser.add_argument("--backend", default="tf",
++            choices=["tf", "pytorch", "onnxruntime"],
++            help="name of the mlperf backend, ie. tf")
++    parser.add_argument("--model", default="resnet50",
++            choices=["resnet50", "mobilenet", "ssd-mobilenet", "ssd-resnet34"],
++            help="name of the mlperf model, ie. resnet50")
++    parser.add_argument("--device", default="cpu",
++            choices=["cpu", "gpu"],
++            help="name of the mlperf device, ie. cpu")
++    parser.add_argument("--scenario", default="SingleStream",
++            choices=["SingleStream", "MultiStream", "Server", "Offline"],
++            help="mlperf benchmark scenario, ie. SingleStream")
++    parser.add_argument("--processes", default=1, type=int, help="processes")
++    parser.add_argument("--threads", default=os.cpu_count(), type=int, help="threads")
++
++    return  parser.parse_args()
++
++
++def get_online_cpus():
++    online_cpus = []
++    from sh import lscpu
++    for line in lscpu().split('\n'):
++        if "On-line CPU(s) list:" in line:
++            num_list = [item.strip() for item in (line.split(':'))[1].split(',')]
++            for item in num_list:
++                if '-' in item:
++                    a, b = item.split('-')
++                    online_cpus.append(range(int(a), int(b)+1))
++                else:
++                    online_cpus.append([int(item)])
++            break
++
++    return [item for item in chain(*zip_longest(*online_cpus)) if item is not None]
++
++
++
++def main():
++    # parse arguments in the command line
++    args = get_args()
++    run_exe = './run_local.sh'
++    run_params = [args.backend, args.model, args.device, '--scenario', args.scenario]
++    assert(args.processes * args.threads <= os.cpu_count())
++
++    # recommend disabling smt if possible
++    if os.path.exists('/sys/devices/system/cpu/smt/active'):
++        with open('/sys/devices/system/cpu/smt/active', 'r') as f:
++            if f.read().strip() == '1':
++                sys.stderr.write('Error: please disable smt using \"echo off > /sys/devices/system/cpu/smt/control\"\n')
++                sys.exit(1)
++
++    # get a list of online cpus
++    online_cpu_list = get_online_cpus()
++
++    # set OneDNN environment variables
++    os.environ['KMP_AFFINITY'] = 'granularity=fine,verbose,compact,1,0'
++    os.environ['KMP_BLOCKTIME'] = '0'
++    os.environ['KMP_WARNINGS'] = '0'
++    os.environ['KMP_SETTINGS'] = '0'
++
++    # prepare the dataset
++    sh.Command(run_exe)(run_params + ['--initialize-dataset', 'True'])
++
++    # run multiple multithreaded processes with affinity settings
++    os.environ['OMP_NUM_THREADS'] = str(args.threads)
++    os.environ['MLPERF_NUM_INTRA_THREADS'] = str(args.threads)
++    output_parent_dir = 'output/{}-{}/{}'.format(args.backend, args.device, args.model)
++
++    aff_list = [None] * args.processes
++    output_dirs = [None] * args.processes
++    for proc_index in range(args.processes):
++        aff_list[proc_index] = ','.join([str(item) for item in
++                online_cpu_list[proc_index * args.threads : (proc_index + 1) * args.threads]])
++        output_dirs[proc_index] = '{}/p{}'.format(output_parent_dir, proc_index)
++        if os.path.exists(output_dirs[proc_index]):
++            shutil.rmtree(output_dirs[proc_index], ignore_errors=True)
++        os.makedirs(output_dirs[proc_index])
++
++    processes = [None] * args.processes
++    for proc_index in range(args.processes):
++        output_dir = output_dirs[proc_index]
++        processes[proc_index] = sh.taskset('-c', aff_list[proc_index],
++                run_exe, run_params + ['--threads', str(args.threads), '--output', output_dir],
++                _out='{}/mlperf_log_out.txt'.format(output_dir), _err_to_out=True, _bg=True)
++    for proc in processes:
++        proc.wait()
++
++    # proces the data
++    scores = [None] * args.processes
++    valids = [None] * args.processes
++    for proc_index in range(args.processes):
++        with open('{}/mlperf_log_summary.txt'.format(output_dirs[proc_index])) as f:
++            output = f.readlines()
++        score = num(output[6].split(':')[1].strip())
++        scores[proc_index] = score / 1e6 if args.scenario == 'SingleStream' else score
++        valids[proc_index] = output[7].split(':')[1].strip()
++
++    print(scores)
++    print(valids)
++
++
++if __name__ == "__main__":
++    main()

--- a/docker/tensorflow-aarch64/scripts/build-mlcommons.sh
+++ b/docker/tensorflow-aarch64/scripts/build-mlcommons.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# *******************************************************************************
+# Copyright 2020 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+set -euo pipefail
+
+source python3-venv/bin/activate
+pip install cython
+pip install absl-py pillow pycocotools
+pip install ck
+ck pull repo:ck-env
+pip install scikit-build
+sudo apt-get -y install protobuf-compiler libprotoc-dev
+git clone https://github.com/mlcommons/inference.git --recursive
+cd inference
+git checkout master
+# Scripts to support running of MLPerf in different modes. Refer to README.md for details.
+patch -p1 < ../optional-mlcommons-changes.patch
+cd loadgen
+CFLAGS="-std=c++14" python setup.py develop
+cd ../vision/classification_and_detection
+python setup.py develop

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -17,7 +17,6 @@
 # limitations under the License.
 # *******************************************************************************
 
-
 set -euo pipefail
 
 cd $PACKAGE_DIR

--- a/docker/tensorflow-aarch64/scripts/download-dataset.sh
+++ b/docker/tensorflow-aarch64/scripts/download-dataset.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script is  based on the upstream MLCommon's instructions to download datasets
+# Refer: https://github.com/mlperf/inference/tree/master/vision/classification_and_detection
+
+# Download ImageNet's validation set
+# These will be installed to ${HOME}/CK_TOOLS/
+# Select option 1: val-min data set. Issue when downloading the complete val data set using ck-env [https://github.com/ctuning/ck-env/issues/101]
+
+ck install package --tags=image-classification,dataset,imagenet,aux
+ck install package --tags=image-classification,dataset,imagenet,val
+
+# Copy the labels into the image location
+cp ${HOME}/CK-TOOLS/dataset-imagenet-ilsvrc2012-aux/val.txt ${HOME}/CK-TOOLS/dataset-imagenet-ilsvrc2012-val-min/val_map.txt
+
+# Download Coco dataset
+ck install package --tags=object-detection,dataset,coco,2017,val,original

--- a/docker/tensorflow-aarch64/scripts/download-model.sh
+++ b/docker/tensorflow-aarch64/scripts/download-model.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This script is based on the upstream MLCommon's instructions to download models.
+# Refer: https://github.com/mlperf/inference/tree/master/vision/classification_and_detection
+
+cd vision/classification_and_detection
+# resnet50
+wget https://zenodo.org/record/2535873/files/resnet50_v1.pb
+# mobilenet
+wget http://download.tensorflow.org/models/mobilenet_v1_2018_08_02/mobilenet_v1_1.0_224.tgz
+tar -zxf mobilenet_v1_1.0_224.tgz
+# sdd-mobilenet
+wget http://download.tensorflow.org/models/object_detection/ssd_mobilenet_v1_coco_2018_01_28.tar.gz
+tar -zxf ssd_mobilenet_v1_coco_2018_01_28.tar.gz
+cp ssd_mobilenet_v1_coco_2018_01_28/frozen_inference_graph.pb  ssd_mobilenet_v1_coco_2018_01_28.pb
+# ssd-resnet34
+wget https://zenodo.org/record/3246481/files/ssd_resnet34_mAP_20.2.pb


### PR DESCRIPTION
Includes recipes to build MLPerf with optional changes to the benchmark harness that supports oneDNN backends.

Signed-off-by: cfRod <crefeda.rodrigues@arm.com>