### PR TITLE
Add option to TF to build with oneDNN + Compute Library using Bazel

### DIFF
--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -272,6 +272,7 @@ COPY patches/oneDNN-opensource.patch $PACKAGE_DIR/oneDNN-opensource.patch
 # Patches to support different flavours of oneDNN
 COPY patches/tf2-armpl.patch $PACKAGE_DIR/tf2-armpl.patch
 COPY patches/tf2-openblas.patch $PACKAGE_DIR/tf2-openblas.patch
+COPY patches/tf2-acl.patch $PACKAGE_DIR/tf2-acl.patch
 RUN $PACKAGE_DIR/build-tensorflow.sh
 
 CMD ["bash", "-l"]

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -14,7 +14,7 @@ aarch64
 ## What's in the final image?
   * OS: Ubuntu 18.04
   * Compiler: GCC 9.3.0
-  * Maths libraries: [Arm Performance Libraries](https://developer.arm.com/tools-and-software/server-and-hpc/compile/arm-compiler-for-linux/arm-performance-libraries) 20.2.1 and [OpenBLAS](https://www.openblas.net/) 0.3.9
+  * Maths libraries: [Arm Performance Libraries](https://developer.arm.com/tools-and-software/server-and-hpc/compile/arm-compiler-for-linux/arm-performance-libraries) 20.2.1, [OpenBLAS](https://www.openblas.net/) 0.3.9, [Compute Library](https://developer.arm.com/ip-products/processors/machine-learning/compute-library) 20.11.
   * [oneDNN](https://github.com/oneapi-src/oneDNN) 0.21.3 or 1.7. Previously known as (MKL-DNN/DNNL).
   * Python3 environment built from CPython 3.7 and containing:
     - NumPy 1.17.1
@@ -96,7 +96,7 @@ Without the '--onednn' flag, the default Eigen backend of Tensorflow is chosen. 
 
 The BLAS backend for oneDNN can also be selected using the '--onednn' or '--dnnl' flags:
 For TensorFlow 1.x builds, this defaults to the C++ reference kernels, setting '--dnnl openblas' will use the OpenBLAS libary where possible.
-For TensorFlow 2.x builds, this defaults to using Arm Performance Libraries, but '--onednn reference' and '--onednn openblas' can also be selected to use the reference C++ kernels, or OpenBLAS respectively.
+For TensorFlow 2.x builds, this defaults to using Arm Performance Libraries, but '--onednn reference', '--onednn openblas' or '--onednn acl' can also be selected to use the reference C++ kernels, OpenBLAS, or Compute Library respectively.
 _Note: The oneDNN backend chosen will be apended to the image name: `tensorflow-v$tf_version$onednn_blas`._
 _Note: selecting OpenBLAS will also cause other dependencies (NumPy and SciPy) to be built against OpenBLAS rather than Arm Performance Libraries._
 

--- a/docker/tensorflow-aarch64/build.sh
+++ b/docker/tensorflow-aarch64/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020 Arm Limited and affiliates.
+# Copyright 2020-2021 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -33,6 +33,7 @@ function print_usage_and_exit {
   echo "                                 * reference    - use the C++ reference kernels throughout."
   echo "                                 * openblas     - use OpenBLAS for BLAS calls."
   echo "                                 * armpl        - use Arm Performance Libraries for BLAS calls (default)."
+  echo "                                 * acl          - use Compute Library."
   echo "      --tf_version             TensorFlow version:"
   echo "                                 * 1            - TensorFlow v1.15.2 build."
   echo "                                 * 2            - TensorFlow 2.3.0 build (default)."
@@ -170,6 +171,10 @@ do
           ;;
         armpl )
           onednn="armpl"
+          shift
+          ;;
+        acl )
+          onednn="acl"
           shift
           ;;
         * )

