### PR TITLE
Adds additional OS and Python packages

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -32,18 +32,25 @@ RUN apt-get -y update && \
     apt-get -y install software-properties-common && \
     add-apt-repository ppa:ubuntu-toolchain-r/test && \
     apt-get -y install \
+      accountsservice \
+      apport \
+      at \
       autoconf \
       bc \
       build-essential \
       cmake \
+      cpufrequtils \
       curl \
+      ethtool \
       g++-9 \
       gcc-7 \
       gcc-9 \
       gettext-base \
       gfortran-9 \
       git \
+      iproute2 \
       iputils-ping \
+      lxd \
       libbz2-dev \
       libc++-dev \
       libcgal-dev \
@@ -61,9 +68,15 @@ RUN apt-get -y update && \
       libxml2-dev \
       libxslt-dev \
       locales \
+      lsb-release \
+      lvm2 \
       moreutils \
+      net-tools \
+      open-iscsi \
       openjdk-8-jdk \
       openssl \
+      pciutils \
+      policykit-1 \
       python${PY_VERSION} \
       python${PY_VERSION}-dev \
       python${PY_VERSION}-distutils \
@@ -71,11 +84,16 @@ RUN apt-get -y update && \
       python3-pip \
       python-openssl \
       rsync \
+      rsyslog \
+      snapd \
       scons \
       ssh \
       sudo \
       time \
+      udev \
       unzip \
+      ufw \
+      uuid-runtime \
       vim \
       wget \
       xz-utils \
@@ -312,6 +330,7 @@ COPY scripts/download-model.sh $MLCOMMONS_DIR/.
 RUN pip install --no-cache-dir requests
 RUN pip install --no-cache-dir tqdm
 RUN pip install --no-cache-dir boto3
+RUN pip install --no-cache-dir future onnx==1.8.1
 
 # Copy examples
 ENV EXAMPLE_DIR=/home/$DOCKER_USER/examples

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -34,17 +34,25 @@ RUN apt-get -y update && \
     apt-get -y install software-properties-common && \
     add-apt-repository ppa:ubuntu-toolchain-r/test && \
     apt-get -y install \
+      accountsservice \
+      apport \
+      at \
       autoconf \
       bc \
       build-essential \
       cmake \
+      cpufrequtils \
       curl \
+      ethtool \
       g++-9 \
+      gcc-7 \
       gcc-9 \
       gettext-base \
       gfortran-9 \
       git \
+      iproute2 \
       iputils-ping \
+      lxd \
       libbz2-dev \
       libc++-dev \
       libcgal-dev \
@@ -62,9 +70,15 @@ RUN apt-get -y update && \
       libxml2-dev \
       libxslt-dev \
       locales \
+      lsb-release \
+      lvm2 \
       moreutils \
+      net-tools \
+      open-iscsi \
       openjdk-8-jdk \
       openssl \
+      pciutils \
+      policykit-1 \
       python${PY_VERSION} \
       python${PY_VERSION}-dev \
       python${PY_VERSION}-distutils \
@@ -72,16 +86,22 @@ RUN apt-get -y update && \
       python3-pip \
       python-openssl \
       rsync \
+      rsyslog \
+      snapd \
       scons \
       ssh \
       sudo \
       time \
+      udev \
       unzip \
+      ufw \
+      uuid-runtime \
       vim \
       wget \
       xz-utils \
       zip \
       zlib1g-dev
+
 
 # Make gcc 9 and python 3(.8) the default
 RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-9 1 --slave /usr/bin/g++ g++ /usr/bin/g++-9 && \


### PR DESCRIPTION
PyTorch installs ONNX 1.9 by default, but 1.8.1 is needed to run
ML Commons benchmarks with ONNX backend

Also adds a number of OS packages and utils.