### PR TITLE
Updates for r21.09 release

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -128,12 +128,14 @@ ARG njobs
 ARG cpu
 ARG arch
 ARG blas_cpu
+ARG blas_ncores
 ARG acl_arch
 
 ENV NP_MAKE="${njobs}" \
     CPU="${cpu}" \
     ARCH="${arch}" \
     BLAS_CPU="${blas_cpu}" \
+    BLAS_NCORES="{blas_ncores}" \
     ACL_ARCH="${acl_arch}"
 
 # Key version numbers
@@ -276,7 +278,8 @@ ENV ONEDNN_BUILD="${onednn_opt}" \
 ENV PY_VERSION="${default_py_version}" \
     TORCH_VERSION=1.9.0 \
     ONEDNN_VERSION="v2.3" \
-    VISION_VERSION="v0.9.1"
+    VISION_VERSION="v0.9.1" \
+    TEXT_VERSION=0.10.0
 
 # Use a PACKAGE_DIR in userspace
 WORKDIR /home/$DOCKER_USER
@@ -293,6 +296,10 @@ ENV PATH="$VENV_DIR/bin:$PATH"
 COPY scripts/build-pytorch.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-pytorch.sh
 RUN pip install torchvision==$VISION_VERSION
+# Build torchtext
+ENV VENV_PACKAGE_DIR=$VENV_DIR/lib/python$PY_VERSION/site-packages
+COPY scripts/build-torchtext.sh $PACKAGE_DIR/.
+RUN $PACKAGE_DIR/build-torchtext.sh
 
 CMD ["bash", "-l"]
 
@@ -320,6 +327,7 @@ RUN mkdir -p $MLCOMMONS_DIR
 # Clone and install  MLCommons (MLPerf)
 COPY scripts/build-mlcommons.sh $MLCOMMONS_DIR/.
 COPY patches/mlcommons_bert.patch $MLCOMMONS_DIR/.
+COPY patches/pytorch_native.patch $MLCOMMONS_DIR/.
 RUN $MLCOMMONS_DIR/build-mlcommons.sh
 RUN rm -f $MLCOMMONS_DIR/build-mlcommons.sh
 # Copy scripts to download dataset and models
@@ -331,6 +339,7 @@ RUN pip install --no-cache-dir requests
 RUN pip install --no-cache-dir tqdm
 RUN pip install --no-cache-dir boto3
 RUN pip install --no-cache-dir future onnx==1.8.1
+RUN pip install --no-cache-dir iopath
 
 # Copy examples
 ENV EXAMPLE_DIR=/home/$DOCKER_USER/examples

--- a/docker/pytorch-aarch64/build.sh
+++ b/docker/pytorch-aarch64/build.sh
@@ -207,6 +207,7 @@ extra_args="$extra_args --build-arg cpu=$cpu \
     --build-arg tune=$tune \
     --build-arg arch=$arch \
     --build-arg blas_cpu=$blas_cpu \
+    --build-arg blas_ncores=$blas_ncores \
     --build-arg acl_arch=$acl_arch"
 
 if [[ $build_base_image ]]; then

--- a/docker/pytorch-aarch64/cpu_info.sh
+++ b/docker/pytorch-aarch64/cpu_info.sh
@@ -60,7 +60,19 @@ echo $target
 }
 
 ################################################################################
