### PR TITLE
Sets Eigen caches sizes during TF build.

### DIFF
--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -228,13 +228,18 @@ ARG bazel_version
 ARG default_py_version
 ARG cpu
 ARG arch
+ARG eigen_l1_cache
+ARG eigen_l2_cache
+ARG eigen_l3_cache
 
 ENV NP_MAKE="${njobs}" \
     BZL_RAM="${bazel_mem}" \
     ONEDNN_BUILD="${onednn_opt}" \
     CPU="${cpu}" \
-    ARCH="${arch}"
-
+    ARCH="${arch}" \
+    EIGEN_L1_CACHE="${eigen_l1_cache}" \
+    EIGEN_L2_CACHE="${eigen_l2_cache}" \
+    EIGEN_L3_CACHE="${eigen_l3_cache}"
 # Key version numbers
 ENV PY_VERSION="${default_py_version}" \
     BZL_VERSION="${bazel_version}" \
@@ -258,6 +263,8 @@ ENV PATH=$PACKAGE_DIR/bazel:$PATH
 
 # Build TensorFlow
 COPY patches/tf_acl.patch $PACKAGE_DIR/.
+COPY patches/eigen_workspace.patch $PACKAGE_DIR/.
+COPY patches/eigen_gebp_cache.patch  $PACKAGE_DIR/.
 COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh
 

--- a/docker/tensorflow-aarch64/build.sh
+++ b/docker/tensorflow-aarch64/build.sh
@@ -225,7 +225,10 @@ set_target $target
 extra_args="$extra_args --build-arg cpu=$cpu \
     --build-arg tune=$tune \
     --build-arg arch=$arch \
-    --build-arg blas_cpu=$blas_cpu"
+    --build-arg blas_cpu=$blas_cpu \
+    --build-arg eigen_l1_cache=$eigen_l1_cache \
+    --build-arg eigen_l2_cache=$eigen_l2_cache \
+    --build-arg eigen_l3_cache=$eigen_l3_cache"
 
 if [[ $build_base_image ]]; then
   # Stage 1: Base image, Ubuntu with core packages and GCC9

--- a/docker/tensorflow-aarch64/cpu_info.sh
+++ b/docker/tensorflow-aarch64/cpu_info.sh
@@ -82,18 +82,27 @@ function set_target {
       tune="neoverse-n1"
       arch="armv8.2-a"
       blas_cpu="NEOVERSEN1"
+      eigen_l1_cache="64*1024"
+      eigen_l2_cache="1024*1024"
+      eigen_l3_cache=
     ;;
     thunderx2t99 )
       cpu="thunderx2t99"
       tune="thunderx2t99"
       arch="armv8.1-a"
       blas_cpu="THUNDERX2T99"
+      eigen_l1_cache="32*1024"
+      eigen_l2_cache="256*1024"
+      eigen_l3_cache="512*1024"
     ;;
     generic )
       cpu="generic"
       tune="generic"
       arch="armv8-a"
       blas_cpu="ARMV8"
+      eigen_l1_cache=
+      eigen_l2_cache=
+      eigen_l3_cache=
     ;;
     custom )
     # Update with custom settings
@@ -101,20 +110,28 @@ function set_target {
       tune="neoverse-n1"
       arch="armv8.2-a"
       blas_cpu="NEOVERSEN1"
+      eigen_l1_cache="64*1024"
+      eigen_l2_cache="1024*1024"
+      eigen_l3_cache="1024*1024"
     ;;
     * )
       cpu="native"
       tune="native"
       arch="native"
       blas_cpu=
+      eigen_l1_cache=
+      eigen_l2_cache=
+      eigen_l3_cache=
     ;;
  esac
-echo "================================="
-echo "Building for target: $target"
-echo "---------------------------------"
-echo " -mcpu           = $cpu"
-echo " -mtune          = $tune"
-echo " -march          = $arch"
-echo " OpenBLAS target = $blas_cpu"
-echo "================================="
+echo "======================================="
+echo "Building for target: ${target}"
+echo "---------------------------------------"
+echo " -mcpu            = ${cpu}"
+echo " -mtune           = ${tune}"
+echo " -march           = ${arch}"
+echo " OpenBLAS target  = ${blas_cpu}"
+echo " Eigen GEBP cache = ${eigen_l1_cache}, ${eigen_l2_cache}, ${eigen_l3_cache}"
+echo "                    L1, L2, L3 in bytes"
+echo "======================================="
 }

