### PR TITLE
tensorflow-aarch64 build: set OpenBLAS NUM_THREADS to support instanc…

### DIFF
--- a/docker/tensorflow-aarch64/scripts/build-openblas.sh
+++ b/docker/tensorflow-aarch64/scripts/build-openblas.sh
@@ -33,7 +33,7 @@ git checkout v$version -b v$version
 install_dir=$PROD_DIR/$package/$version
 
 export CFLAGS="-O3"
-extra_args="USE_OPENMP=1"
+extra_args="USE_OPENMP=1 NUM_THREADS=64"
 [[ ${BLAS_CPU} ]] && extra_args="$extra_args TARGET=${blas_cpu}"
 
 make -j $NP_MAKE $extra_args


### PR DESCRIPTION
…es upto 64 cores

This patch sets the OpenBLAS NUM_THREADS explicitly to remove dependency on the
docker build machine configuration, and supports instances upto 64 cores.