### PR TITLE
pytorch-aarch64 build: enable openmp as scheduler for acl backend

### DIFF
--- a/docker/pytorch-aarch64/scripts/build-acl.sh
+++ b/docker/pytorch-aarch64/scripts/build-acl.sh
@@ -38,7 +38,8 @@ arch=${ACL_ARCH:-"arm64-v8a"}
 echo "Compute Library arch = ${arch}"
 
 # Build with scons
-scons -j16  Werror=0 debug=0 neon=1 gles_compute=0 embed_kernels=0 \
+scons -j16  Werror=0 debug=0 neon=1 openmp=1 cppthreads=0 \
+  gles_compute=0 embed_kernels=0 \
   os=linux arch=$arch build=native \
   build_dir=$install_dir/build
 


### PR DESCRIPTION
This patch switches the acl scheduler from cppthreads to openmp.
This improves multicore thread scheduling hence acl primitive performance
significantly.