-# Sets required -mtune, -mcou, -march flags for chosen target
+# Sets target-specific flags used in the build:
+#
+# Compiler flags for chosen target:
+#   -mcpu  = Target processor, can include one or more feature modifiers.
+#   -mtune = Target processor for which the compiler should tune the performance of the code
+#   -march = Target architecture, can include  one or more feature modifiers
+# Note: further details can be found in the GCC documentation
+#
+# OpenBLAS settings:
+#   blas_cpu = target processor for OpenBLAS build
+#     Note: defaults to host processor if unset.
+#   blas_ncores = max thread count for OpenBLAS build.
+#     Note: defaults to number of cores on host machine if unset.
 
 function set_target {
 
@@ -82,6 +94,7 @@ function set_target {
       tune="neoverse-n1"
       arch="armv8.2-a"
       blas_cpu="NEOVERSEN1"
+      blas_ncores=64
       acl_arch="arm64-v8.2-a"
     ;;
     thunderx2t99 )
@@ -89,6 +102,7 @@ function set_target {
       tune="thunderx2t99"
       arch="armv8.1-a"
       blas_cpu="THUNDERX2T99"
+      blas_ncores=64
       acl_arch="arm64-v8a"
     ;;
     generic )
@@ -96,6 +110,7 @@ function set_target {
       tune="generic"
       arch="armv8-a"
       blas_cpu="ARMV8"
+      blas_ncores=
       acl_arch="arm64-v8a"
     ;;
     custom )
@@ -104,6 +119,7 @@ function set_target {
       tune="neoverse-n1"
       arch="armv8.2-a"
       blas_cpu="NEOVERSEN1"
+      blas_ncpu=64
       acl_arch="arm64-v8.2-a"
     ;;
     * )
@@ -111,6 +127,7 @@ function set_target {
       tune="native"
       arch="native"
       blas_cpu=
+      blas_ncores=
       acl_arch="arm64-v8a"
     ;;
  esac

--- a/docker/pytorch-aarch64/examples/README.md
+++ b/docker/pytorch-aarch64/examples/README.md
@@ -94,17 +94,49 @@ python answer_questions.py -t context.txt -q "When was the battle of Hastings?"
 
 where `context.txt` is the text file containing the text on which the question is based. If no text file is provided, `answer_questions.py` will search through the SQuAD dataset for the question and, if the question can be located, use the context associated with it.
 
+### Torchtext Article Reading
+
+The script 'torchtext_example.py' shows the functionality of the 'torchtext' Pytorch library. The example reads an article and determines its genre out of 4 options: world, sports, business, or science & technology.
+
+To run the script:
+
+```
+python torchtext_example.py
+```
+
+The example reads an excerpt from an article from https://news.northeastern.edu/2021/08/09/holy-grail-discovery-in-solid-state-physics-could-usher-in-new-technologies/, and correctly determines that it is a science & technology article.
+
+This script was built following the approach detailed in https://pytorch.org/tutorials/beginner/text_sentiment_ngrams_tutorial.html
 
 ## MLCommons :tm: benchmarks
 
-### Object detection
+### Vision
 
-To run ResNet34-ssd with the COCO 2017 validation dataset for object detection, download the dataset and model using the scripts provided in the `$HOME/examples/MLCommons` directory of the final image.
+To run the image classification and object detection benchmarks, first download the datasets and models using the scripts provided in the `$HOME/examples/MLCommons` directory of the final image.
 
-  * `download-dataset.sh` downloads the Coco 2017 dataset using CK to `${HOME}/CK-TOOLS/`
-  * `download-model.sh` downloads the resnet34-ssd model.
+  * `download-dataset.sh` downloads the ImageNet min-validation and Coco 2017 datasets using CK to `${HOME}/CK-TOOLS/`. Select option 1: for the val-min ImageNet dataset.
+  * `download-model.sh` downloads the ResNet50 and SSD-ResNet34 models.
 
-Set `DATA_DIR` to the location of the downloaded dataset and `MODEL_DIR` to the location of the downloaded model.
+The environment variables `DATA_DIR` and `MODEL_DIR` will need to be set to the location of the downloaded dataset and model in each case.
+
+#### Image classification
+
+To run ResNet50 on ImageNet min-validation dataset for image classification, set `DATA_DIR` to the location of the downloaded dataset and `MODEL_DIR` to the location of the downloaded model.
+
+```
+export DATA_DIR=${HOME}/CK-TOOLS/dataset-imagenet-ilsvrc2012-val-min
+export MODEL_DIR=$(pwd)
+```
+
+From `$HOME/examples/MLCommons/inference/vision/classification_and_detection` use the `run_local.sh` to start the benchmark.
+
+```
+./run_local.sh pytorch resnet50 cpu
+```
+
+#### Object detection
+
+To run ResNet34-ssd with the COCO 2017 validation dataset for object detection, set `DATA_DIR` to the location of the downloaded dataset and `MODEL_DIR` to the location of the downloaded model.
 
 ```
 export DATA_DIR=${HOME}/CK-TOOLS/dataset-coco-2017-val

--- a/docker/pytorch-aarch64/examples/axion.txt
+++ b/docker/pytorch-aarch64/examples/axion.txt
@@ -1,0 +1,16 @@
+There are many mysteries still to unravel in the world of
+quantum mechanics, but scientists at Northeastern believe they’ve
+made a “holy grail” discovery that could help pave the way for
+the next generation of electronic devices.  Their findings,
+published recently in Nature, center mostly on the discovery of a
+so-called topological axion insulator, a unique state of quantum
+matter of which researchers previously only theorized existed,
+according to physicist Arun Bansil, who led a team of researchers at
+Northeastern involved in the study. There were several dozen
+scientists from universities around the world involved in the
+project. This axion insulating state was realized, Bansil says,
+by combining certain metals and observing their magnetoelectric
+response. In this case, researchers used a solid state chip composed
+of manganese bismuth telluride, which were adhered together in
+two-dimensional layers, to measure the resulting electric and
+magnetic properties.

--- a/docker/pytorch-aarch64/examples/torchtext_example.py
+++ b/docker/pytorch-aarch64/examples/torchtext_example.py
@@ -1,0 +1,204 @@
+# *****************************************************************************$
+# Copyright 2021 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *****************************************************************************$
+
+# This script was built following the approach detailed in:
+# https://pytorch.org/tutorials/beginner/text_sentiment_ngrams_tutorial.html
+
+import torch
+from torch import nn
+from torch.utils.data import DataLoader
+from torch.utils.data.dataset import random_split
+from torchtext.vocab import build_vocab_from_iterator
+from torchtext.datasets import AG_NEWS
+from torchtext.data.utils import get_tokenizer
+from torchtext.data.functional import to_map_style_dataset
+from TextClassificationModel import TextClassificationModel
+from pathlib import Path
+import time
+import sys
+
+
+# Hyperparameters
+EPOCHS = 10  # epoch
+LR = 5  # learning rate
+BATCH_SIZE = 64  # batch size for training
+
+
+# Yields a list of tokens from iterator of input data
+def yield_tokens(data_iter, tokenizer):
+    for _, text in data_iter:
+        yield tokenizer(text)
+
+
+# Trains the model
+def train(dataloader, model, optimizer, criterion, epoch):
+    model.train()
+    total_acc, total_count = 0, 0
+    log_interval = 500
+    start_time = time.time()
+
+    for idx, (label, text, offsets) in enumerate(dataloader):
+        optimizer.zero_grad()
+        predicted_label = model(text, offsets)
+        loss = criterion(predicted_label, label)
+        loss.backward()
+        torch.nn.utils.clip_grad_norm_(model.parameters(), 0.1)
+        optimizer.step()
+        total_acc += (predicted_label.argmax(1) == label).sum().item()
+        total_count += label.size(0)
+        if idx % log_interval == 0 and idx > 0:
+            elapsed = time.time() - start_time
+            print('| epoch {:3d} | {:5d}/{:5d} batches '
+                '| accuracy {:8.3f}'.format(epoch, idx, len(dataloader),
+                                            total_acc/total_count))
+            total_acc, total_count = 0, 0
+            start_time = time.time()
+
+
+# Evaluates test accuracy of model
+def evaluate(dataloader, model, criterion):
+    model.eval()
+    total_acc, total_count = 0, 0
+
+    with torch.no_grad():
+        for idx, (label, text, offsets) in enumerate(dataloader):
+            predicted_label = model(text, offsets)
+            loss = criterion(predicted_label, label)
+            total_acc += (predicted_label.argmax(1) == label).sum().item()
+            total_count += label.size(0)
+    return total_acc/total_count
+
+
+# Predicts article type of test article
+def predict(text, text_pipeline, model):
+    with torch.no_grad():
+        text = torch.tensor(text_pipeline(text))
+        output = model(text, torch.tensor([0]))
+        return output.argmax(1).item() + 1
+
+
+def main():
+
+    num_args = len(sys.argv)
+
+    # Checking if filename input is specified
+    if num_args < 2:
+        sys.exit("Please specify an input file")
+
+    filename = str(sys.argv[1])
+    p = Path(filename)
+
+    # Checking if filepath is valid and/or file exists
+    if not (p.exists()):
+        sys.exit("File not found")
+
+    # Prepare data processing pipelines
+    tokenizer = get_tokenizer('basic_english')
+    train_iter = AG_NEWS(split='train')
+
+    vocab = build_vocab_from_iterator(yield_tokens(train_iter, tokenizer),
+        specials=["<unk>"])
+    vocab.set_default_index(vocab["<unk>"])
+
+    text_pipeline = lambda x: vocab(tokenizer(x))
+    label_pipeline = lambda x: int(x) - 1
+
+    # Generate data batch and iterator
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    def collate_batch(batch):
+        label_list, text_list, offsets = [], [], [0]
+        for (_label, _text) in batch:
+            label_list.append(label_pipeline(_label))
+            processed_text = torch.tensor(text_pipeline(_text),
+                dtype=torch.int64)
+            text_list.append(processed_text)
+            offsets.append(processed_text.size(0))
+        label_list = torch.tensor(label_list, dtype=torch.int64)
+        offsets = torch.tensor(offsets[:-1]).cumsum(dim=0)
+        text_list = torch.cat(text_list)
+        return label_list.to(device), text_list.to(device), offsets.to(device)
+
+    # This variable needs to be initialized twice or else an IndexError occurs
+    train_iter = AG_NEWS(split='train')
+    dataloader = DataLoader(train_iter, batch_size=8, shuffle=False,
+        collate_fn=collate_batch)
+
+    # Build an instance
+    num_class = len(set([label for (label, text) in train_iter]))
+    vocab_size = len(vocab)
+    emsize = 64
+    model = TextClassificationModel(vocab_size, emsize, num_class).to(device)
+
+    # Split the dataset and run the model
+    criterion = torch.nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=LR)
+    scheduler = torch.optim.lr_scheduler.StepLR(optimizer, 1.0, gamma=0.1)
+    total_accu = None
+    train_iter, test_iter = AG_NEWS()
+    train_dataset = to_map_style_dataset(train_iter)
+    test_dataset = to_map_style_dataset(test_iter)
+    num_train = int(len(train_dataset) * 0.95)
+    split_train_, split_valid_ = \
+        random_split(train_dataset,
+        [num_train, len(train_dataset) - num_train])
+
+    train_dataloader = DataLoader(split_train_, batch_size=BATCH_SIZE,
+                                shuffle=True, collate_fn=collate_batch)
+    valid_dataloader = DataLoader(split_valid_, batch_size=BATCH_SIZE,
+                                shuffle=True, collate_fn=collate_batch)
+    test_dataloader = DataLoader(test_dataset, batch_size=BATCH_SIZE,
+                                shuffle=True, collate_fn=collate_batch)
+
+    # Run epochs
+    for epoch in range(1, EPOCHS + 1):
+        epoch_start_time = time.time()
+        train(train_dataloader, model, optimizer, criterion, epoch)
+        accu_val = evaluate(valid_dataloader, model, criterion)
+        if total_accu is not None and total_accu > accu_val:
+            scheduler.step()
+        else:
+            total_accu = accu_val
+        print('-' * 59)
+        print('| end of epoch {:3d} | time: {:5.2f}s | '
+            'valid accuracy {:8.3f} '.format(epoch,
+                                            time.time() - epoch_start_time,
+                                            accu_val))
+        print('-' * 59)
+
+    print('Checking the results of test dataset.')
+    accu_test = evaluate(test_dataloader, model, criterion)
+    print('test accuracy {:8.3f}'.format(accu_test))
+
+    # Run article prediction
+    ag_news_label = {1: "World",
+                    2: "Sports",
+                    3: "Business",
+                    4: "Sci/Tec"}
+
+    with p.open() as readfile:
+        ex_text_str = readfile.read()
+
+    model = model.to("cpu")
+
+    print("This is a %s news" % ag_news_label[predict(ex_text_str,
+        text_pipeline, model)])
+
+
+if __name__ == '__main__':
+    main()
+

--- a/docker/pytorch-aarch64/patches/pytorch_native.patch
+++ b/docker/pytorch-aarch64/patches/pytorch_native.patch
@@ -1,0 +1,231 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/vision/classification_and_detection/python/backend.py b/vision/classification_and_detection/python/backend.py
+index 955eddb..f607738 100755
+--- a/vision/classification_and_detection/python/backend.py
++++ b/vision/classification_and_detection/python/backend.py
+@@ -16,7 +16,7 @@ class Backend():
+     def name(self):
+         raise NotImplementedError("Backend:name")
+ 
+-    def load(self, model_path, inputs=None, outputs=None):
++    def load(self, model_path, profile=None, inputs=None, outputs=None):
+         raise NotImplementedError("Backend:load")
+ 
+     def predict(self, feed):
+diff --git a/vision/classification_and_detection/python/backend_null.py b/vision/classification_and_detection/python/backend_null.py
+index ed58170..3cbb405 100755
+--- a/vision/classification_and_detection/python/backend_null.py
++++ b/vision/classification_and_detection/python/backend_null.py
+@@ -22,7 +22,7 @@ class BackendNull(backend.Backend):
+     def image_format(self):
+         return "NHWC"
+ 
+-    def load(self, model_path, inputs=None, outputs=None):
++    def load(self, model_path, profile=None, inputs=None, outputs=None):
+         self.outputs = ["output"]
+         self.inputs = ["input"]
+         return self
+diff --git a/vision/classification_and_detection/python/backend_onnxruntime.py b/vision/classification_and_detection/python/backend_onnxruntime.py
+index 66b8fda..4456925 100755
+--- a/vision/classification_and_detection/python/backend_onnxruntime.py
++++ b/vision/classification_and_detection/python/backend_onnxruntime.py
+@@ -24,7 +24,7 @@ class BackendOnnxruntime(backend.Backend):
+         """image_format. For onnx it is always NCHW."""
+         return "NCHW"
+ 
+-    def load(self, model_path, inputs=None, outputs=None):
++    def load(self, model_path, profile=None, inputs=None, outputs=None):
+         """Load model and find input/outputs from the model file."""
+         opt = rt.SessionOptions()
+         # enable level 3 optimizations
+diff --git a/vision/classification_and_detection/python/backend_pytorch.py b/vision/classification_and_detection/python/backend_pytorch.py
+index 02b010a..6858147 100755
+--- a/vision/classification_and_detection/python/backend_pytorch.py
++++ b/vision/classification_and_detection/python/backend_pytorch.py
+@@ -30,7 +30,7 @@ class BackendPytorch(backend.Backend):
+     def image_format(self):
+         return "NCHW"
+ 
+-    def load(self, model_path, inputs=None, outputs=None):
++    def load(self, model_path, profile=None, inputs=None, outputs=None):
+         self.model = onnx.load(model_path)
+ 
+         # find inputs from the model if not passed in by config
+diff --git a/vision/classification_and_detection/python/backend_pytorch_native.py b/vision/classification_and_detection/python/backend_pytorch_native.py
+index f631ac5..13f16d6 100755
+--- a/vision/classification_and_detection/python/backend_pytorch_native.py
++++ b/vision/classification_and_detection/python/backend_pytorch_native.py
+@@ -1,18 +1,18 @@
+ """
+-pytoch native backend 
++pytorch native backend
+ """
+ # pylint: disable=unused-argument,missing-docstring
+ import torch  # currently supports pytorch1.0
+ import backend
+ 
+ 
+-
+ class BackendPytorchNative(backend.Backend):
+     def __init__(self):
+         super(BackendPytorchNative, self).__init__()
+         self.sess = None
+         self.model = None
+         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
++
+     def version(self):
+         return torch.__version__
+ 
+@@ -22,8 +22,14 @@ class BackendPytorchNative(backend.Backend):
+     def image_format(self):
+         return "NCHW"
+ 
+-    def load(self, model_path, inputs=None, outputs=None):
+-        self.model = torch.load(model_path,map_location=lambda storage, loc: storage)
++    def load(self, model_path, profile=None, inputs=None, outputs=None):
++        self.profile = profile
++        if profile == "resnet50-pytorch":
++            from torchvision.models.resnet import resnet50
++            self.model = resnet50(pretrained=False)
++            self.model.load_state_dict(torch.load(model_path,map_location=lambda storage, loc: storage))
++        else:
++            self.model = torch.load(model_path,map_location=lambda storage, loc: storage)
+         self.model.eval()
+         # find inputs from the model if not passed in by config
+         if inputs:
+@@ -48,10 +54,9 @@ class BackendPytorchNative(backend.Backend):
+         self.model = self.model.to(self.device)
+         return self
+ 
+-        
+     def predict(self, feed):
+-        key=[key for key in feed.keys()][0]    
++        key=[key for key in feed.keys()][0]
+         feed[key] = torch.tensor(feed[key]).float().to(self.device)
+         with torch.no_grad():
+-            output = self.model(feed[key])    
+-        return output
++            output = self.model(feed[key])
++        return [output] if self.profile == "resnet50-pytorch" else output
+diff --git a/vision/classification_and_detection/python/backend_tf.py b/vision/classification_and_detection/python/backend_tf.py
+index b8d1c6d..7682dce 100755
+--- a/vision/classification_and_detection/python/backend_tf.py
++++ b/vision/classification_and_detection/python/backend_tf.py
+@@ -27,7 +27,7 @@ class BackendTensorflow(backend.Backend):
+         # By default tensorflow uses NHWC (and the cpu implementation only does NHWC)
+         return "NHWC"
+ 
+-    def load(self, model_path, inputs=None, outputs=None):
++    def load(self, model_path, profile=None, inputs=None, outputs=None):
+         # there is no input/output meta data i the graph so it need to come from config.
+         if not inputs:
+             raise ValueError("BackendTensorflow needs inputs")
+diff --git a/vision/classification_and_detection/python/backend_tflite.py b/vision/classification_and_detection/python/backend_tflite.py
+index de0a958..e4e7e81 100755
+--- a/vision/classification_and_detection/python/backend_tflite.py
++++ b/vision/classification_and_detection/python/backend_tflite.py
+@@ -28,7 +28,7 @@ class BackendTflite(backend.Backend):
+         # tflite is always NHWC
+         return "NHWC"
+ 
+-    def load(self, model_path, inputs=None, outputs=None):
++    def load(self, model_path, profile=None, inputs=None, outputs=None):
+         self.sess = interpreter_wrapper.Interpreter(model_path=model_path)
+         self.sess.allocate_tensors()
+         # keep input/output name to index mapping
+diff --git a/vision/classification_and_detection/python/dataset.py b/vision/classification_and_detection/python/dataset.py
+index 597c751..dce968a 100755
+--- a/vision/classification_and_detection/python/dataset.py
++++ b/vision/classification_and_detection/python/dataset.py
+@@ -202,6 +202,22 @@ def pre_process_mobilenet(img, dims=None, need_transpose=False):
+     return img
+ 
+ 
++def pre_process_imagenet_pytorch(img, dims=None, need_transpose=False):
++    from PIL import Image
++    import torchvision.transforms.functional as F
++
++    img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB)
++    img = Image.fromarray(img)
++    img = F.resize(img, 256, Image.BILINEAR)
++    img = F.center_crop(img, 224)
++    img = F.to_tensor(img)
++    img = F.normalize(img, mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225], inplace=False)
++    if not need_transpose:
++        img = img.permute(1, 2, 0) # NHWC
++    img = np.asarray(img, dtype='float32')
++    return img
++
++
+ def maybe_resize(img, dims):
+     img = np.array(img, dtype=np.float32)
+     if len(img.shape) < 3 or img.shape[2] != 3:
+diff --git a/vision/classification_and_detection/python/main.py b/vision/classification_and_detection/python/main.py
+index cd6825f..cff785e 100755
+--- a/vision/classification_and_detection/python/main.py
++++ b/vision/classification_and_detection/python/main.py
+@@ -37,6 +37,9 @@ SUPPORTED_DATASETS = {
+     "imagenet":
+         (imagenet.Imagenet, dataset.pre_process_vgg, dataset.PostProcessCommon(offset=-1),
+          {"image_size": [224, 224, 3]}),
++    "imagenet-pytorch":
++        (imagenet.Imagenet, dataset.pre_process_imagenet_pytorch, dataset.PostProcessArgMax(offset=0),
++         {"image_size": [224, 224, 3]}),
+     "imagenet_mobilenet":
+         (imagenet.Imagenet, dataset.pre_process_mobilenet, dataset.PostProcessArgMax(offset=-1),
+          {"image_size": [224, 224, 3]}),
+@@ -85,6 +88,13 @@ SUPPORTED_PROFILES = {
+         "backend": "onnxruntime",
+         "model-name": "resnet50",
+     },
++    "resnet50-pytorch": {
++         "inputs": "image",
++         "dataset": "imagenet-pytorch",
++         "outputs": "ArgMax:0",
++         "backend": "pytorch-native",
++         "model-name": "resnet50",
++    },
+ 
+     # mobilenet
+     "mobilenet-tf": {
+@@ -429,7 +439,7 @@ def main():
+                         use_cache=args.cache,
+                         count=count, **kwargs)
+     # load model to backend
+-    model = backend.load(args.model, inputs=args.inputs, outputs=args.outputs)
++    model = backend.load(args.model, profile=args.profile, inputs=args.inputs, outputs=args.outputs)
+     final_results = {
+         "runtime": model.name(),
+         "version": model.version(),
+diff --git a/vision/classification_and_detection/run_common.sh b/vision/classification_and_detection/run_common.sh
+index ea7c1d6..5a294ab 100755
+--- a/vision/classification_and_detection/run_common.sh
++++ b/vision/classification_and_detection/run_common.sh
+@@ -82,9 +82,8 @@ fi
+ # pytorch
+ #
+ if [ $name == "resnet50-pytorch" ] ; then
+-    model_path="$MODEL_DIR/resnet50_v1.onnx"
+-    profile=resnet50-onnxruntime
+-    extra_args="$extra_args --backend pytorch"
++    model_path="$MODEL_DIR/resnet50-19c8e357.pth"
++    profile=resnet50-pytorch
+ fi
+ if [ $name == "mobilenet-pytorch" ] ; then
+     model_path="$MODEL_DIR/mobilenet_v1_1.0_224.onnx"

--- a/docker/pytorch-aarch64/scripts/build-mlcommons.sh
+++ b/docker/pytorch-aarch64/scripts/build-mlcommons.sh
@@ -26,6 +26,10 @@ cd $EXAMPLE_DIR/MLCommons
 git clone https://github.com/mlcommons/inference.git --recursive
 cd inference
 git checkout r0.7
+
+patch -p1 < $MLCOMMONS_DIR/pytorch_native.patch
+rm $MLCOMMONS_DIR/pytorch_native.patch
+
 git checkout v1.0.1 -- language/bert
 patch -p1 < $MLCOMMONS_DIR/mlcommons_bert.patch
 rm $MLCOMMONS_DIR/mlcommons_bert.patch

--- a/docker/pytorch-aarch64/scripts/build-torchtext.sh
+++ b/docker/pytorch-aarch64/scripts/build-torchtext.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020-2021 Arm Limited and affiliates.
+# Copyright 2021 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -19,22 +19,20 @@
 
 set -euo pipefail
 
+source python3-venv/bin/activate
 cd $PACKAGE_DIR
-readonly package=openblas
-readonly version=$OPENBLAS_VERSION
-readonly src_host="https://github.com/xianyi"
-readonly src_repo="OpenBLAS"
+readonly package=torchtext
+readonly version=$TEXT_VERSION
+readonly src_host=https://github.com/pytorch
+readonly src_repo=text
+readonly cppflags="-I$VENV_PACKAGE_DIR/pybind11/include"
 
-git clone ${src_host}/${src_repo}.git
-cd ${src_repo}
+# Clone TorchText
+git clone ${src_host}/${src_repo}.git ${package}
+cd ${package}
 git checkout v$version -b v$version
+git submodule sync
+git submodule update --init --recursive
 
-install_dir=$PROD_DIR/$package/$version
-
-export CFLAGS="-O3"
-extra_args="USE_OPENMP=1"
-[[ ${BLAS_CPU} ]] && extra_args="$extra_args TARGET=${blas_cpu}"
-[[ ${BLAS_NCORES} ]] && extra_args="$extra_args NUM_THREADS=${blas_ncores}"
-
-make -j $NP_MAKE $extra_args
-make -j $NP_MAKE $extra_args PREFIX=$install_dir install
+# Run Python build script
+CPPFLAGS=$cppflags python setup.py clean install

--- a/docker/pytorch-aarch64/scripts/download-dataset.sh
+++ b/docker/pytorch-aarch64/scripts/download-dataset.sh
@@ -1,7 +1,18 @@
 #!/bin/bash
+set -euo pipefail
 
 # This script is based on the upstream MLCommon's instructions to download datasets.
 # https://github.com/mlperf/inference/tree/master/vision/classification_and_detection
+
+# Download ImageNet's validation set
+# These will be installed to ${HOME}/CK_TOOLS/
+# Select option 1: val-min data set. Issue when downloading the complete val data set using ck-env [https://github.com/ctuning/ck-env/issues/101]
+
+ck install package --tags=image-classification,dataset,imagenet,aux
+ck install package --tags=image-classification,dataset,imagenet,val
+
+# Copy the labels into the image location
+cp ${HOME}/CK-TOOLS/dataset-imagenet-ilsvrc2012-aux/val.txt ${HOME}/CK-TOOLS/dataset-imagenet-ilsvrc2012-val-min/val_map.txt
 
 # Download coco dataset
 ck install package --tags=object-detection,dataset,coco,2017,val,original

--- a/docker/pytorch-aarch64/scripts/download-model.sh
+++ b/docker/pytorch-aarch64/scripts/download-model.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
+set -euo pipefail
 
 # This script is  based on the upstream MLCommon's instructions to download models.
 # https://github.com/mlperf/inference/tree/master/vision/classification_and_detection
 
-cd vision/classification_and_detection
-# ssd-resnet34
+cd inference/vision/classification_and_detection
+# ResNet50
+wget https://zenodo.org/record/4588417/files/resnet50-19c8e357.pth
+# SSD-ResNet34
 wget https://zenodo.org/record/3236545/files/resnet34-ssd1200.pytorch

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -131,11 +131,13 @@ ARG njobs
 ARG cpu
 ARG arch
 ARG blas_cpu
+ARG blas_ncores
 
 ENV NP_MAKE="${njobs}" \
     CPU="${cpu}" \
     ARCH="${arch}" \
-    BLAS_CPU="${blas_cpu}"
+    BLAS_CPU="${blas_cpu}" \
+    BLAS_NCORES="${blas_ncores}"
 
 # Key version numbers
 ENV OPENBLAS_VERSION=0.3.10
@@ -282,10 +284,12 @@ RUN $PACKAGE_DIR/get-bazel.sh
 ENV PATH=$PACKAGE_DIR/bazel:$PATH
 
 # Build TensorFlow
-COPY patches/tf_acl.patch $PACKAGE_DIR/.
 COPY patches/eigen_workspace.patch $PACKAGE_DIR/.
 COPY patches/eigen_gebp_cache.patch  $PACKAGE_DIR/.
+COPY patches/tf_acl.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_primitives.patch $PACKAGE_DIR/.
 COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
+COPY patches/TF-caching-ip.patch $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh
 
 CMD ["bash", "-l"]

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -19,7 +19,7 @@ Pre-built images are available for download from [Arm's Software Developers Dock
   * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.3. Previously known as (MKL-DNN/DNNL).
   * Python3 environment containing:
     - NumPy 1.19.5
-    - TensorFlow 2.5.0. (_Note: support for TensorFlow 1.x is now deprecated. Please use the [tensorflow-v1-aarch64)](https://github.com/ARM-software/Tool-Solutions/releases/tag/tensorflow-v1-aarch64) tag_).
+    - TensorFlow 2.6.0. (_Note: support for TensorFlow 1.x is now deprecated. Please use the [tensorflow-v1-aarch64)](https://github.com/ARM-software/Tool-Solutions/releases/tag/tensorflow-v1-aarch64) tag_).
     - SciPy 1.5.2
   * TensorFlow Benchmarks
   * [MLCommons :tm: (MLPerf)](https://mlperf.org/) benchmarks with an optional patch to support benchmarking for TF oneDNN builds.

--- a/docker/tensorflow-aarch64/build.sh
+++ b/docker/tensorflow-aarch64/build.sh
@@ -213,7 +213,7 @@ if [[ $clean_build ]]; then
 fi
 
 # Set TensorFlow, bazel and oneDNN version
-version="v2.5.0"
+version="v2.6.0"
 bazel_version="3.7.2"
 # Add build-args to pass version numbers,
 extra_args="$extra_args \
@@ -226,6 +226,7 @@ extra_args="$extra_args --build-arg cpu=$cpu \
     --build-arg tune=$tune \
     --build-arg arch=$arch \
     --build-arg blas_cpu=$blas_cpu \
+    --build-arg blas_ncores=$blas_ncores \
     --build-arg eigen_l1_cache=$eigen_l1_cache \
     --build-arg eigen_l2_cache=$eigen_l2_cache \
     --build-arg eigen_l3_cache=$eigen_l3_cache"

--- a/docker/tensorflow-aarch64/cpu_info.sh
+++ b/docker/tensorflow-aarch64/cpu_info.sh
@@ -60,7 +60,24 @@ echo $target
 }
 
 ################################################################################
-# Sets required -mtune, -mcou, -march flags for chosen target
+# Sets target-specific flags used in the build:
+#
+# Compiler flags for chosen target:
+#   -mcpu  = Target processor, can include one or more feature modifiers.
+#   -mtune = Target processor for which the compiler should tune the performance of the code
+#   -march = Target architecture, can include  one or more feature modifiers
+# Note: further details can be found in the GCC documentation
+#
+# Eigen settings:
+#   eigen_l{1,2,3}_cache = Sets the L1, 2, 3 cache size used for Eigen's GEBP
+#     kernel. If unset, the build will use Eigen defaults.
+#
+# OpenBLAS settings:
+#   blas_cpu = target processor for OpenBLAS build
+#     Note: defaults to host processor if unset.
+#   blas_ncores = max thread count for OpenBLAS build.
+#     Note: defaults to number of cores on host machine if unset.
+
 
 function set_target {
 
@@ -82,6 +99,7 @@ function set_target {
       tune="neoverse-n1"
       arch="armv8.2-a"
       blas_cpu="NEOVERSEN1"
+      blas_ncores=64
       eigen_l1_cache="64*1024"
       eigen_l2_cache="1024*1024"
       eigen_l3_cache=
@@ -91,6 +109,7 @@ function set_target {
       tune="thunderx2t99"
       arch="armv8.1-a"
       blas_cpu="THUNDERX2T99"
+      blas_ncores=64
       eigen_l1_cache="32*1024"
       eigen_l2_cache="256*1024"
       eigen_l3_cache="512*1024"
@@ -100,6 +119,7 @@ function set_target {
       tune="generic"
       arch="armv8-a"
       blas_cpu="ARMV8"
+      blas_ncores=
       eigen_l1_cache=
       eigen_l2_cache=
       eigen_l3_cache=
@@ -110,6 +130,7 @@ function set_target {
       tune="neoverse-n1"
       arch="armv8.2-a"
       blas_cpu="NEOVERSEN1"
+      blas_ncores=64
       eigen_l1_cache="64*1024"
       eigen_l2_cache="1024*1024"
       eigen_l3_cache="1024*1024"
@@ -119,6 +140,7 @@ function set_target {
       tune="native"
       arch="native"
       blas_cpu=
+      blas_ncores=
       eigen_l1_cache=
       eigen_l2_cache=
       eigen_l3_cache=

--- a/docker/tensorflow-aarch64/examples/README.md
+++ b/docker/tensorflow-aarch64/examples/README.md
@@ -185,9 +185,11 @@ In order to reduce the runtime, for the purposes of confirming that it runs as e
 *.*.min_query_count = 1
 *.*.performance_sample_count_override = 1
 ```
+TensorFlow threading can be set using environment variables TF_INTRA_OP_PARALLELISM_THREADS and TF_INTER_OP_PARALLELISM_THREADS.
 
 # C++ Examples
 
+To build the C++ examples, simply run `make` from inside the `cpp-api` directory.
 When executing the resulting binaries, the following flags are required:
 * `-m` flag sets the configuration file that describes model in YAML format (see Python section above)
 * `-i` sets the input image
@@ -195,15 +197,15 @@ When executing the resulting binaries, the following flags are required:
 _Note:_ unlike in the python examples, the model/labels/image paths are local relative paths. The examples expect these files to be downloaded before execution. By default, the makefile build will download the required models, labels and input images.
 
 To run the examples:
-* `./classify_image` -m resnet50.yml -i images/guineapig.jpeg
+* `./classify_image -m resnet50.yml -i images/guineapig.jpeg`
   * Resnet50 in `SavedModel` format (single image inference)
   * _input_: images/guineapig.jpeg | _labels:_ labels/imagenet-labels.txt
   * _output:_ Top 3 predictions with confidence and labels
-* `./inception_inference` -m inception.yml -i images/guineapig.jpeg
+* `./inception_inference -m inception.yml -i images/guineapig.jpeg`
   * Inception model in `FrozenModel.pb` format (single image inference)
   * _input:_ images/guineapig.jpes | _labels_: labels/imagenet_slim_labels.txt
   * _output:_ Top 3 predictions with confidence and labels
-* `./detect_objects` -m ssd_resnet50.yml -i images/cows.jpeg
+* `./detect_objects -m ssd_resnet50.yml -i images/cows.jpeg`
   * SSD-Resnet50 in `SavedModel` format (single image inference)
   * uses OpenCV to load _and_ post-process the image.
   * post-processing create a new image `output_image.jpeg` where the detected objects are framed in red rectangles.

--- a/docker/tensorflow-aarch64/patches/TF-caching-ip.patch
+++ b/docker/tensorflow-aarch64/patches/TF-caching-ip.patch
@@ -1,0 +1,76 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+index de334f3c8d2..6a961bf7c09 100644
+--- a/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
++++ b/tensorflow/core/kernels/mkl/mkl_matmul_op_fused.cc
+@@ -122,7 +122,12 @@ class MklFusedMatMulOp : public MklDnnMatMulOpBase<T, T> {
+         memory::format_tag::nc);
+ 
+     // Extend the basic parameters for data types and fusions.
+-    ExtendMklDnnMatMulFwdParams(ctx, matmul_params);
++    ExtendMklDnnMatMulFwdParams(ctx, matmul_params); 
++    #ifdef DNNL_AARCH64_USE_ACL
++        //Specifics of ACL: a primitive per constant weights ptr
++        matmul_params.filter_address = const_cast<void*>(
++          static_cast<const void*>(weight_tensor.flat<T>().data()));
++    #endif
+     MklDnnMatMulFwdPrimitive<T, T, T, T, T>* matmul_prim =
+         MklDnnMatMulFwdPrimitiveFactory<T, T, T, T, T>::Get(matmul_params, 0);
+ 
+diff --git a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+index 2c739a8567d..22db9cf1fe1 100644
+--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
++++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+@@ -56,6 +56,9 @@ struct MklDnnMatMulFwdParams {
+   memory::format_tag weight_format;
+   memory::format_tag dst_format;
+   string dtypes = string("");
++#ifdef DNNL_AARCH64_USE_ACL
++  void* filter_address = nullptr;
++#endif
+   struct PostOpParam {
+     string name;
+     std::vector<float> param;
+@@ -106,6 +109,7 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
+   void Execute(const Tinput* src_data, const Tweight* weight_data,
+                const Tbias* bias_data, Toutput* dst_data,
+                std::shared_ptr<stream> fwd_stream) {
++
+ #ifndef ENABLE_ONEDNN_OPENMP
+     context_.src_mem->set_data_handle(
+         static_cast<void*>(const_cast<Tinput*>(src_data)), *fwd_stream);
+@@ -300,7 +304,7 @@ class MklDnnMatMulFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
+       const MklDnnMatMulFwdParams& mkldnn_matmul_fwd_dims, bool do_not_cache) {
+     MklDnnMatMulFwdPrimitive<T, Tinput, Tweight, Tbias, Toutput>* matmul_fwd =
+         nullptr;
+-
++ 
+     if (do_not_cache) {
+       // Always create new primitive
+       matmul_fwd =
+@@ -344,6 +348,9 @@ class MklDnnMatMulFwdPrimitiveFactory : public MklPrimitiveFactory<T> {
+     key_creator.AddAsKey(mkldnn_matmul_fwd_dims.dst_dims);
+     key_creator.AddAsKey(mkldnn_matmul_fwd_dims.dtypes);
+     key_creator.AddAsKey(mkldnn_matmul_fwd_dims.weight_format);
++#ifdef DNNL_AARCH64_USE_ACL
++    key_creator.AddAsKey(mkldnn_matmul_fwd_dims.filter_address);
++#endif
+ 
+     // Generate keys for post-ops
+     for (auto const& post_op_param : mkldnn_matmul_fwd_dims.post_op_params) {

--- a/docker/tensorflow-aarch64/patches/mlcommons_bert.patch
+++ b/docker/tensorflow-aarch64/patches/mlcommons_bert.patch
@@ -397,3 +397,29 @@ index 43e91ec..270a26e 100644
  
  from transformers import BertTokenizer
  from create_squad_data import read_squad_examples, convert_examples_to_features
+diff --git a/language/bert/tf_SUT.py b/language/bert/tf_SUT.py
+index a34207b..5844f3d 100644
+--- a/language/bert/tf_SUT.py
++++ b/language/bert/tf_SUT.py
+@@ -1,4 +1,5 @@
+ # coding=utf-8
++# Copyright 2021 Arm Limited and affiliates.
+ # Copyright (c) 2020 NVIDIA CORPORATION. All rights reserved.
+ # Copyright 2018 The Google AI Language Team Authors.
+ #
+@@ -29,7 +30,14 @@ from squad_QSL import get_squad_QSL
+ class BERT_TF_SUT():
+     def __init__(self, args):
+         print("Loading TF model...")
+-        self.sess = tf.compat.v1.Session()
++        infer_config = tf.compat.v1.ConfigProto()
++        infer_config.intra_op_parallelism_threads = int(os.environ['TF_INTRA_OP_PARALLELISM_THREADS']) \
++                if 'TF_INTRA_OP_PARALLELISM_THREADS' in os.environ else os.cpu_count()
++        infer_config.inter_op_parallelism_threads = int(os.environ['TF_INTER_OP_PARALLELISM_THREADS']) \
++                if 'TF_INTER_OP_PARALLELISM_THREADS' in os.environ else os.cpu_count()
++        infer_config.use_per_session_threads = 1
++        self.sess = tf.compat.v1.Session(config=infer_config)
++
+         with gfile.FastGFile('build/data/bert_tf_v1_1_large_fp32_384_v2/model.pb', 'rb') as f:
+             graph_def = tf.compat.v1.GraphDef()
+             graph_def.ParseFromString(f.read())

--- a/docker/tensorflow-aarch64/patches/onednn_acl_primitives.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_primitives.patch
@@ -1,0 +1,1872 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
+index afa784054..242c799cf 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.cpp
++++ b/src/cpu/aarch64/acl_convolution_utils.cpp
+@@ -14,23 +14,15 @@
+ * limitations under the License.
+ *******************************************************************************/
+ 
+-#include "oneapi/dnnl/dnnl_types.h"
+-
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/type_helpers.hpp"
+-#include "common/utils.hpp"
+-
+-#include "common/bfloat16.hpp"
+ #include "cpu/aarch64/acl_convolution_utils.hpp"
+ 
+-#include "cpu/platform.hpp"
+-
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+ namespace aarch64 {
+ 
++namespace acl_convolution_utils {
++
+ using namespace dnnl::impl::status;
+ using namespace dnnl::impl::utils;
+ using namespace dnnl::impl::alg_kind;
+@@ -38,8 +30,6 @@ using namespace prop_kind;
+ using namespace data_type;
+ using uint = unsigned int;
+ 
+-namespace acl_convolution_utils {
+-
+ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &weights_md, memory_desc_t &dst_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+@@ -162,14 +152,10 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     const auto acl_layout = is_nspc ? arm_compute::DataLayout::NHWC
+                                     : arm_compute::DataLayout::NCHW;
+ 
+-    auto acl_src_data_t
+-            = acl_convolution_utils::get_acl_data_t(src_d.data_type());
+-    auto acl_wei_data_t
+-            = acl_convolution_utils::get_acl_data_t(wei_d.data_type());
+-    auto acl_dst_data_t
+-            = acl_convolution_utils::get_acl_data_t(dst_d.data_type());
+-    auto acl_bia_data_t
+-            = acl_convolution_utils::get_acl_data_t(bia_d.data_type());
++    auto acl_src_data_t = acl_common_utils::get_acl_data_t(src_d.data_type());
++    auto acl_wei_data_t = acl_common_utils::get_acl_data_t(wei_d.data_type());
++    auto acl_dst_data_t = acl_common_utils::get_acl_data_t(dst_d.data_type());
++    auto acl_bia_data_t = acl_common_utils::get_acl_data_t(bia_d.data_type());
+ 
+     if (acl_bia_data_t == arm_compute::DataType::UNKNOWN)
+         acl_bia_data_t = arm_compute::DataType::F32;
+@@ -221,7 +207,7 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     const auto &post_ops = attr.post_ops_;
+     acp.sum_with_eltwise = (post_ops.len() == 2) && post_ops.entry_[0].is_sum()
+             && post_ops.entry_[1].is_eltwise();
+-    acp.act_info = acl_convolution_utils::get_acl_act(attr);
++    acp.act_info = acl_common_utils::get_acl_act(attr);
+ 
+     return status::success;
+ }
+@@ -236,8 +222,7 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+ 
+     // clang-format off
+     // Validate convolution manually to check for return status
+-    arm_compute::NEGEMMConvolutionLayer acl_gemm_conv;
+-    auto acl_st = acl_gemm_conv.validate(
++    auto acl_st = arm_compute::NEGEMMConvolutionLayer::validate(
+         &acp.src_info,
+         &acp.wei_info,
+         acp.with_bias ? &acp.bia_info : nullptr,
+@@ -316,8 +301,7 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+ 
+     // clang-format off
+     // Validate convolution manually to check for return status
+-    arm_compute::NEWinogradConvolutionLayer acl_wino_conv;
+-    auto acl_st = acl_wino_conv.validate(
++    auto acl_st = arm_compute::NEWinogradConvolutionLayer::validate(
+         &acp.src_info,
+         &acp.wei_info,
+         acp.with_bias ? &acp.bia_info : nullptr,
+@@ -333,69 +317,6 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     return status::success;
+ }
+ 
+-arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt) {
+-    switch (dt) {
+-        case bf16: return arm_compute::DataType::BFLOAT16; break;
+-        case f32: return arm_compute::DataType::F32; break;
+-        case s32: return arm_compute::DataType::S32; break;
+-        case f16: return arm_compute::DataType::F16; break;
+-        case s8: return arm_compute::DataType::QASYMM8_SIGNED; break;
+-        case u8: return arm_compute::DataType::QASYMM8; break;
+-        default: return arm_compute::DataType::UNKNOWN;
+-    }
+-}
+-
+-arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr) {
+-    const auto &post_ops = attr.post_ops_;
+-    const int entry_idx = post_ops.find(primitive_kind::eltwise);
+-    if (entry_idx == -1) { return arm_compute::ActivationLayerInfo(); }
+-
+-    const auto eltwise_alg = post_ops.entry_[entry_idx].eltwise.alg;
+-    float alpha = post_ops.entry_[entry_idx].eltwise.alpha;
+-    float beta = post_ops.entry_[entry_idx].eltwise.beta;
+-
+-    using acl_act_t = arm_compute::ActivationLayerInfo::ActivationFunction;
+-    acl_act_t acl_act_alg;
+-    switch (eltwise_alg) {
+-        case eltwise_relu:
+-            // oneDNN defines RELU: f(x) = (x > 0) ? x : a*x
+-            // Compute Library defines LEAKY_RELU: f(x) = (x > 0) ? x : a*x
+-            // whilst Compute Library RELU is defined as: f(x) = max(0,x)
+-            if (alpha == 0) {
+-                acl_act_alg = acl_act_t::RELU;
+-            } else {
+-                acl_act_alg = acl_act_t::LEAKY_RELU;
+-            }
+-            break;
+-        case eltwise_tanh:
+-            // oneDNN defines TANH activation as:          f(x) = tanh(x)
+-            // Compute Library defines TANH activation as: f(x) = a*tanh(b*x)
+-            // Setting a=b=1 makes the two equivalent
+-            alpha = 1.f;
+-            beta = 1.f;
+-            acl_act_alg = acl_act_t::TANH;
+-            break;
+-        case eltwise_elu: acl_act_alg = acl_act_t::ELU; break;
+-        case eltwise_square: acl_act_alg = acl_act_t::SQUARE; break;
+-        case eltwise_abs: acl_act_alg = acl_act_t::ABS; break;
+-        case eltwise_sqrt: acl_act_alg = acl_act_t::SQRT; break;
+-        case eltwise_linear: acl_act_alg = acl_act_t::LINEAR; break;
+-        case eltwise_bounded_relu: acl_act_alg = acl_act_t::BOUNDED_RELU; break;
+-        case eltwise_soft_relu: acl_act_alg = acl_act_t::SOFT_RELU; break;
+-        case eltwise_logistic: acl_act_alg = acl_act_t::LOGISTIC; break;
+-        default: return arm_compute::ActivationLayerInfo();
+-    }
+-
+-    return arm_compute::ActivationLayerInfo(acl_act_alg, alpha, beta);
+-}
+-
+-bool acl_act_ok(alg_kind_t eltwise_activation) {
+-    return utils::one_of(eltwise_activation, eltwise_relu, eltwise_tanh,
+-            eltwise_elu, eltwise_square, eltwise_abs, eltwise_sqrt,
+-            eltwise_linear, eltwise_bounded_relu, eltwise_soft_relu,
+-            eltwise_logistic);
+-}
+-
+ } // namespace acl_convolution_utils
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/aarch64/acl_convolution_utils.hpp b/src/cpu/aarch64/acl_convolution_utils.hpp
+index 9d5273a6b..9b2f486d5 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.hpp
++++ b/src/cpu/aarch64/acl_convolution_utils.hpp
+@@ -17,14 +17,9 @@
+ #ifndef CPU_AARCH64_ACL_CONVOLUTION_UTILS_HPP
+ #define CPU_AARCH64_ACL_CONVOLUTION_UTILS_HPP
+ 
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/memory_tracking.hpp"
+-
+ #include "cpu/cpu_convolution_pd.hpp"
+-#include "cpu/cpu_engine.hpp"
+ 
+-#include "arm_compute/runtime/NEON/NEFunctions.h"
++#include "cpu/aarch64/acl_utils.hpp"
+ 
+ namespace dnnl {
+ namespace impl {
+@@ -74,12 +69,49 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+         const primitive_attr_t &attr);
+ 
+-arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt);
+-arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
+-bool acl_act_ok(alg_kind_t eltwise_activation);
+-
+ } // namespace acl_convolution_utils
+ 
++template <typename conv_obj_t, typename conv_pd_t, typename src_data_t,
++        typename wei_data_t = src_data_t, typename dst_data_t = src_data_t,
++        typename bia_data_t = src_data_t>
++status_t execute_forward_conv_acl(
++        const exec_ctx_t &ctx, conv_obj_t &acl_conv_obj, const conv_pd_t *pd) {
++    bool with_bias = pd->acp_.with_bias;
++    bool sum_with_eltwise = pd->acp_.sum_with_eltwise;
++
++    auto src_base = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
++    auto wei_base = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
++    auto dst_base = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
++
++    // import_memory() and free() methods do not allocate/free any additional
++    // memory, only acquire/release pointers.
++    acl_conv_obj.src_tensor.allocator()->import_memory(
++            const_cast<src_data_t *>(src_base));
++    acl_conv_obj.wei_tensor.allocator()->import_memory(
++            const_cast<wei_data_t *>(wei_base));
++    acl_conv_obj.dst_tensor.allocator()->import_memory(dst_base);
++
++    if (with_bias) {
++        auto bia_base = CTX_IN_MEM(const bia_data_t *, DNNL_ARG_BIAS);
++        acl_conv_obj.bia_tensor.allocator()->import_memory(
++                const_cast<bia_data_t *>(bia_base));
++    }
++
++    acl_conv_obj.conv.run();
++
++    if (sum_with_eltwise) {
++        acl_conv_obj.add.run();
++        acl_conv_obj.act.run();
++    }
++
++    acl_conv_obj.src_tensor.allocator()->free();
++    acl_conv_obj.wei_tensor.allocator()->free();
++    acl_conv_obj.dst_tensor.allocator()->free();
++    if (with_bias) { acl_conv_obj.bia_tensor.allocator()->free(); }
++
++    return status::success;
++}
++
+ } // namespace aarch64
+ } // namespace cpu
+ } // namespace impl
+diff --git a/src/cpu/aarch64/acl_eltwise.cpp b/src/cpu/aarch64/acl_eltwise.cpp
+new file mode 100644
+index 000000000..4e187a966
+--- /dev/null
++++ b/src/cpu/aarch64/acl_eltwise.cpp
+@@ -0,0 +1,64 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_eltwise.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++using namespace dnnl::impl::status;
++using namespace dnnl::impl::memory_tracking::names;
++using namespace dnnl::impl::utils;
++
++template <data_type_t data_type>
++status_t acl_eltwise_fwd_t<data_type>::execute_forward(
++        const exec_ctx_t &ctx) const {
++    // Lock here is needed because resource_mapper does not support
++    // concurrent access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
++
++    status_t status = status::success;
++    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
++    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
++
++    // Retrieve primitive resource and configured Compute Library objects
++    auto *acl_resource
++            = ctx.get_resource_mapper()->get<acl_eltwise_resource_t>(this);
++    acl_eltwise_obj_t &acl_obj = acl_resource->get_acl_obj();
++
++    // import_memory() and free() methods do not allocate/free any additional
++    // memory, only acquire/release pointers.
++    acl_obj.src_tensor.allocator()->import_memory(
++            const_cast<data_t *>(src_base));
++    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
++
++    acl_obj.act.run();
++
++    acl_obj.src_tensor.allocator()->free();
++    acl_obj.dst_tensor.allocator()->free();
++
++    return status;
++}
++
++template struct acl_eltwise_fwd_t<data_type::f32>;
++template struct acl_eltwise_fwd_t<data_type::s8>;
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_eltwise.hpp b/src/cpu/aarch64/acl_eltwise.hpp
+new file mode 100644
+index 000000000..daa6fa8f1
+--- /dev/null
++++ b/src/cpu/aarch64/acl_eltwise.hpp
+@@ -0,0 +1,125 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_ELTWISE_HPP
++#define CPU_AARCH64_ACL_ELTWISE_HPP
++
++#include "cpu/cpu_eltwise_pd.hpp"
++
++#include "cpu/aarch64/acl_eltwise_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_eltwise_resource_t : public resource_t {
++    acl_eltwise_resource_t()
++        : acl_eltwise_obj_(utils::make_unique<acl_eltwise_obj_t>()) {}
++
++    status_t configure(const acl_eltwise_conf_t &aep) {
++        if (!acl_eltwise_obj_) return status::out_of_memory;
++
++        // Init Compute Library tensors based on info from descriptor
++        acl_eltwise_obj_->src_tensor.allocator()->init(aep.src_info);
++        acl_eltwise_obj_->dst_tensor.allocator()->init(aep.dst_info);
++
++        // clang-format off
++        acl_eltwise_obj_->act.configure(
++            &acl_eltwise_obj_->src_tensor,
++            &acl_eltwise_obj_->dst_tensor,
++            aep.act_info);
++        // clang-format on
++
++        return status::success;
++    }
++
++    acl_eltwise_obj_t &get_acl_obj() const { return *acl_eltwise_obj_; }
++
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_eltwise_resource_t);
++
++private:
++    std::unique_ptr<acl_eltwise_obj_t> acl_eltwise_obj_;
++}; // acl_eltwise_resource_t
++
++template <data_type_t data_type>
++struct acl_eltwise_fwd_t : public primitive_t {
++    struct pd_t : public cpu_eltwise_fwd_pd_t {
++        using cpu_eltwise_fwd_pd_t::cpu_eltwise_fwd_pd_t;
++        pd_t(const eltwise_desc_t *adesc, const primitive_attr_t *attr,
++                const eltwise_fwd_pd_t *hint_fwd_pd)
++            : cpu_eltwise_fwd_pd_t(adesc, attr, hint_fwd_pd), aep_() {}
++
++        DECLARE_COMMON_PD_T("eltwise:acl", acl_eltwise_fwd_t);
++
++        status_t init(engine_t *engine) {
++            using namespace utils;
++            using sm = primitive_attr_t::skip_mask_t;
++            const auto &po = attr()->post_ops_;
++
++            bool ok = is_fwd() && data_type == desc()->data_desc.data_type
++                    && !has_zero_dim_memory()
++                    && attr()->has_default_values(sm::post_ops)
++                    && po.len() == 0;
++            if (!ok) return status::unimplemented;
++
++            auto conf_status = acl_eltwise_utils::init_conf_eltwise(
++                    aep_, data_md_, *desc(), *attr());
++            if (conf_status != status::success) return status::unimplemented;
++
++            acl_common_utils::acl_thread_bind();
++
++            return status::success;
++        }
++
++        acl_eltwise_conf_t aep_;
++    };
++
++    acl_eltwise_fwd_t(const pd_t *apd) : primitive_t(apd) {}
++
++    using data_t = typename prec_traits<data_type>::type;
++
++    status_t execute(const exec_ctx_t &ctx) const override {
++        return execute_forward(ctx);
++    }
++
++    status_t create_resource(
++            engine_t *engine, resource_mapper_t &mapper) const override {
++        if (mapper.has_resource(this)) return status::success;
++
++        auto r = utils::make_unique<acl_eltwise_resource_t>();
++        if (!r) return status::out_of_memory;
++
++        // Configure the resource based on information from primitive descriptor
++        auto st = r->configure(pd()->aep_);
++        if (st == status::success) { mapper.add(this, std::move(r)); }
++
++        return st;
++    }
++
++private:
++    // execute_forward has to be const thus mutability of mtx
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++}; // acl_eltwise_fwd_t
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_ELTWISE_HPP
+diff --git a/src/cpu/aarch64/acl_eltwise_utils.cpp b/src/cpu/aarch64/acl_eltwise_utils.cpp
+new file mode 100644
+index 000000000..35e809e04
+--- /dev/null
++++ b/src/cpu/aarch64/acl_eltwise_utils.cpp
+@@ -0,0 +1,125 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_eltwise_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++using namespace dnnl::impl::status;
++using namespace dnnl::impl::utils;
++using namespace dnnl::impl::alg_kind;
++using namespace prop_kind;
++using namespace data_type;
++using uint = unsigned int;
++
++namespace acl_eltwise_utils {
++
++status_t acl_eltwise_check(acl_eltwise_conf_t &aep, memory_desc_t &data_md,
++        const eltwise_desc_t &ed, const primitive_attr_t &attr) {
++
++    const memory_desc_wrapper data_d(&data_md);
++
++    const int ndims = data_d.ndims();
++    const bool is_1d = ndims == 3;
++    const bool is_3d = ndims == 5;
++    const bool is_int8 = one_of(ed.data_desc.data_type, s8, u8);
++    bool is_nspc {true};
++
++    // Compute Library unsupported shape scenarios
++    if (one_of(true, is_3d, is_1d)) { return status::unimplemented; }
++
++    const alg_kind_t eltwise_alg = ed.alg_kind;
++
++    bool activation_supported = acl_common_utils::acl_act_ok(eltwise_alg);
++    if (!activation_supported) { return status::unimplemented; }
++
++    // batch size
++    const int mb = data_d.dims()[0];
++
++    // src/dst channels, height, width
++    const int ic = data_d.dims()[1];
++    const int ih = data_d.dims()[ndims - 2];
++    const int iw = data_d.dims()[ndims - 1];
++
++    const int oc = ic;
++    const int oh = ih;
++    const int ow = iw;
++
++    auto data_tag = memory_desc_matches_one_of_tag(
++            data_md, format_tag::nhwc, format_tag::nchw);
++    if (data_tag == format_tag::undef) { return status::unimplemented; }
++
++    is_nspc = utils::one_of(data_tag, format_tag::nhwc);
++    const auto acl_layout = is_nspc ? arm_compute::DataLayout::NHWC
++                                    : arm_compute::DataLayout::NCHW;
++
++    auto acl_src_data_t = acl_common_utils::get_acl_data_t(data_d.data_type());
++    auto acl_dst_data_t = acl_common_utils::get_acl_data_t(data_d.data_type());
++
++    // clang-format off
++    aep.src_info = arm_compute::TensorInfo(
++            is_nspc ? arm_compute::TensorShape(ic, iw, ih, mb) :
++            arm_compute::TensorShape(iw, ih, ic, mb),
++            1,
++            acl_src_data_t,
++            acl_layout);
++
++    aep.dst_info = arm_compute::TensorInfo(
++            is_nspc ? arm_compute::TensorShape(oc, ow, oh, mb) :
++            arm_compute::TensorShape(ow, oh, oc, mb),
++            1,
++            acl_dst_data_t,
++            acl_layout);
++    // clang-format on
++
++    if (is_int8) {
++        aep.src_info.set_quantization_info(arm_compute::QuantizationInfo(1, 0));
++        aep.dst_info.set_quantization_info(arm_compute::QuantizationInfo(1, 0));
++    }
++
++    aep.act_info = acl_common_utils::get_acl_act(ed);
++
++    return status::success;
++}
++
++status_t init_conf_eltwise(acl_eltwise_conf_t &aep, memory_desc_t &data_md,
++        const eltwise_desc_t &ed, const primitive_attr_t &attr) {
++
++    // General Compute Library checks
++    CHECK(acl_eltwise_check(aep, data_md, ed, attr));
++
++    // clang-format off
++    auto acl_st = arm_compute::NEActivationLayer::validate(
++        &aep.src_info,
++        &aep.dst_info,
++        aep.act_info);
++    // clang-format on
++    if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        return status::unimplemented;
++    }
++
++    return status::success;
++}
++
++} // namespace acl_eltwise_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_eltwise_utils.hpp b/src/cpu/aarch64/acl_eltwise_utils.hpp
+new file mode 100644
+index 000000000..84be9b2d7
+--- /dev/null
++++ b/src/cpu/aarch64/acl_eltwise_utils.hpp
+@@ -0,0 +1,53 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_ELTWISE_UTILS_HPP
++#define CPU_AARCH64_ACL_ELTWISE_UTILS_HPP
++
++#include "cpu/cpu_convolution_pd.hpp"
++
++#include "cpu/aarch64/acl_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_eltwise_obj_t {
++    arm_compute::NEActivationLayer act;
++    arm_compute::Tensor src_tensor;
++    arm_compute::Tensor dst_tensor;
++};
++
++struct acl_eltwise_conf_t {
++    arm_compute::ActivationLayerInfo act_info;
++    arm_compute::TensorInfo src_info;
++    arm_compute::TensorInfo dst_info;
++};
++
++namespace acl_eltwise_utils {
++
++status_t init_conf_eltwise(acl_eltwise_conf_t &aep, memory_desc_t &data_md,
++        const eltwise_desc_t &ed, const primitive_attr_t &attr);
++
++} // namespace acl_eltwise_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_ELTWISE_UTILS_HPP
+diff --git a/src/cpu/aarch64/acl_gemm_convolution.cpp b/src/cpu/aarch64/acl_gemm_convolution.cpp
+index 82158e21d..e4b92a126 100644
+--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
++++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
+@@ -14,72 +14,30 @@
+ * limitations under the License.
+ *******************************************************************************/
+ 
+-#include "oneapi/dnnl/dnnl_types.h"
+-
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/type_helpers.hpp"
+-#include "common/utils.hpp"
+ #include "cpu/aarch64/acl_gemm_convolution.hpp"
+ 
+-#include <cstring>
+-
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+ namespace aarch64 {
+ 
+-using namespace dnnl::impl::status;
+-using namespace dnnl::impl::memory_tracking::names;
+-using namespace dnnl::impl::utils;
+-
++// src_type is enum and is mapped to src_data_t via
++// prec_traits<src_type>::type src_data_t
+ template <data_type_t src_type, data_type_t wei_type, data_type_t dst_type,
+         data_type_t bia_type>
+ status_t acl_gemm_convolution_fwd_t<src_type, wei_type, dst_type,
+         bia_type>::execute_forward(const exec_ctx_t &ctx) const {
+-    status_t status = status::success;
+-    auto src_base = CTX_IN_MEM(const src_data_t *, DNNL_ARG_SRC);
+-    auto wei_base = CTX_IN_MEM(const wei_data_t *, DNNL_ARG_WEIGHTS);
+-    auto bia_base = CTX_IN_MEM(const bia_data_t *, DNNL_ARG_BIAS);
+-    auto dst_base = CTX_OUT_MEM(dst_data_t *, DNNL_ARG_DST);
+-
+-    bool with_bias = pd()->acp_.with_bias;
+-    bool sum_with_eltwise = pd()->acp_.sum_with_eltwise;
+-
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
+     // Retrieve primitive resource and configured Compute Library objects
+     auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
+     acl_obj_t<arm_compute::NEGEMMConvolutionLayer> &acl_obj
+             = acl_resource->get_acl_obj();
+ 
+-    acl_obj.src_tensor.allocator()->import_memory(
+-            const_cast<src_data_t *>(src_base));
+-    acl_obj.wei_tensor.allocator()->import_memory(
+-            const_cast<wei_data_t *>(wei_base));
+-    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+-
+-    // Retrieve extra bias memory from the scratchpad and copy from user memory
+-    if (with_bias) {
+-        const auto scratchpad = ctx.get_scratchpad_grantor();
+-        auto *bia_memory = scratchpad.template get<bia_data_t>(
+-                memory_tracking::names::key_none);
+-        size_t oc = acl_obj.bia_tensor.info()->tensor_shape()[0];
+-        std::memcpy(bia_memory, bia_base, oc * sizeof(bia_data_t));
+-        acl_obj.bia_tensor.allocator()->import_memory(bia_memory);
+-    }
+-
+-    acl_obj.conv.run();
+-
+-    if (sum_with_eltwise) {
+-        acl_obj.add.run();
+-        acl_obj.act.run();
+-    }
+-
+-    acl_obj.src_tensor.allocator()->free();
+-    acl_obj.wei_tensor.allocator()->free();
+-    acl_obj.dst_tensor.allocator()->free();
+-    if (with_bias) { acl_obj.bia_tensor.allocator()->free(); }
+-
+-    return status;
++    return execute_forward_conv_acl<
++            acl_obj_t<arm_compute::NEGEMMConvolutionLayer>, pd_t, src_data_t,
++            wei_data_t, dst_data_t, bia_data_t>(ctx, acl_obj, pd());
+ }
+ 
+ using namespace data_type;
+diff --git a/src/cpu/aarch64/acl_gemm_convolution.hpp b/src/cpu/aarch64/acl_gemm_convolution.hpp
+index 15f8ab06b..5ac3ffde9 100644
+--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
++++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
+@@ -17,17 +17,9 @@
+ #ifndef CPU_AARCH64_ACL_GEMM_CONVOLUTION_HPP
+ #define CPU_AARCH64_ACL_GEMM_CONVOLUTION_HPP
+ 
+-#include "common/c_types_map.hpp"
+-#include "common/memory_tracking.hpp"
+-#include "common/primitive.hpp"
+-
+-#include "cpu/aarch64/acl_convolution_utils.hpp"
+-#include "cpu/gemm/gemm.hpp"
+-
+ #include "cpu/cpu_convolution_pd.hpp"
+ 
+-#include "arm_compute/runtime/NEON/NEFunctions.h"
+-#include "arm_compute/runtime/Scheduler.h"
++#include "cpu/aarch64/acl_convolution_utils.hpp"
+ 
+ namespace dnnl {
+ namespace impl {
+@@ -115,13 +107,7 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+                     src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr());
+             if (conf_status != status::success) return status::unimplemented;
+ 
+-            // Number of threads in Compute Library is set by OMP_NUM_THREADS
+-            // dnnl_get_max_threads() == OMP_NUM_THREADS
+-
+-            arm_compute::IScheduler::BindFunc linear
+-                    = [](int i, int max_cores) { return i % max_cores; };
+-            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+-                    dnnl_get_max_threads(), linear);
++            acl_common_utils::acl_thread_bind();
+ 
+             // TODO: remove dependence on scratchpad memory
+             // Using user provided memory for the biases currently segfaults
+@@ -154,6 +140,8 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+         }
+ 
+         bool post_ops_ok() const {
++            using namespace data_type;
++            using namespace alg_kind;
+             auto const &po = attr()->post_ops_;
+             auto is_eltwise
+                     = [&](int idx) { return po.entry_[idx].is_eltwise(); };
+@@ -167,7 +155,7 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+             // sum+eltwise post-ops
+             if (eltwise_only || sum_with_eltwise) {
+                 const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
+-                eltwise_ok = acl_convolution_utils::acl_act_ok(act_type);
++                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
+             }
+ 
+             return eltwise_ok || (po.len() == 0);
+@@ -200,6 +188,8 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+     }
+ 
+ private:
++    // To guard the const execute_forward(), the mutex must be 'mutable'
++    mutable std::mutex mtx;
+     status_t execute_forward(const exec_ctx_t &ctx) const;
+     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+ 
+diff --git a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+index c975c516b..204192c45 100644
+--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
++++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.cpp
+@@ -23,14 +23,9 @@ namespace aarch64 {
+ 
+ status_t acl_indirect_gemm_convolution_fwd_t::execute_forward(
+         const exec_ctx_t &ctx) const {
+-    status_t status = status::success;
+-    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+-    auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+-    auto bia_base = CTX_IN_MEM(const data_t *, DNNL_ARG_BIAS);
+-    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+-
+-    bool with_bias = pd()->acp_.with_bias;
+-
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
+     // Retrieve primitive resource and configured Compute Library objects
+     auto *acl_resource
+             = ctx.get_resource_mapper()->get<acl_indirect_gemm_resource_t>(
+@@ -38,30 +33,8 @@ status_t acl_indirect_gemm_convolution_fwd_t::execute_forward(
+     acl_obj_t<arm_compute::NEGEMMConv2d> &acl_indirect_gemm_obj
+             = acl_resource->get_acl_obj();
+ 
+-    acl_indirect_gemm_obj.src_tensor.allocator()->import_memory(
+-            const_cast<data_t *>(src_base));
+-    acl_indirect_gemm_obj.wei_tensor.allocator()->import_memory(
+-            const_cast<data_t *>(wei_base));
+-    acl_indirect_gemm_obj.dst_tensor.allocator()->import_memory(dst_base);
+-
+-    // Retrieve extra bias memory from the scratchpad and copy from user memory
+-    if (with_bias) {
+-        const auto scratchpad = ctx.get_scratchpad_grantor();
+-        data_t *bia_memory = scratchpad.template get<data_t>(
+-                memory_tracking::names::key_none);
+-        size_t oc = acl_indirect_gemm_obj.bia_tensor.info()->tensor_shape()[0];
+-        std::memcpy(bia_memory, bia_base, oc * sizeof(data_t));
+-        acl_indirect_gemm_obj.bia_tensor.allocator()->import_memory(bia_memory);
+-    }
+-
+-    acl_indirect_gemm_obj.conv.run();
+-
+-    acl_indirect_gemm_obj.src_tensor.allocator()->free();
+-    acl_indirect_gemm_obj.wei_tensor.allocator()->free();
+-    acl_indirect_gemm_obj.dst_tensor.allocator()->free();
+-    if (with_bias) { acl_indirect_gemm_obj.bia_tensor.allocator()->free(); }
+-
+-    return status;
++    return execute_forward_conv_acl<acl_obj_t<arm_compute::NEGEMMConv2d>, pd_t,
++            data_t>(ctx, acl_indirect_gemm_obj, pd());
+ }
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+index c038770f8..f338623dd 100644
+--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
++++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+@@ -17,16 +17,9 @@
+ #ifndef CPU_AARCH64_ACL_INDIRECT_GEMM_CONVOLUTION_HPP
+ #define CPU_AARCH64_ACL_INDIRECT_GEMM_CONVOLUTION_HPP
+ 
+-#include "common/primitive.hpp"
+-#include "common/utils.hpp"
+-
+-#include "cpu/aarch64/acl_convolution_utils.hpp"
+-
+ #include "cpu/cpu_convolution_pd.hpp"
+ 
+-#include "arm_compute/runtime/FunctionDescriptors.h"
+-#include "arm_compute/runtime/NEON/NEFunctions.h"
+-#include "arm_compute/runtime/Scheduler.h"
++#include "cpu/aarch64/acl_convolution_utils.hpp"
+ 
+ namespace dnnl {
+ namespace impl {
+@@ -34,7 +27,6 @@ namespace cpu {
+ namespace aarch64 {
+ 
+ struct acl_indirect_gemm_resource_t : public resource_t {
+-
+     acl_indirect_gemm_resource_t()
+         : acl_obj_(utils::make_unique<acl_obj_t<arm_compute::NEGEMMConv2d>>()) {
+     }
+@@ -47,19 +39,32 @@ struct acl_indirect_gemm_resource_t : public resource_t {
+         acl_obj_->wei_tensor.allocator()->init(acp.wei_info);
+         acl_obj_->dst_tensor.allocator()->init(acp.dst_info);
+         acl_obj_->bia_tensor.allocator()->init(acp.bia_info);
+-
++        if (acp.sum_with_eltwise) {
++            acl_obj_->dst_acc_tensor.allocator()->init(acp.dst_info);
++        }
+         // clang-format off
+         acl_obj_->conv.configure(
+             &acl_obj_->src_tensor,
+             &acl_obj_->wei_tensor,
+             acp.with_bias ? &acl_obj_->bia_tensor : nullptr,
+-            &acl_obj_->dst_tensor,
++            acp.sum_with_eltwise ? &acl_obj_->dst_acc_tensor
++                                 : &acl_obj_->dst_tensor,
+             arm_compute::Conv2dInfo(acp.padstride_info,
+                                     acp.dilation_info,
+-                                    acp.act_info,
++                                    acp.sum_with_eltwise
++                                        ? arm_compute::ActivationLayerInfo()
++                                        : acp.act_info,
+                                     false,
+                                     1));
+         // clang-format on
++        if (acp.sum_with_eltwise) {
++            acl_obj_->add.configure(&acl_obj_->dst_tensor,
++                    &acl_obj_->dst_acc_tensor, &acl_obj_->dst_acc_tensor,
++                    arm_compute::ConvertPolicy::SATURATE);
++            acl_obj_->act.configure(&acl_obj_->dst_acc_tensor,
++                    &acl_obj_->dst_tensor, acp.act_info);
++            acl_obj_->dst_acc_tensor.allocator()->allocate();
++        }
+ 
+         return status::success;
+     }
+@@ -104,13 +109,7 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
+                     *attr());
+             if (conf_status != status::success) return status::unimplemented;
+ 
+-            // Number of threads in Compute Library is set by OMP_NUM_THREADS
+-            // dnnl_get_max_threads() == OMP_NUM_THREADS
+-
+-            arm_compute::IScheduler::BindFunc linear
+-                    = [](int i, int max_cores) { return i % max_cores; };
+-            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+-                    dnnl_get_max_threads(), linear);
++            acl_common_utils::acl_thread_bind();
+ 
+             // TODO: remove dependence on scratchpad memory
+             // Using user provided memory for the biases currently segfaults
+@@ -133,12 +132,17 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
+             auto const &po = attr()->post_ops_;
+             auto is_eltwise
+                     = [&](int idx) { return po.entry_[idx].is_eltwise(); };
++            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
+ 
++            bool sum_with_eltwise
++                    = (po.len() == 2) && is_sum(0) && is_eltwise(1);
++            bool eltwise_only = (po.len() == 1) ? is_eltwise(0) : false;
+             bool eltwise_ok = false;
+-            // Compute Library supports only one eltwise post-op
+-            if (po.len() == 1 && is_eltwise(0)) {
+-                const auto act_type = po.entry_[0].eltwise.alg;
+-                eltwise_ok = acl_convolution_utils::acl_act_ok(act_type);
++            // Compute Library supports only one eltwise post-op or
++            // sum+eltwise post-ops
++            if (eltwise_only || sum_with_eltwise) {
++                const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
++                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
+             }
+ 
+             return eltwise_ok || (po.len() == 0);
+@@ -168,6 +172,8 @@ struct acl_indirect_gemm_convolution_fwd_t : public primitive_t {
+     }
+ 
+ private:
++    // To guard the const execute_forward(), the mutex must be 'mutable'
++    mutable std::mutex mtx;
+     status_t execute_forward(const exec_ctx_t &ctx) const;
+     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+ };
+diff --git a/src/cpu/aarch64/acl_inner_product.cpp b/src/cpu/aarch64/acl_inner_product.cpp
+new file mode 100644
+index 000000000..7a316135f
+--- /dev/null
++++ b/src/cpu/aarch64/acl_inner_product.cpp
+@@ -0,0 +1,73 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_inner_product.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++using namespace dnnl::impl::status;
++using namespace dnnl::impl::memory_tracking::names;
++using namespace dnnl::impl::utils;
++
++status_t acl_inner_product_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
++
++    status_t status = status::success;
++    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
++    auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
++    auto bia_base = CTX_IN_MEM(const data_t *, DNNL_ARG_BIAS);
++    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
++
++    bool with_bias = pd()->aip_.with_bias;
++    bool with_sum = pd()->aip_.with_sum;
++
++    // Retrieve primitive resource and configured Compute Library objects
++    auto *acl_resource
++            = ctx.get_resource_mapper()->get<acl_ip_resource_t>(this);
++    acl_ip_obj_t &acl_obj = acl_resource->get_acl_obj();
++
++    // import_memory() and free() methods do not allocate/free any additional
++    // memory, only acquire/release pointers.
++    acl_obj.src_tensor.allocator()->import_memory(
++            const_cast<data_t *>(src_base));
++    acl_obj.wei_tensor.allocator()->import_memory(
++            const_cast<data_t *>(wei_base));
++    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
++    if (with_bias) {
++        acl_obj.bia_tensor.allocator()->import_memory(
++                const_cast<data_t *>(bia_base));
++    }
++
++    acl_obj.fc.run();
++    if (with_sum) { acl_obj.add.run(); }
++
++    acl_obj.src_tensor.allocator()->free();
++    acl_obj.wei_tensor.allocator()->free();
++    acl_obj.dst_tensor.allocator()->free();
++    if (with_bias) { acl_obj.bia_tensor.allocator()->free(); }
++
++    return status;
++}
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_inner_product.hpp b/src/cpu/aarch64/acl_inner_product.hpp
+new file mode 100644
+index 000000000..1544ba58a
+--- /dev/null
++++ b/src/cpu/aarch64/acl_inner_product.hpp
+@@ -0,0 +1,155 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_INNER_PRODUCT_HPP
++#define CPU_AARCH64_ACL_INNER_PRODUCT_HPP
++
++#include "cpu/cpu_inner_product_pd.hpp"
++
++#include "cpu/aarch64/acl_inner_product_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_ip_resource_t : public resource_t {
++    acl_ip_resource_t() : acl_ip_obj_(utils::make_unique<acl_ip_obj_t>()) {}
++
++    status_t configure(const acl_ip_conf_t &aip) {
++        if (!acl_ip_obj_) return status::out_of_memory;
++
++        // Init Compute Library tensors based on info from descriptor
++        acl_ip_obj_->src_tensor.allocator()->init(aip.src_info);
++        acl_ip_obj_->wei_tensor.allocator()->init(aip.wei_info);
++        acl_ip_obj_->dst_tensor.allocator()->init(aip.dst_info);
++        acl_ip_obj_->bia_tensor.allocator()->init(aip.bia_info);
++        if (aip.with_sum) {
++            acl_ip_obj_->dst_acc_tensor.allocator()->init(aip.dst_info);
++        }
++
++        // clang-format off
++        acl_ip_obj_->fc.configure(
++            &acl_ip_obj_->src_tensor,
++            &acl_ip_obj_->wei_tensor,
++            aip.with_bias ? &acl_ip_obj_->bia_tensor : nullptr,
++            aip.with_sum ? &acl_ip_obj_->dst_acc_tensor : &acl_ip_obj_->dst_tensor,
++            aip.fc_info);
++        // clang-format on
++        if (aip.with_sum) {
++            acl_ip_obj_->add.configure(&acl_ip_obj_->dst_tensor,
++                    &acl_ip_obj_->dst_acc_tensor, &acl_ip_obj_->dst_tensor,
++                    arm_compute::ConvertPolicy::SATURATE);
++            acl_ip_obj_->dst_acc_tensor.allocator()->allocate();
++        }
++
++        return status::success;
++    }
++
++    acl_ip_obj_t &get_acl_obj() const { return *acl_ip_obj_; }
++
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_ip_resource_t);
++
++private:
++    std::unique_ptr<acl_ip_obj_t> acl_ip_obj_;
++}; // acl_ip_resource_t
++
++struct acl_inner_product_fwd_t : public primitive_t {
++    struct pd_t : public cpu_inner_product_fwd_pd_t {
++        using cpu_inner_product_fwd_pd_t::cpu_inner_product_fwd_pd_t;
++
++        DECLARE_COMMON_PD_T("inner_product:acl", acl_inner_product_fwd_t);
++
++        status_t init(engine_t *engine) {
++            using namespace utils;
++
++            const bool ok = is_fwd() && !has_zero_dim_memory()
++                    && expect_data_types(data_type::f32, data_type::f32,
++                            data_type::f32, data_type::f32, data_type::f32)
++                    && attr()->has_default_values(
++                            primitive_attr_t::skip_mask_t::post_ops,
++                            data_type::f32)
++                    && (set_default_params() == status::success)
++                    && post_ops_ok();
++
++            if (!ok) return status::unimplemented;
++
++            auto conf_status = acl_inner_product_utils::init_conf_ip(aip_,
++                    src_md_, weights_md_, dst_md_, bias_md_, *desc(), *attr());
++
++            if (conf_status != status::success) return status::unimplemented;
++
++            acl_common_utils::acl_thread_bind();
++
++            return status::success;
++        }
++
++        acl_ip_conf_t aip_;
++
++    protected:
++        bool post_ops_ok() const {
++            auto const &po = attr()->post_ops_;
++            auto is_eltwise
++                    = [&](int idx) { return po.entry_[idx].is_eltwise(); };
++            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
++
++            bool eltwise_ok = false;
++            // Compute Library supports here only one eltwise post-op or sum
++            if (po.len() == 1 && is_eltwise(0)) {
++                const auto act_type = po.entry_[0].eltwise.alg;
++                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
++            }
++
++            return eltwise_ok || (po.len() == 1 && is_sum(0))
++                    || (po.len() == 0);
++        }
++    }; // pd_t
++
++    acl_inner_product_fwd_t(const pd_t *apd) : primitive_t(apd) {}
++
++    status_t create_resource(
++            engine_t *engine, resource_mapper_t &mapper) const override {
++        if (mapper.has_resource(this)) return status::success;
++
++        auto r = utils::make_unique<acl_ip_resource_t>();
++        if (!r) return status::out_of_memory;
++
++        // Configure the resource based on information from primitive descriptor
++        auto st = r->configure(pd()->aip_);
++        if (st == status::success) { mapper.add(this, std::move(r)); }
++
++        return st;
++    }
++
++    using data_t = typename prec_traits<data_type::f32>::type;
++
++    status_t execute(const exec_ctx_t &ctx) const override {
++        return execute_forward(ctx);
++    }
++
++private:
++    //To guard the const execute_forward, the mutex must be 'mutable'
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++}; // acl_inner_product_fwd_t
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_INNER_PRODUCT_HPP
+diff --git a/src/cpu/aarch64/acl_inner_product_utils.cpp b/src/cpu/aarch64/acl_inner_product_utils.cpp
+new file mode 100644
+index 000000000..8a8d1cc93
+--- /dev/null
++++ b/src/cpu/aarch64/acl_inner_product_utils.cpp
+@@ -0,0 +1,158 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_inner_product_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++namespace acl_inner_product_utils {
++
++using namespace format_tag;
++using namespace utils;
++using namespace status;
++
++status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
++        memory_desc_t &wei_md, memory_desc_t &dst_md, memory_desc_t &bias_md,
++        const inner_product_desc_t &ipd, const primitive_attr_t &attr) {
++    const memory_desc_wrapper src_d(&src_md);
++    const memory_desc_wrapper wei_d(&wei_md);
++    const memory_desc_wrapper dst_d(&dst_md);
++    const memory_desc_wrapper bia_d(&bias_md);
++
++    // Compute Library currently supports forward propagation only
++    const prop_kind_t prop_kind = ipd.prop_kind;
++    const bool is_fwd = (prop_kind == dnnl_forward_training)
++            || (prop_kind == dnnl_forward_inference);
++    if (!is_fwd) return status::unimplemented;
++
++    const int with_groups = wei_d.ndims() == src_d.ndims() + 1;
++    const int ndims = src_d.ndims();
++
++    // There are two sub-cases: src & wei tensors are either 2- or 4-dimensional
++    const bool is_2d = (ndims == 2) && (wei_d.ndims() == 2);
++    const bool is_4d = (ndims == 4) && (wei_d.ndims() == 4);
++
++    // Compute Library unsupported shape scenarios
++    // FP32 only is supported at the moment
++    if (one_of(true, !(is_4d || is_2d), with_groups)) { return unimplemented; }
++
++    // batch size
++    const int mb = src_d.dims()[0];
++
++    // src/input channels, height, width
++    const int ic = src_d.dims()[1];
++    const int ih = is_4d ? src_d.dims()[ndims - 2] : 0;
++    const int iw = is_4d ? src_d.dims()[ndims - 1] : 0;
++
++    // dst/output channels
++    const int oc = dst_d.dims()[1];
++
++    // weights height, width
++    const int kh = is_4d ? wei_d.dims()[with_groups + ndims - 2] : 0;
++    const int kw = is_4d ? wei_d.dims()[with_groups + ndims - 1] : 0;
++
++    aip.with_bias = ipd.bias_desc.format_kind != format_kind::undef;
++
++    // Data layout is already defined thus should only be checked
++    auto src_tag = memory_desc_matches_one_of_tag(src_md, nhwc, nchw, nc, cn);
++    auto wei_tag = memory_desc_matches_one_of_tag(wei_md, ohwi, oihw, oi, io);
++    auto dst_tag = memory_desc_matches_one_of_tag(dst_md, nc, cn);
++    if (one_of(format_tag::undef, src_tag, wei_tag, dst_tag)) {
++        return status::unimplemented;
++    }
++
++    arm_compute::TensorShape src_shape {(src_tag == nc)
++                    ? arm_compute::TensorShape(ic, mb)
++                    : arm_compute::TensorShape(mb, ic)};
++    if (is_4d) {
++        src_shape = (src_tag == nhwc)
++                ? arm_compute::TensorShape(ic, iw, ih, mb)
++                : arm_compute::TensorShape(iw, ih, ic, mb);
++    }
++
++    // Compute Library requires the weights to be 2-dimensional for FC layer
++    arm_compute::TensorShape wei_shape {
++            arm_compute::TensorShape(is_4d ? ic * kh * kw : ic, oc)};
++    if (is_2d && wei_tag == io) {
++        wei_shape = arm_compute::TensorShape(oc, ic);
++    }
++
++    arm_compute::DataLayout wei_layout {(wei_tag == ohwi || wei_tag == oi)
++                    ? arm_compute::DataLayout::NHWC
++                    : arm_compute::DataLayout::NCHW};
++
++    // clang-format off
++    aip.src_info = arm_compute::TensorInfo(
++            src_shape,
++            1,
++            arm_compute::DataType::F32,
++            (src_tag == nhwc || src_tag == nc) ?
++            arm_compute::DataLayout::NHWC : arm_compute::DataLayout::NCHW);
++
++    aip.wei_info = arm_compute::TensorInfo(
++            wei_shape,
++            1,
++            arm_compute::DataType::F32,
++            wei_layout);
++
++    aip.dst_info = arm_compute::TensorInfo(
++            (dst_tag == nhwc || dst_tag == nc) ?
++            arm_compute::TensorShape(oc, mb) : arm_compute::TensorShape(mb, oc),
++            1,
++            arm_compute::DataType::F32,
++            (dst_tag == nhwc || dst_tag == nc) ?
++            arm_compute::DataLayout::NHWC : arm_compute::DataLayout::NCHW);
++
++    aip.bia_info = arm_compute::TensorInfo(
++            aip.with_bias ?
++            arm_compute::TensorShape(oc) : arm_compute::TensorShape(),
++            1,
++            arm_compute::DataType::F32);
++    // clang-format on
++
++    aip.fc_info.weights_trained_layout = wei_layout;
++    if (is_2d && wei_tag != src_tag) { aip.fc_info.transpose_weights = false; }
++
++    // Either activation or sum is supported as post-op at the moment
++    aip.fc_info.activation_info = acl_common_utils::get_acl_act(attr);
++    const auto &post_ops = attr.post_ops_;
++    aip.with_sum = (post_ops.len() == 1) && post_ops.entry_[0].is_sum();
++
++    // clang-format off
++    // Validate convolution manually to check for return status
++    auto acl_st = arm_compute::NEFullyConnectedLayer::validate(
++        &aip.src_info,
++        &aip.wei_info,
++        aip.with_bias ? &aip.bia_info : nullptr,
++        &aip.dst_info,
++	aip.fc_info);
++    // clang-format on
++    if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        return status::unimplemented;
++    }
++
++    return status::success;
++}
++
++} // namespace acl_inner_product_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_inner_product_utils.hpp b/src/cpu/aarch64/acl_inner_product_utils.hpp
+new file mode 100644
+index 000000000..022d0e334
+--- /dev/null
++++ b/src/cpu/aarch64/acl_inner_product_utils.hpp
+@@ -0,0 +1,62 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP
++#define CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP
++
++#include "cpu/cpu_inner_product_pd.hpp"
++
++#include "cpu/aarch64/acl_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_ip_obj_t {
++    arm_compute::NEFullyConnectedLayer fc;
++    arm_compute::NEArithmeticAddition add;
++    arm_compute::Tensor src_tensor;
++    arm_compute::Tensor wei_tensor;
++    arm_compute::Tensor bia_tensor;
++    arm_compute::Tensor dst_tensor;
++    arm_compute::Tensor dst_acc_tensor;
++};
++
++struct acl_ip_conf_t {
++    bool with_bias;
++    bool with_sum;
++    arm_compute::TensorInfo src_info;
++    arm_compute::TensorInfo wei_info;
++    arm_compute::TensorInfo bia_info;
++    arm_compute::TensorInfo dst_info;
++    arm_compute::FullyConnectedLayerInfo fc_info;
++};
++
++namespace acl_inner_product_utils {
++
++status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
++        memory_desc_t &wei_md, memory_desc_t &dst_md, memory_desc_t &bias_md,
++        const inner_product_desc_t &ipd, const primitive_attr_t &attr);
++
++} // namespace acl_inner_product_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_INNER_PRODUCT_UTILS_HPP
+diff --git a/src/cpu/aarch64/acl_utils.cpp b/src/cpu/aarch64/acl_utils.cpp
+new file mode 100644
+index 000000000..ba625c770
+--- /dev/null
++++ b/src/cpu/aarch64/acl_utils.cpp
+@@ -0,0 +1,122 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++namespace acl_common_utils {
++
++using namespace dnnl::impl::alg_kind;
++using namespace data_type;
++
++arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt) {
++    switch (dt) {
++        case bf16: return arm_compute::DataType::BFLOAT16; break;
++        case f32: return arm_compute::DataType::F32; break;
++        case s32: return arm_compute::DataType::S32; break;
++        case f16: return arm_compute::DataType::F16; break;
++        case s8: return arm_compute::DataType::QASYMM8_SIGNED; break;
++        case u8: return arm_compute::DataType::QASYMM8; break;
++        default: return arm_compute::DataType::UNKNOWN;
++    }
++}
++
++arm_compute::ActivationLayerInfo convert_to_acl_act(
++        const alg_kind_t eltwise_alg, const float alpha, const float beta) {
++    using acl_act_t = arm_compute::ActivationLayerInfo::ActivationFunction;
++    acl_act_t acl_act_alg;
++
++    switch (eltwise_alg) {
++        case eltwise_relu:
++            // oneDNN defines RELU: f(x) = (x > 0) ? x : a*x
++            // Compute Library defines LEAKY_RELU: f(x) = (x > 0) ? x : a*x
++            // whilst Compute Library RELU is defined as: f(x) = max(0,x)
++            if (alpha == 0) {
++                acl_act_alg = acl_act_t::RELU;
++            } else {
++                acl_act_alg = acl_act_t::LEAKY_RELU;
++            }
++            break;
++        case eltwise_tanh:
++            // oneDNN defines TANH activation as:          f(x) = tanh(x)
++            // Compute Library defines TANH activation as: f(x) = a*tanh(b*x)
++            // Setting a=b=1 makes the two equivalent
++            return arm_compute::ActivationLayerInfo(acl_act_t::TANH, 1.f, 1.f);
++            break;
++        case eltwise_elu: acl_act_alg = acl_act_t::ELU; break;
++        case eltwise_square: acl_act_alg = acl_act_t::SQUARE; break;
++        case eltwise_abs: acl_act_alg = acl_act_t::ABS; break;
++        case eltwise_sqrt: acl_act_alg = acl_act_t::SQRT; break;
++        case eltwise_linear: acl_act_alg = acl_act_t::LINEAR; break;
++        case eltwise_bounded_relu: acl_act_alg = acl_act_t::BOUNDED_RELU; break;
++        case eltwise_soft_relu: acl_act_alg = acl_act_t::SOFT_RELU; break;
++        case eltwise_logistic: acl_act_alg = acl_act_t::LOGISTIC; break;
++        default: return arm_compute::ActivationLayerInfo();
++    }
++
++    return arm_compute::ActivationLayerInfo(acl_act_alg, alpha, beta);
++}
++
++arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr) {
++    const auto &post_ops = attr.post_ops_;
++    const int entry_idx = post_ops.find(primitive_kind::eltwise);
++    if (entry_idx == -1) { return arm_compute::ActivationLayerInfo(); }
++
++    const auto eltwise_alg = post_ops.entry_[entry_idx].eltwise.alg;
++    float alpha = post_ops.entry_[entry_idx].eltwise.alpha;
++    float beta = post_ops.entry_[entry_idx].eltwise.beta;
++
++    return convert_to_acl_act(eltwise_alg, alpha, beta);
++}
++
++arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed) {
++    const alg_kind_t eltwise_alg = ed.alg_kind;
++    float alpha = ed.alpha;
++    float beta = ed.beta;
++
++    return convert_to_acl_act(eltwise_alg, alpha, beta);
++}
++
++bool acl_act_ok(alg_kind_t eltwise_activation) {
++    return utils::one_of(eltwise_activation, eltwise_relu, eltwise_tanh,
++            eltwise_elu, eltwise_square, eltwise_abs, eltwise_sqrt,
++            eltwise_linear, eltwise_bounded_relu, eltwise_soft_relu,
++            eltwise_logistic);
++}
++
++void acl_thread_bind() {
++    static std::once_flag flag_once;
++    // The threads in Compute Library are bound for the cores 0..max_threads-1
++    // dnnl_get_max_threads() returns OMP_NUM_THREADS
++    const int max_threads = dnnl_get_max_threads();
++    // arm_compute::Scheduler does not support concurrent access thus a
++    // workaround here restricts it to only one call
++    std::call_once(flag_once, [&]() {
++        arm_compute::Scheduler::get().set_num_threads(
++                max_threads);
++    });
++}
++
++} // namespace acl_common_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_utils.hpp b/src/cpu/aarch64/acl_utils.hpp
+new file mode 100644
+index 000000000..9bd0036cd
+--- /dev/null
++++ b/src/cpu/aarch64/acl_utils.hpp
+@@ -0,0 +1,56 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_UTILS_HPP
++#define CPU_AARCH64_ACL_UTILS_HPP
++
++#include <mutex>
++
++#include "oneapi/dnnl/dnnl_types.h"
++
++#include "common/bfloat16.hpp"
++#include "common/c_types_map.hpp"
++#include "common/dnnl_thread.hpp"
++#include "common/memory_tracking.hpp"
++#include "common/primitive.hpp"
++#include "common/utils.hpp"
++
++#include "cpu/cpu_engine.hpp"
++
++#include "arm_compute/runtime/NEON/NEFunctions.h"
++#include "arm_compute/runtime/Scheduler.h"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++namespace acl_common_utils {
++
++arm_compute::DataType get_acl_data_t(const dnnl_data_type_t dt);
++arm_compute::ActivationLayerInfo get_acl_act(const primitive_attr_t &attr);
++arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed);
++bool acl_act_ok(alg_kind_t eltwise_activation);
++void acl_thread_bind();
++
++} // namespace acl_common_utils
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_UTILS_HPP
+diff --git a/src/cpu/aarch64/acl_winograd_convolution.cpp b/src/cpu/aarch64/acl_winograd_convolution.cpp
+index 8e7bc5db6..1494a3f24 100644
+--- a/src/cpu/aarch64/acl_winograd_convolution.cpp
++++ b/src/cpu/aarch64/acl_winograd_convolution.cpp
+@@ -1,5 +1,5 @@
+ /*******************************************************************************
+-* Copyright 2020 Arm Ltd. and affiliates
++* Copyright 2020-2021 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -14,66 +14,27 @@
+ * limitations under the License.
+ *******************************************************************************/
+ 
+-#include "dnnl_types.h"
+-
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/type_helpers.hpp"
+-#include "common/utils.hpp"
+-#include "cpu/aarch64/acl_convolution_utils.hpp"
+ #include "cpu/aarch64/acl_winograd_convolution.hpp"
+ 
+-#include <cstring>
+-
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+ namespace aarch64 {
+ 
+-using namespace dnnl::impl::status;
+-using namespace dnnl::impl::memory_tracking::names;
+-using namespace dnnl::impl::utils;
+-
+ status_t acl_wino_convolution_fwd_t::execute_forward(
+         const exec_ctx_t &ctx) const {
+-    status_t status = status::success;
+-    auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+-    auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+-    auto bia_base = CTX_IN_MEM(const data_t *, DNNL_ARG_BIAS);
+-    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+-
+-    bool with_bias = pd()->acp_.with_bias;
+-
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
+     // Retrieve primitive resource and configured Compute Library objects
+     auto *acl_resource
+             = ctx.get_resource_mapper()->get<acl_wino_resource_t>(this);
+     acl_obj_t<arm_compute::NEWinogradConvolutionLayer> &acl_wino_obj
+             = acl_resource->get_acl_obj();
+ 
+-    acl_wino_obj.src_tensor.allocator()->import_memory(
+-            const_cast<data_t *>(src_base));
+-    acl_wino_obj.wei_tensor.allocator()->import_memory(
+-            const_cast<data_t *>(wei_base));
+-    acl_wino_obj.dst_tensor.allocator()->import_memory(dst_base);
+-
+-    // Retrieve extra bias memory from the scratchpad and copy from user memory
+-    if (with_bias) {
+-        const auto scratchpad = ctx.get_scratchpad_grantor();
+-        data_t *bia_memory = scratchpad.template get<data_t>(
+-                memory_tracking::names::key_none);
+-        size_t oc = acl_wino_obj.bia_tensor.info()->tensor_shape()[0];
+-        std::memcpy(bia_memory, bia_base, oc * sizeof(data_t));
+-        acl_wino_obj.bia_tensor.allocator()->import_memory(bia_memory);
+-    }
+-
+-    acl_wino_obj.conv.run();
+-
+-    acl_wino_obj.src_tensor.allocator()->free();
+-    acl_wino_obj.wei_tensor.allocator()->free();
+-    acl_wino_obj.dst_tensor.allocator()->free();
+-    if (with_bias) { acl_wino_obj.bia_tensor.allocator()->free(); }
+-
+-    return status;
++    return execute_forward_conv_acl<
++            acl_obj_t<arm_compute::NEWinogradConvolutionLayer>, pd_t, data_t>(
++            ctx, acl_wino_obj, pd());
+ }
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/aarch64/acl_winograd_convolution.hpp b/src/cpu/aarch64/acl_winograd_convolution.hpp
+index 08e548ba0..108697129 100644
+--- a/src/cpu/aarch64/acl_winograd_convolution.hpp
++++ b/src/cpu/aarch64/acl_winograd_convolution.hpp
+@@ -17,19 +17,10 @@
+ #ifndef CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+ #define CPU_AARCH64_ACL_WINOGRAD_CONVOLUTION_HPP
+ 
+-#include "common/c_types_map.hpp"
+-#include "common/dnnl_thread.hpp"
+-#include "common/memory_tracking.hpp"
+-#include "common/primitive.hpp"
+-
+ #include "cpu/cpu_convolution_pd.hpp"
+-#include "cpu/platform.hpp"
+ 
+ #include "cpu/aarch64/acl_convolution_utils.hpp"
+ 
+-#include "arm_compute/runtime/NEON/NEFunctions.h"
+-#include "arm_compute/runtime/NEON/NEScheduler.h"
+-
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+@@ -49,16 +40,30 @@ struct acl_wino_resource_t : public resource_t {
+         acl_wino_obj_->dst_tensor.allocator()->init(acp.dst_info);
+         acl_wino_obj_->bia_tensor.allocator()->init(acp.bia_info);
+ 
++        if (acp.sum_with_eltwise) {
++            acl_wino_obj_->dst_acc_tensor.allocator()->init(acp.dst_info);
++        }
+         // clang-format off
+         acl_wino_obj_->conv.configure(
+             &acl_wino_obj_->src_tensor,
+             &acl_wino_obj_->wei_tensor,
+             acp.with_bias ? &acl_wino_obj_->bia_tensor : nullptr,
+-            &acl_wino_obj_->dst_tensor,
++            acp.sum_with_eltwise ? &acl_wino_obj_->dst_acc_tensor
++                                 : &acl_wino_obj_->dst_tensor,
+             acp.padstride_info,
+-            acp.act_info,
++            acp.sum_with_eltwise ? arm_compute::ActivationLayerInfo()
++                                 : acp.act_info,
+             true); // to support 5x5, 7x7 filter shapes in addition to 3x3
+         // clang-format on
++        if (acp.sum_with_eltwise) {
++            acl_wino_obj_->add.configure(&acl_wino_obj_->dst_tensor,
++                    &acl_wino_obj_->dst_acc_tensor,
++                    &acl_wino_obj_->dst_acc_tensor,
++                    arm_compute::ConvertPolicy::SATURATE);
++            acl_wino_obj_->act.configure(&acl_wino_obj_->dst_acc_tensor,
++                    &acl_wino_obj_->dst_tensor, acp.act_info);
++            acl_wino_obj_->dst_acc_tensor.allocator()->allocate();
++        }
+ 
+         return status::success;
+     }
+@@ -84,7 +89,7 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
+                 "wino:acl", acl_wino_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
+ 
+         status_t init(engine_t *engine) {
+-            bool ok = true && is_fwd()
++            bool ok = is_fwd()
+                     && utils::one_of(desc()->alg_kind,
+                             alg_kind::convolution_auto,
+                             alg_kind::convolution_winograd)
+@@ -102,13 +107,7 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
+ 
+             set_default_alg_kind(alg_kind::convolution_winograd);
+ 
+-            // Number of threads in Compute Library is set by OMP_NUM_THREADS
+-            // dnnl_get_max_threads() == OMP_NUM_THREADS
+-
+-            arm_compute::IScheduler::BindFunc linear
+-                    = [](int i, int max_cores) { return i % max_cores; };
+-            arm_compute::Scheduler::get().set_num_threads_with_affinity(
+-                    dnnl_get_max_threads(), linear);
++            acl_common_utils::acl_thread_bind();
+ 
+             // TODO: remove dependence on scratchpad memory
+             // Using user provided memory for the biases currently segfaults
+@@ -129,12 +128,17 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
+             auto const &po = attr()->post_ops_;
+             auto is_eltwise
+                     = [&](int idx) { return po.entry_[idx].is_eltwise(); };
++            auto is_sum = [&](int idx) { return po.entry_[idx].is_sum(); };
+ 
++            bool sum_with_eltwise
++                    = (po.len() == 2) && is_sum(0) && is_eltwise(1);
++            bool eltwise_only = (po.len() == 1) ? is_eltwise(0) : false;
+             bool eltwise_ok = false;
+-            // Compute Library supports only one eltwise post-op
+-            if (po.len() == 1 && is_eltwise(0)) {
+-                const auto act_type = po.entry_[0].eltwise.alg;
+-                eltwise_ok = acl_convolution_utils::acl_act_ok(act_type);
++            // Compute Library supports only one eltwise post-op or
++            // sum+eltwise post-ops
++            if (eltwise_only || sum_with_eltwise) {
++                const auto act_type = po.entry_[sum_with_eltwise].eltwise.alg;
++                eltwise_ok = acl_common_utils::acl_act_ok(act_type);
+             }
+ 
+             return eltwise_ok || (po.len() == 0);
+@@ -166,6 +170,8 @@ struct acl_wino_convolution_fwd_t : public primitive_t {
+     }
+ 
+ private:
++    // To guard the const execute_forward(), the mutex must be 'mutable'
++    mutable std::mutex mtx;
+     status_t execute_forward(const exec_ctx_t &ctx) const;
+     const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
+ 
+diff --git a/src/cpu/cpu_eltwise_list.cpp b/src/cpu/cpu_eltwise_list.cpp
+index 9fdbdf9c9..8c8126027 100644
+--- a/src/cpu/cpu_eltwise_list.cpp
++++ b/src/cpu/cpu_eltwise_list.cpp
+@@ -1,6 +1,7 @@
+ /*******************************************************************************
+ * Copyright 2019-2021 Intel Corporation
+ * Copyright 2021 FUJITSU LIMITED
++* Copyright 2021 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -29,6 +30,11 @@ using namespace dnnl::impl::cpu::x64;
+ using namespace dnnl::impl::cpu::aarch64;
+ #endif
+ 
++#if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
++#include "cpu/aarch64/acl_eltwise.hpp"
++using namespace dnnl::impl::cpu::aarch64;
++#endif
++
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+@@ -62,6 +68,8 @@ const impl_list_item_t impl_list[] = {
+         CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s32>)
+         CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, s8>)
+         CPU_INSTANCE_AARCH64(jit_uni_eltwise_int_fwd_t<sve_512, u8>)
++        CPU_INSTANCE_AARCH64_ACL(acl_eltwise_fwd_t<f32>)
++        CPU_INSTANCE_AARCH64_ACL(acl_eltwise_fwd_t<s8>)
+         CPU_INSTANCE(ref_eltwise_fwd_t<f32>)
+         CPU_INSTANCE(ref_eltwise_bwd_t<f32>)
+         CPU_INSTANCE(ref_eltwise_fwd_t<bf16>)
+diff --git a/src/cpu/cpu_inner_product_list.cpp b/src/cpu/cpu_inner_product_list.cpp
+index 755c74550..6b06414b6 100644
+--- a/src/cpu/cpu_inner_product_list.cpp
++++ b/src/cpu/cpu_inner_product_list.cpp
+@@ -26,6 +26,11 @@
+ using namespace dnnl::impl::cpu::x64;
+ #endif
+ 
++#if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
++#include "cpu/aarch64/acl_inner_product.hpp"
++using namespace dnnl::impl::cpu::aarch64;
++#endif
++
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+@@ -39,6 +44,7 @@ const impl_list_item_t impl_list[] = {
+         CPU_INSTANCE_X64(brgemm_inner_product_fwd_t<avx512_core>)
+         CPU_INSTANCE_X64(brgemm_inner_product_bwd_data_t<avx512_core>)
+         CPU_INSTANCE_X64(brgemm_inner_product_bwd_weights_t<avx512_core>)
++        CPU_INSTANCE_AARCH64_ACL(acl_inner_product_fwd_t)
+         CPU_INSTANCE(gemm_inner_product_fwd_t<f32>)
+         CPU_INSTANCE(gemm_inner_product_bwd_data_t<f32>)
+         CPU_INSTANCE(gemm_inner_product_bwd_weights_t<f32>)
+

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -16,102 +16,15 @@
  *******************************************************************************
 
 diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
-index efc50709b8f..4d1e7bf5fe2 100644
+index 3e66023a149..ec12334041a 100644
 --- a/tensorflow/workspace2.bzl
 +++ b/tensorflow/workspace2.bzl
-@@ -191,23 +191,23 @@ def _tf_repositories():
+@@ -192,6 +192,7 @@ def _tf_repositories():
      tf_http_archive(
          name = "mkl_dnn_acl_compatible",
          build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
--        sha256 = "4d655c0751ee6439584ef5e3d465953fe0c2f4ee2700bc02699bdc1d1572af0d",
--        strip_prefix = "oneDNN-2.2",
-+        sha256 = "ccb2dbd9da36cd873cf573b4201d61bdba7438f12b144e6c7d061eb12a641751",
-+        strip_prefix = "oneDNN-2.3",
++        patch_file = "//third_party/mkl_dnn:onednn_acl_primitives.patch",
+         sha256 = "ccb2dbd9da36cd873cf573b4201d61bdba7438f12b144e6c7d061eb12a641751",
+         strip_prefix = "oneDNN-2.3",
          urls = [
--            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.2.tar.gz",
--            "https://github.com/oneapi-src/oneDNN/archive/v2.2.tar.gz",
-+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/oneapi-src/oneDNN/archive/v2.3.tar.gz",
-+            "https://github.com/oneapi-src/oneDNN/archive/v2.3.tar.gz",
-         ],
-     )
- 
-     tf_http_archive(
-         name = "compute_library",
--        sha256 = "cdb3d8a7ab7ea13f0df207a20657f2827ac631c24aa0e8487bacf97697237bdf",
--        strip_prefix = "ComputeLibrary-21.02",
-+        sha256 = "18011eb6dc999f030df609ff2b528e0067ab9f76921fa0b53e35859e06a0aa10",
-+        strip_prefix = "ComputeLibrary-21.05",
-         build_file = "//third_party/compute_library:BUILD",
-         patch_file = "//third_party/compute_library:compute_library.patch",
-         urls = [
--            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/ARM-software/ComputeLibrary/archive/v21.02.tar.gz",
--            "https://github.com/ARM-software/ComputeLibrary/archive/v21.02.tar.gz",
-+            "https://storage.googleapis.com/mirror.tensorflow.org/github.com/ARM-software/ComputeLibrary/archive/v21.05.tar.gz",
-+            "https://github.com/ARM-software/ComputeLibrary/archive/v21.05.tar.gz",
-         ],
-     )
- 
-diff --git a/third_party/compute_library/BUILD b/third_party/compute_library/BUILD
-index e65de83bc1c..59cdbf67fb1 100644
---- a/third_party/compute_library/BUILD
-+++ b/third_party/compute_library/BUILD
-@@ -45,6 +45,7 @@ cc_library(
-         "src/core/NEON/kernels/assembly",
-         "src/core/NEON/kernels/convolution/common",
-         "src/core/NEON/kernels/convolution/winograd",
-+        "arm_compute/runtime",
-     ],
-     deps = ["include"],
- )
-@@ -58,7 +59,9 @@ cc_library(
-         "src/runtime/cpu/**/*.cpp",
-         "**/*.h",
-     ]),
--    hdrs = glob(["arm_compute/runtime/**/*.h"]) + [
-+    hdrs = glob([
-+        "arm_compute/runtime/**/*.h",
-+        "arm_compute/runtime/*.h",]) + [
-         "arm_compute_version.embed",
-     ],
-     defines = ["ARM_COMPUTE_CPP_SCHEDULER"],
-diff --git a/third_party/compute_library/compute_library.patch b/third_party/compute_library/compute_library.patch
-index 43b0c9a1c0d..ee811b03a57 100644
---- a/third_party/compute_library/compute_library.patch
-+++ b/third_party/compute_library/compute_library.patch
-@@ -4,5 +4,5 @@ index 000000000..c986ad52a
- --- /dev/null
- +++ b/arm_compute_version.embed
- @@ -0,0 +1,1 @@
--+"arm_compute_version=v21.02 Build options: {} Git hash=b'N/A'"
-++"arm_compute_version=v21.05 Build options: {} Git hash=b'N/A'"
- \ No newline at end of file
-\ No newline at end of file
-diff --git a/third_party/mkl_dnn/mkldnn_acl.BUILD b/third_party/mkl_dnn/mkldnn_acl.BUILD
-index 017abff688a..7c72949d251 100644
---- a/third_party/mkl_dnn/mkldnn_acl.BUILD
-+++ b/third_party/mkl_dnn/mkldnn_acl.BUILD
-@@ -9,9 +9,10 @@ _DNNL_RUNTIME_OMP = {
-     "#cmakedefine DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_${DNNL_CPU_THREADING_RUNTIME}": "#define DNNL_CPU_THREADING_RUNTIME DNNL_RUNTIME_OMP",
-     "#cmakedefine DNNL_CPU_RUNTIME DNNL_RUNTIME_${DNNL_CPU_RUNTIME}": "#define DNNL_CPU_RUNTIME DNNL_RUNTIME_OMP",
-     "#cmakedefine DNNL_GPU_RUNTIME DNNL_RUNTIME_${DNNL_GPU_RUNTIME}": "#define DNNL_GPU_RUNTIME DNNL_RUNTIME_NONE",
--    "#cmakedefine DNNL_WITH_SYCL": "/* #undef DNNL_WITH_SYCL */",
--    "#cmakedefine DNNL_WITH_LEVEL_ZERO": "/* #undef DNNL_WITH_LEVEL_ZERO */",
--    "#cmakedefine DNNL_SYCL_CUDA": "/* #undef DNNL_SYCL_CUDA */",
-+    "#cmakedefine DNNL_USE_RT_OBJECTS_IN_PRIMITIVE_CACHE": "#undef DNNL_USE_RT_OBJECTS_IN_PRIMITIVE_CACHE",
-+    "#cmakedefine DNNL_WITH_SYCL": "#undef DNNL_WITH_SYCL",
-+    "#cmakedefine DNNL_WITH_LEVEL_ZERO": "#undef DNNL_WITH_LEVEL_ZERO",
-+    "#cmakedefine DNNL_SYCL_CUDA": "#undef DNNL_SYCL_CUDA",
- }
- 
- template_rule(
-@@ -27,9 +28,9 @@ template_rule(
-     out = "include/oneapi/dnnl/dnnl_version.h",
-     substitutions = {
-         "@DNNL_VERSION_MAJOR@": "2",
--        "@DNNL_VERSION_MINOR@": "2",
-+        "@DNNL_VERSION_MINOR@": "3",
-         "@DNNL_VERSION_PATCH@": "0",
--        "@DNNL_VERSION_HASH@": "269680b228218158fc172e9d5277446f73ac1917",
-+        "@DNNL_VERSION_HASH@": "593e0de6267d2575f3e4c9e9818f0f11253d093a",
-     },
- )
+

--- a/docker/tensorflow-aarch64/scripts/build-openblas.sh
+++ b/docker/tensorflow-aarch64/scripts/build-openblas.sh
@@ -17,7 +17,6 @@
 # limitations under the License.
 # *******************************************************************************
 
-
 set -euo pipefail
 
 cd $PACKAGE_DIR
@@ -35,7 +34,7 @@ install_dir=$PROD_DIR/$package/$version
 export CFLAGS="-O3"
 extra_args="USE_OPENMP=1"
 [[ ${BLAS_CPU} ]] && extra_args="$extra_args TARGET=${blas_cpu}"
+[[ ${BLAS_NCORES} ]] && extra_args="$extra_args NUM_THREADS=${blas_ncores}"
 
 make -j $NP_MAKE $extra_args
-make -j $NP_MAKE PREFIX=$install_dir install
-
+make -j $NP_MAKE $extra_args PREFIX=$install_dir install

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -28,7 +28,7 @@ readonly src_repo=tensorflow
 # Clone tensorflow and benchmarks
 git clone ${src_host}/${src_repo}.git
 cd ${src_repo}
-git checkout $version -b $version
+git checkout $version
 
 # Env vars used to avoid interactive elements of the build.
 export HOST_C_COMPILER=(which gcc)
@@ -69,7 +69,12 @@ if [[ $ONEDNN_BUILD ]]; then
       sed -i '/DNNL_AARCH64_USE_ACL/d' ./third_party/mkl_dnn/mkldnn_acl.BUILD
     elif [[ $ONEDNN_BUILD == 'acl' ]]; then
       echo "TensorFlow $TF_VERSION with oneDNN backend - Compute Library build."
+      # Update Bazel build to include onednn_acl_primitives patch
       patch -p1 < ../tf_acl.patch
+      # Patch for oneDNN to implement additional Compute Library primitives
+      mv ../onednn_acl_primitives.patch ./third_party/mkl_dnn/.
+      # Patch TensorFlow to support caching of inner_product primitive
+      patch -p1 < ../TF-caching-ip.patch
     fi
 else
     echo "TensorFlow $TF_VERSION with Eigen backend."

--- a/docker/tensorflow-aarch64/scripts/download-dataset.sh
+++ b/docker/tensorflow-aarch64/scripts/download-dataset.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # This script is  based on the upstream MLCommon's instructions to download datasets
 # Refer: https://github.com/mlperf/inference/tree/master/vision/classification_and_detection

--- a/docker/tensorflow-aarch64/scripts/download-model.sh
+++ b/docker/tensorflow-aarch64/scripts/download-model.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
+set -euo pipefail
 
 # This script is based on the upstream MLCommon's instructions to download models.
 # Refer: https://github.com/mlperf/inference/tree/master/vision/classification_and_detection
 
-cd vision/classification_and_detection
+cd inference/vision/classification_and_detection
 # resnet50
 wget https://zenodo.org/record/2535873/files/resnet50_v1.pb
 # mobilenet


### PR DESCRIPTION
- Adds support for pytorch native ResNet50 model
- Updates TendorFlow build to use the v2.6 release.
- Adds Compute Library primtitives for inner product and
  eltwise to oneDNN
- Ensures caching in TF's primitive factory for inner product
  supports Compute Library primitives
- Dissables thread binding for Compute Library primtitives
- Assorted updates to the README files
- Adds torchtext to PyTorch build, with example
- Sets default OpenBLAS build to use a thread limit of 64 threads
  rather than the number of threads available on the host.
  Controlled via parameter in cpu_info.sh
- Assorted minor corrections and improvements