--- a/docker/tensorflow-aarch64/patches/tf2-acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf2-acl.patch
@@ -1,0 +1,371 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/.bazelrc b/.bazelrc
+index 13739b05abc..bb7a202c9ac 100644
+--- a/.bazelrc
++++ b/.bazelrc
+@@ -167,6 +167,12 @@ build:mkl_opensource_only --define=build_with_mkl_dnn_v1_only=true
+ build:mkl_opensource_only --define=build_with_mkl_opensource=true
+ build:mkl_opensource_only -c opt
+
++# Config setting to build oneDNN with Compute Library for Arm.
++build:mkl_aarch64_acl --define=build_with_mkl_aarch64_acl=true --define=enable_mkl=true
++build:mkl_aarch64_acl --define=tensorflow_mkldnn_contraction_kernel=0
++build:mkl_aarch64_acl --define=build_with_mkl_opensource=true
++build:mkl_aarch64_acl -c opt
++
+ # This config refers to building with CUDA available. It does not necessarily
+ # mean that we build CUDA op kernels.
+ build:using_cuda --define=using_cuda=true
+diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
+index f0a578eabfc..2c8eb806cf1 100644
+--- a/tensorflow/tensorflow.bzl
++++ b/tensorflow/tensorflow.bzl
+@@ -49,6 +49,7 @@ load(
+     "if_mkl_open_source_only",
+     "if_mkl_v1",
+     "if_mkldnn_threadpool",
++    "if_mkldnn_aarch64_acl",
+ )
+ load(
+     "//third_party/ngraph:build_defs.bzl",
+@@ -329,6 +330,7 @@ def tf_copts(
+         if_mkl_open_source_only(["-DINTEL_MKL_DNN_ONLY"]) +
+         if_mkl_v1(["-DENABLE_MKLDNN_V1", "-DENABLE_INTEL_MKL_BFLOAT16"]) +
+         if_mkldnn_threadpool(["-DENABLE_MKLDNN_THREADPOOL"]) +
++        if_mkldnn_aarch64_acl(["-DENABLE_MKLDNN_V1", "-DINTEL_MKL_DNN_ONLY"]) +
+         if_enable_mkl(["-DENABLE_MKL"]) +
+         if_ngraph(["-DINTEL_NGRAPH=1"]) +
+         if_android_arm(["-mfpu=neon"]) +
+diff --git a/tensorflow/workspace.bzl b/tensorflow/workspace.bzl
+index 61ac9f79141..440533d5dc9 100755
+--- a/tensorflow/workspace.bzl
++++ b/tensorflow/workspace.bzl
+@@ -219,6 +219,17 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
+         ],
+     )
+
++    tf_http_archive(
++       name = "mkl_dnn_acl_compatible",
++       build_file = clean_dep("//third_party/mkl_dnn:mkldnn_acl.BUILD"),
++       sha256 = "2dbd53578b36bd84bbc3e411d1a4cacc0eed832892818c5fa16b72cbf1dab015",
++       strip_prefix = "oneDNN-1.7",
++       patch_file = clean_dep("//third_party/mkl_dnn:mkldnn_acl_log.patch"),
++       urls = [
++            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v1.7.tar.gz",
++            "https://github.com/oneapi-src/oneDNN/archive/v1.7.tar.gz"]
++    )
++
+     tf_http_archive(
+         name = "com_google_absl",
+         build_file = clean_dep("//third_party:com_google_absl.BUILD"),
+@@ -1182,6 +1193,18 @@ def tf_repositories(path_prefix = "", tf_repo_name = ""):
+         ],
+     )
+
++    tf_http_archive(
++        name = "arm_compute_library",
++        sha256 = "2c4cfbe5f87cf47170aa497209c24567d425365fa5f959129a50be665317a8ab",
++        patch_file = clean_dep("//third_party/arm_compute_library:arm_compute_library.patch"),
++        strip_prefix = "ComputeLibrary-20.11",
++        build_file = clean_dep("//third_party/arm_compute_library:BUILD"),
++        urls = [
++            "http://mirror.tensorflow.org/github.com/ARM-software/ComputeLibrary/archive/v20.11.tar.gz",
++            "https://github.com/ARM-software/ComputeLibrary/archive/v20.11.tar.gz"
++        ],
++    )
++
+ def tf_bind():
+     """Bind targets for some external repositories"""
+     ##############################################################################
+diff --git a/third_party/arm_compute_library/BUILD b/third_party/arm_compute_library/BUILD
+new file mode 100644
+index 00000000000..322b8a67f12
+--- /dev/null
++++ b/third_party/arm_compute_library/BUILD
+@@ -0,0 +1,74 @@
++cc_library(
++    name = "include",
++    hdrs = glob(["include/**/*.h", "include/**/*.hpp"]),
++    strip_include_prefix = "include",
++    includes = ["include"],
++)
++
++cc_library(
++    name = "arm_compute_core",
++
++    srcs = glob(["src/core/*.cpp",
++                 "src/core/helpers/*.cpp",
++                 "src/core/CPP/**/*.cpp",
++                 "src/core/utils/**/*.cpp",
++                 "src/core/NEON/kernels/**/*.cpp",
++                 "src/core/**/*.hpp",
++                 "**/*.h"],
++                 exclude=["src/core/TracePoint.cpp"]),
++
++    hdrs = glob(["arm_compute/core/**/*.h",
++                 "**/*.inl"])
++           + ["src/core/utils/quantization/AsymmHelpers.cpp",
++              "arm_compute_version.embed"],
++
++    includes = ["src/core/NEON/kernels/convolution/common",
++                "src/core/NEON/kernels/convolution/winograd",
++                "src/core/NEON/kernels/assembly"],
++
++    defines = ["ENABLE_FP16_KERNELS", "ENABLE_FP32_KERNELS", "ENABLE_QASYMM8_KERNELS",
++               "ENABLE_QASYMM8_SIGNED_KERNELS", "ENABLE_QSYMM16_KERNELS"],
++
++    deps = ["include"],
++)
++
++cc_library(
++    name = "arm_compute_runtime",
++
++    srcs = glob(["src/runtime/*.cpp",
++                 "src/runtime/CPP/**/*.cpp",
++                 "src/runtime/NEON/**/*.cpp",
++                 "**/*.h"]),
++
++    hdrs = glob(["arm_compute/runtime/**/*.h"])
++            + ["arm_compute_version.embed"],
++
++    deps = ["arm_compute_core"],
++
++    defines = ["ARM_COMPUTE_CPP_SCHEDULER"],
++
++    linkopts = ["-lpthread"],
++
++    visibility = ["//visibility:public"],
++)
++
++cc_library(
++    name = "arm_compute_graph",
++
++    srcs = glob(["src/graph/*.cpp",
++                 "src/graph/algorithms/*.cpp",
++                 "src/graph/backends/*.cpp",
++                 "src/graph/detail/*.cpp",
++                 "src/graph/frontend/*.cpp",
++                 "src/graph/mutators/*.cpp",
++                 "src/graph/nodes/*.cpp",
++                 "src/graph/printers/*.cpp",
++                 "src/graph/backends/NEON/*.cpp",
++                 "**/*.h"]),
++
++    hdrs = glob(["arm_compute/graph/**/*.h"]),
++
++    deps = ["arm_compute_core"],
++
++    visibility = ["//visibility:public"],
++)
+\ No newline at end of file
+diff --git a/third_party/arm_compute_library/LICENSE b/third_party/arm_compute_library/LICENSE
+new file mode 100644
+index 00000000000..be847369eda
+--- /dev/null
++++ b/third_party/arm_compute_library/LICENSE
+@@ -0,0 +1,21 @@
++MIT License
++
++Copyright (c) 2017-2021 Arm Limited
++
++Permission is hereby granted, free of charge, to any person obtaining a copy
++of this software and associated documentation files (the "Software"), to deal
++in the Software without restriction, including without limitation the rights
++to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
++copies of the Software, and to permit persons to whom the Software is
++furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in all
++copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++SOFTWARE.
+diff --git a/third_party/arm_compute_library/arm_compute_library.patch b/third_party/arm_compute_library/arm_compute_library.patch
+new file mode 100644
+index 00000000000..cda322982ef
+--- /dev/null
++++ b/third_party/arm_compute_library/arm_compute_library.patch
+@@ -0,0 +1,21 @@
++diff --git a/src/runtime/NEON/functions/NEElementwiseOperators.cpp b/src/runtime/NEON/functions/NEElementwiseOperators.cpp
++index 7f3fe8b30..41a0242d9 100644
++--- a/src/runtime/NEON/functions/NEElementwiseOperators.cpp
+++++ b/src/runtime/NEON/functions/NEElementwiseOperators.cpp
++@@ -23,7 +23,7 @@
++  */
++ #include "arm_compute/core/Validate.h"
++ #include "arm_compute/runtime/NEON/functions/NEElementwiseOperations.h"
++-#include <src/core/NEON/kernels/NEElementwiseOperationKernel.h>
+++#include "src/core/NEON/kernels/NEElementwiseOperationKernel.h"
++
++ #include "arm_compute/core/ITensor.h"
++ #include "support/MemorySupport.h"
++diff --git a/arm_compute_version.embed b/arm_compute_version.embed
++new file mode 100644
++index 000000000..c986ad52a
++--- /dev/null
+++++ b/arm_compute_version.embed
++@@ -0,0 +1 @@
+++"arm_compute_version=v20.11 Build options: {} Git hash=b'N/A'"
++\ No newline at end of file
+\ No newline at end of file
+diff --git a/third_party/mkl/BUILD b/third_party/mkl/BUILD
+index 470b3d50ea5..53aef40f362 100644
+--- a/third_party/mkl/BUILD
++++ b/third_party/mkl/BUILD
+@@ -21,6 +21,14 @@ config_setting(
+     visibility = ["//visibility:public"],
+ )
+
++config_setting(
++    name = "build_with_mkl_aarch64_acl",
++    define_values = {
++        "build_with_mkl_aarch64_acl": "true",
++    },
++    visibility = ["//visibility:public"],
++)
++
+ config_setting(
+     name = "enable_mkl",
+     define_values = {
+diff --git a/third_party/mkl/build_defs.bzl b/third_party/mkl/build_defs.bzl
+index 851403fd13a..5fb94b574cd 100644
+--- a/third_party/mkl/build_defs.bzl
++++ b/third_party/mkl/build_defs.bzl
+@@ -26,6 +26,7 @@ def if_mkl(if_true, if_false = []):
+     """
+     return select({
+         "@org_tensorflow//third_party/mkl:build_with_mkl": if_true,
++        "@org_tensorflow//third_party/mkl:build_with_mkl_aarch64_acl": if_true,
+         "//conditions:default": if_false,
+     })
+
+@@ -77,6 +78,7 @@ def if_enable_mkl(if_true, if_false = []):
+     """
+     return select({
+         "@org_tensorflow//third_party/mkl:enable_mkl": if_true,
++        "@org_tensorflow//third_party/mkl:build_with_mkl_aarch64_acl": if_true,
+         "//conditions:default": if_false,
+     })
+
+@@ -96,6 +98,7 @@ def mkl_deps():
+             "@org_tensorflow//third_party/mkl:intel_binary_blob",
+             "@mkl_dnn",
+         ],
++        "@org_tensorflow//third_party/mkl:build_with_mkl_aarch64_acl": ["@mkl_dnn_acl_compatible//:mkl_dnn_acl"],
+         "//conditions:default": [],
+     })
+
+diff --git a/third_party/mkl_dnn/build_defs.bzl b/third_party/mkl_dnn/build_defs.bzl
+index 6a3e4f827ce..6b3aa4350de 100644
+--- a/third_party/mkl_dnn/build_defs.bzl
++++ b/third_party/mkl_dnn/build_defs.bzl
+@@ -45,3 +45,9 @@ def if_mkldnn_threadpool(if_true, if_false = []):
+         "@org_tensorflow//third_party/mkl_dnn:build_with_mkldnn_threadpool": if_true,
+         "//conditions:default": if_false,
+     })
++
++def if_mkldnn_aarch64_acl(if_true, if_false = []):
++        return select({
++            "@org_tensorflow//third_party/mkl:build_with_mkl_aarch64_acl": if_true,
++            "//conditions:default": if_false,
++})
+diff --git a/third_party/mkl_dnn/mkldnn_acl.BUILD b/third_party/mkl_dnn/mkldnn_acl.BUILD
+new file mode 100644
+index 00000000000..a1cb52f483f
+--- /dev/null
++++ b/third_party/mkl_dnn/mkldnn_acl.BUILD
+@@ -0,0 +1,52 @@
++load(
++    "@org_tensorflow//third_party:common.bzl",
++    "template_rule",
++)
++
++_DNNL_RUNTIME_OMP = {
++    "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_OMP",
++    "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_OMP",
++    "#cmakedefine DNNL_GPU_RUNTIME DNNL_RUNTIME_${DNNL_GPU_RUNTIME}": "#define DNNL_GPU_RUNTIME DNNL_RUNTIME_NONE",
++}
++
++template_rule(
++    name = "dnnl_config_h",
++    src = "include/dnnl_config.h.in",
++    out = "include/dnnl_config.h",
++    substitutions = _DNNL_RUNTIME_OMP,
++)
++
++template_rule(
++    name = "dnnl_version_h",
++    src = "include/dnnl_version.h.in",
++    out = "include/dnnl_version.h",
++    substitutions = {
++        "@DNNL_VERSION_MAJOR@": "1",
++        "@DNNL_VERSION_MINOR@": "7",
++        "@DNNL_VERSION_PATCH@": "0",
++        "@DNNL_VERSION_HASH@": "N/A",
++    },
++)
++
++cc_library(
++    name = "mkl_dnn_acl",
++    srcs = glob(["src/common/*.cpp",
++                 "src/common/*.hpp",
++                 "src/cpu/**/*.cpp",
++                 "src/cpu/**/*.hpp",
++                ], exclude=["src/cpu/x64/**/*"])
++           + [":dnnl_config_h", ":dnnl_version_h"],
++    hdrs = glob(["include/*"]),
++    defines=["DNNL_AARCH64_USE_ACL=1"],
++    includes = [
++        "include",
++        "src",
++        "src/common",
++        "src/cpu",
++        "src/cpu/gemm",
++    ],
++    linkopts = ["-lgomp"],
++    visibility = ["//visibility:public"],
++    deps = ["@arm_compute_library//:arm_compute_runtime",
++            "@arm_compute_library//:arm_compute_graph"],
++)
+diff --git a/third_party/mkl_dnn/mkldnn_acl_log.patch b/third_party/mkl_dnn/mkldnn_acl_log.patch
+new file mode 100644
+index 00000000000..38909dcaf2c
+--- /dev/null
++++ b/third_party/mkl_dnn/mkldnn_acl_log.patch
+@@ -0,0 +1,15 @@
++diff --git a/src/cpu/aarch64/acl_gemm_convolution.hpp b/src/cpu/aarch64/acl_gemm_convolution.hpp
++index c3f84e304..666e9ac82 100644
++--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
+++++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
++@@ -101,8 +101,8 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
++                 const typename pd_t::base_class *hint_fwd_pd)
++             : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd), acp_() {}
++
++-        DECLARE_COMMON_PD_T(GEMM_IMPL_STR, acl_gemm_convolution_fwd_t,
++-                USE_GLOBAL_SCRATCHPAD);
+++        DECLARE_COMMON_PD_T(
+++                "gemm:acl", acl_gemm_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
++
++         status_t init(engine_t *engine) {
++             bool ok = true && is_fwd()


### PR DESCRIPTION
This change adds a new config option in TensorFlow's Bazel build scripts to build using oneDNN 1.7 and Compute Library 20.11 on AArch64. This option is exposed to the docker build script.