### PR TITLE
Fix for ML Commons (run_cnn.py)

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -191,6 +191,7 @@ RUN $PACKAGE_DIR/build-scipy.sh
 RUN pip install --no-cache-dir hypothesis pyyaml pytest
 RUN pip install --no-cache-dir matplotlib
 RUN pip install --no-cache-dir pillow==6.1 lmdb
+RUN pip install --no-cache-dir ck absl-py pycocotools
 
 # Install OpenCV into our venv,
 # Note: Scripts are provided to build and install OpenCV from the

--- a/docker/pytorch-aarch64/scripts/build-mlcommons.sh
+++ b/docker/pytorch-aarch64/scripts/build-mlcommons.sh
@@ -18,9 +18,6 @@
 # *******************************************************************************
 
 source python3-venv/bin/activate
-pip install cython
-pip install absl-py pillow pycocotools
-pip install ck
 ck pull repo:ck-env
 sudo apt-get -y install protobuf-compiler libprotoc-dev
 git clone https://github.com/mlcommons/inference.git --recursive

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -184,7 +184,7 @@ ENV PATH="$VENV_DIR/bin:$PATH"
 
 # Install some basic python packages
 RUN pip install --no-cache-dir --upgrade pip
-RUN pip install --no-cache-dir "setuptools>=41.0.0" six mock wheel cython
+RUN pip install --no-cache-dir "setuptools>=41.0.0" six mock wheel cython sh
 
 # Build numpy from source, using OpenBLAS for BLAS calls
 COPY scripts/build-numpy.sh $PACKAGE_DIR/.
@@ -205,8 +205,9 @@ RUN pip install --no-cache-dir keras_preprocessing==1.1.0 --no-deps
 # it is installed as a dependency for an earlier package and needs
 # to be removed in order for the OpenCV build to complete.
 RUN pip uninstall enum34 -y
-RUN HDF5_DIR=/usr/lib/aarch64-linux-gnu/hdf5/serial pip install h5py
-RUN pip install --no-cache-dir ck absl-py pycocotools
+RUN HDF5_DIR=/usr/lib/aarch64-linux-gnu/hdf5/serial pip install h5py==2.10.0
+RUN pip install --no-cache-dir grpcio
+RUN pip install --no-cache-dir ck absl-py pycocotools pillow
 
 # Install OpenCV into our venv,
 # Note: Scripts are provided to build and install OpenCV from the

--- a/docker/tensorflow-aarch64/patches/optional-mlcommons-changes.patch
+++ b/docker/tensorflow-aarch64/patches/optional-mlcommons-changes.patch
@@ -42,6 +42,7 @@ index 0000000..5f12f1e
 --- /dev/null
 +++ b/vision/classification_and_detection/run_cnn.py
 @@ -0,0 +1,143 @@
++#!/usr/bin/env python3
 +"""
 + Copyright 2020 Arm Limited and affiliates.
 + SPDX-License-Identifier: Apache-2.0
@@ -59,7 +60,6 @@ index 0000000..5f12f1e
 + limitations under the License.
 +"""
 +
-+#!/bin/python3
 +
 +import os
 +import sh

--- a/docker/tensorflow-aarch64/scripts/build-mlcommons.sh
+++ b/docker/tensorflow-aarch64/scripts/build-mlcommons.sh
@@ -20,9 +20,6 @@
 set -euo pipefail
 
 source python3-venv/bin/activate
-pip install cython
-pip install absl-py pillow pycocotools
-pip install ck
 ck pull repo:ck-env
 sudo apt-get -y install protobuf-compiler libprotoc-dev
 git clone https://github.com/mlcommons/inference.git --recursive


### PR DESCRIPTION
Shebang was in the wrong place + incorrect binary path
Script requires 'sh' package installing via pip
Reorganised pip installs to Dockerfiles