--- a/docker/tensorflow-aarch64/patches/eigen_gebp_cache.patch
+++ b/docker/tensorflow-aarch64/patches/eigen_gebp_cache.patch
@@ -1,0 +1,30 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/Eigen/src/Core/products/GeneralBlockPanelKernel.h b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+index 1116321a9..f35b760c1 100644
+--- a/Eigen/src/Core/products/GeneralBlockPanelKernel.h
++++ b/Eigen/src/Core/products/GeneralBlockPanelKernel.h
+@@ -44,7 +44,7 @@ inline std::ptrdiff_t manage_caching_sizes_helper(std::ptrdiff_t a, std::ptrdiff
+ #endif // defined(EIGEN_DEFAULT_L2_CACHE_SIZE)
+ 
+ #if defined(EIGEN_DEFAULT_L3_CACHE_SIZE)
+-#define EIGEN_SET_DEFAULT_L3_CACHE_SIZE(val) EIGEN_SET_DEFAULT_L3_CACHE_SIZE
++#define EIGEN_SET_DEFAULT_L3_CACHE_SIZE(val) EIGEN_DEFAULT_L3_CACHE_SIZE
+ #else
+ #define EIGEN_SET_DEFAULT_L3_CACHE_SIZE(val) val
+ #endif // defined(EIGEN_DEFAULT_L3_CACHE_SIZE)

--- a/docker/tensorflow-aarch64/patches/eigen_workspace.patch
+++ b/docker/tensorflow-aarch64/patches/eigen_workspace.patch
@@ -1,0 +1,29 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/third_party/eigen3/workspace.bzl b/third_party/eigen3/workspace.bzl
+index 233231f5636..475f670b2ad 100644
+--- a/third_party/eigen3/workspace.bzl
++++ b/third_party/eigen3/workspace.bzl
+@@ -12,6 +12,7 @@ def repo():
+     tf_http_archive(
+         name = "eigen_archive",
+         build_file = "//third_party/eigen3:eigen_archive.BUILD",
++        patch_file = "//third_party/eigen3:eigen_gebp_cache.patch",
+         sha256 = EIGEN_SHA256,
+         strip_prefix = "eigen-{commit}".format(commit = EIGEN_COMMIT),
+         urls = [

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -115,4 +115,3 @@ index 017abff688a..7c72949d251 100644
 +        "@DNNL_VERSION_HASH@": "593e0de6267d2575f3e4c9e9818f0f11253d093a",
      },
  )
- 

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -74,6 +74,21 @@ if [[ $ONEDNN_BUILD ]]; then
 else
     echo "TensorFlow $TF_VERSION with Eigen backend."
     extra_args="$extra_args --define tensorflow_mkldnn_contraction_kernel=0"
+
+    # Patch Eigen to fix minor issue when setting L3 cache
+    patch -p1 < ../eigen_workspace.patch
+    mv ../eigen_gebp_cache.patch ./third_party/eigen3/.
+
+    # Manually set L1,2,3 caches sizes for the GEBP kernel in Eigen.
+    [[ $EIGEN_L1_CACHE ]] && extra_args="$extra_args \
+      --cxxopt=-DEIGEN_DEFAULT_L1_CACHE_SIZE=${EIGEN_L1_CACHE} \
+      --copt=-DEIGEN_DEFAULT_L1_CACHE_SIZE=${EIGEN_L1_CACHE}"
+    [[ $EIGEN_L2_CACHE ]] && extra_args="$extra_args \
+      --cxxopt=-DEIGEN_DEFAULT_L2_CACHE_SIZE=${EIGEN_L2_CACHE} \
+      --copt=-DEIGEN_DEFAULT_L2_CACHE_SIZE=${EIGEN_L2_CACHE}"
+    [[ $EIGEN_L3_CACHE ]] && extra_args="$extra_args \
+      --cxxopt=-DEIGEN_DEFAULT_L3_CACHE_SIZE=${EIGEN_L3_CACHE} \
+      --copt=-DEIGEN_DEFAULT_L3_CACHE_SIZE=${EIGEN_L3_CACHE}"
 fi
 
 # Build the tensorflow configuration


### PR DESCRIPTION
Sets the L1 and L2 cache sizes for N1 builds based on the
CPU.

See cpu_info.sh for cache sizes used for various targets, or to
set custom cache sizes.