### PR TITLE
Add support for bf16 fast maths in inner product and matmul

### DIFF
--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -294,10 +294,11 @@ ENV PATH=$PACKAGE_DIR/bazel:$PATH
 
 # Build TensorFlow
 COPY patches/tf_acl.patch $PACKAGE_DIR/.
-COPY patches/tf_softmax.patch $PACKAGE_DIR/.
+COPY patches/mkldnn_acl.patch $PACKAGE_DIR/.
+COPY patches/compute_library.patch $PACKAGE_DIR/.
 COPY scripts/build-tensorflow-io-gcs-filesystem.sh $PACKAGE_DIR/.
-COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow-io-gcs-filesystem.sh
+COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh
 
 CMD ["bash", "-l"]

--- a/docker/tensorflow-aarch64/patches/compute_library.patch
+++ b/docker/tensorflow-aarch64/patches/compute_library.patch
@@ -1,0 +1,331 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/arm_compute_version.embed b/arm_compute_version.embed
+new file mode 100644
+index 000000000..c986ad52a
+--- /dev/null
++++ b/arm_compute_version.embed
+@@ -0,0 +1,1 @@
++"arm_compute_version=v21.08 Build options: {} Git hash=b'N/A'"
+\ No newline at end of file
+diff --git a/arm_compute/core/Types.h b/arm_compute/core/Types.h
+index 9c00cbc88..092e61a83 100644
+--- a/arm_compute/core/Types.h
++++ b/arm_compute/core/Types.h
+@@ -1545,6 +1545,7 @@ struct FullyConnectedLayerInfo
+     bool       are_weights_reshaped{ false };              /**<  Reshape the weights tensor if false. */
+     bool       retain_internal_weights{ false };           /**<  Retain internal reshaped weights. */
+     bool       constant_weights{ true };                   /**<  If false, weights can vary between runs. */
++    bool       enable_fast_math{ false };                  /**<  Enable fast math computation. */
+     /* Other parameters */
+     bool fp_mixed_precision{ false }; /**<  Use wider accumulators (32 bit instead of 16 for FP16) to improve accuracy. */
+ 
+@@ -2073,6 +2074,14 @@ public:
+     {
+         return _fast_math;
+     };
++    /** Set fast math flag
++     *
++     * @param[in] fast_math Flag to set
++     */
++    void set_fast_math(bool fast_math)
++    {
++        _fast_math = fast_math;
++    }
+     /** Flag which specifies whether to broadcast the shape of the bias tensor.
+      *
+      * @return True if the shape of the bias tensor is to be broadcasted.
+diff --git a/arm_compute/graph/GraphBuilder.h b/arm_compute/graph/GraphBuilder.h
+index 14ad0571e..cb88c0e7a 100644
+--- a/arm_compute/graph/GraphBuilder.h
++++ b/arm_compute/graph/GraphBuilder.h
+@@ -295,13 +295,15 @@ public:
+      * @param[in] bias_nid       (Optional) Node ID of the bias node data. Defaults to EmptyNodeID
+      * @param[in] fc_info        (Optional) Fully connected layer metadata
+      * @param[in] out_quant_info (Optional) Output quantization info
++     * @param[in] fast_math_hint (Optional) Fast math hint
+      *
+      * @return Node ID of the created node, EmptyNodeID in case of error
+      */
+     static NodeID add_fully_connected_layer(Graph &g, NodeParams params, NodeIdxPair input, unsigned int num_outputs,
+                                             NodeID weights_nid, NodeID bias_nid = EmptyNodeID,
+                                             const FullyConnectedLayerInfo fc_info        = FullyConnectedLayerInfo(),
+-                                            const QuantizationInfo       &out_quant_info = QuantizationInfo());
++                                            const QuantizationInfo       &out_quant_info = QuantizationInfo(),
++                                            FastMathHint                  fast_math_hint = FastMathHint::Disabled);
+     /** Adds a fully connected layer node to the graph
+      *
+      * @param[in] g                  Graph to add the layer to
+@@ -313,6 +315,7 @@ public:
+      * @param[in] fc_info            (Optional) Fully connected layer metadata
+      * @param[in] weights_quant_info (Optional) Weights quantization info
+      * @param[in] out_quant_info     (Optional) Output quantization info
++     * @param[in] fast_math_hint     (Optional) Fast math hint
+      *
+      * @return Node ID of the created node, EmptyNodeID in case of error
+      */
+@@ -320,7 +323,8 @@ public:
+                                             ITensorAccessorUPtr weights_accessor = nullptr, ITensorAccessorUPtr bias_accessor = nullptr,
+                                             const FullyConnectedLayerInfo fc_info            = FullyConnectedLayerInfo(),
+                                             const QuantizationInfo       &weights_quant_info = QuantizationInfo(),
+-                                            const QuantizationInfo       &out_quant_info     = QuantizationInfo());
++                                            const QuantizationInfo       &out_quant_info     = QuantizationInfo(),
++                                            FastMathHint                  fast_math_hint     = FastMathHint::Disabled);
+     /** Adds a generate proposals layer node to the graph
+      *
+      * @param[in] g       Graph to add the layer to
+diff --git a/arm_compute/graph/backends/FunctionHelpers.h b/arm_compute/graph/backends/FunctionHelpers.h
+index 9830290d0..bd63758a6 100644
+--- a/arm_compute/graph/backends/FunctionHelpers.h
++++ b/arm_compute/graph/backends/FunctionHelpers.h
+@@ -1003,7 +1003,8 @@ std::unique_ptr<IFunction> create_fully_connected_layer(FullyConnectedLayerNode
+     typename TargetInfo::TensorType *weights = get_backing_tensor<TargetInfo>(node.input(1));
+     typename TargetInfo::TensorType *biases  = get_backing_tensor<TargetInfo>(node.input(2));
+     typename TargetInfo::TensorType *output  = get_backing_tensor<TargetInfo>(node.output(0));
+-    const FullyConnectedLayerInfo    fc_info = node.info();
++    FullyConnectedLayerInfo          fc_info = node.info();
++    fc_info.enable_fast_math                 = (node.fast_math_hint() == FastMathHint::Enabled);
+ 
+     ARM_COMPUTE_ERROR_ON(input == nullptr);
+     ARM_COMPUTE_ERROR_ON(weights == nullptr);
+diff --git a/arm_compute/graph/frontend/Layers.h b/arm_compute/graph/frontend/Layers.h
+index bf68b269d..fe0539bac 100644
+--- a/arm_compute/graph/frontend/Layers.h
++++ b/arm_compute/graph/frontend/Layers.h
+@@ -776,7 +776,7 @@ public:
+         {
+             return GraphBuilder::add_fully_connected_layer(s.graph(), common_params, input, _num_outputs,
+                                                            std::move(_weights), std::move(_bias), _fc_info,
+-                                                           std::move(_weights_quant_info), std::move(_out_quant_info));
++                                                           std::move(_weights_quant_info), std::move(_out_quant_info), s.hints().fast_math_hint);
+         }
+         else
+         {
+@@ -785,7 +785,7 @@ public:
+             NodeID bias_nid = (_bias_ss == nullptr) ? EmptyNodeID : _bias_ss->tail_node();
+             return GraphBuilder::add_fully_connected_layer(s.graph(), common_params, input, _num_outputs,
+                                                            _weights_ss->tail_node(), bias_nid, _fc_info,
+-                                                           std::move(_out_quant_info));
++                                                           std::move(_out_quant_info), s.hints().fast_math_hint);
+         }
+     }
+ 
+diff --git a/arm_compute/graph/nodes/FullyConnectedLayerNode.h b/arm_compute/graph/nodes/FullyConnectedLayerNode.h
+index a7712f46b..9ade62bf4 100644
+--- a/arm_compute/graph/nodes/FullyConnectedLayerNode.h
++++ b/arm_compute/graph/nodes/FullyConnectedLayerNode.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2018-2020 Arm Limited.
++ * Copyright (c) 2018-2021 Arm Limited.
+  *
+  * SPDX-License-Identifier: MIT
+  *
+@@ -39,10 +39,22 @@ public:
+      * @param[in] num_outputs    Number of neurons in the layer
+      * @param[in] out_quant_info (Optional) Output quantization info
+      * @param[in] fc_info        (Optional) Additional information about the fully connected layer
++     * @param[in] fast_math_hint (Optional) Fast math hint
+      */
+     FullyConnectedLayerNode(unsigned int            num_outputs,
+                             QuantizationInfo        out_quant_info = QuantizationInfo(),
+-                            FullyConnectedLayerInfo fc_info        = FullyConnectedLayerInfo());
++                            FullyConnectedLayerInfo fc_info        = FullyConnectedLayerInfo(),
++                            FastMathHint            fast_math_hint = FastMathHint::Disabled);
++    /** Sets the fast math fast hint
++     *
++     * @param[in] hint Hint to use for fullyconnected layer
++     */
++    void set_fast_math_hint(FastMathHint hint);
++    /** Fast math hint accessor
++     *
++     * @return Fast math hint to be used by the node
++     */
++    FastMathHint fast_math_hint() const;
+     /** Sets fused activation
+      *
+      * @param[in] fused_activation Fused activation to set
+@@ -94,6 +106,7 @@ private:
+     unsigned int            _num_outputs;
+     QuantizationInfo        _out_quant_info;
+     FullyConnectedLayerInfo _info;
++    FastMathHint            _fast_math_hint;
+ };
+ } // namespace graph
+ } // namespace arm_compute
+diff --git a/src/graph/GraphBuilder.cpp b/src/graph/GraphBuilder.cpp
+index 01d35a15b..15abf3738 100644
+--- a/src/graph/GraphBuilder.cpp
++++ b/src/graph/GraphBuilder.cpp
+@@ -467,7 +467,7 @@ NodeID GraphBuilder::add_flatten_node(Graph &g, NodeParams params, NodeIdxPair i
+ 
+ NodeID GraphBuilder::add_fully_connected_layer(Graph &g, NodeParams params, NodeIdxPair input, unsigned int num_outputs,
+                                                NodeID weights_nid, NodeID bias_nid,
+-                                               const FullyConnectedLayerInfo fc_info, const QuantizationInfo &out_quant_info)
++                                               const FullyConnectedLayerInfo fc_info, const QuantizationInfo &out_quant_info, FastMathHint fast_math_hint)
+ {
+     check_nodeidx_pair(input, g);
+     ARM_COMPUTE_ERROR_ON(num_outputs == 0);
+@@ -479,7 +479,7 @@ NodeID GraphBuilder::add_fully_connected_layer(Graph &g, NodeParams params, Node
+     const TensorDescriptor input_tensor_desc = get_tensor_descriptor(g, g.node(input.node_id)->outputs()[0]);
+ 
+     // Create fully connected node and connect
+-    NodeID fc_nid = g.add_node<FullyConnectedLayerNode>(num_outputs, out_quant_info, fc_info);
++    NodeID fc_nid = g.add_node<FullyConnectedLayerNode>(num_outputs, out_quant_info, fc_info, fast_math_hint);
+     g.add_connection(input.node_id, input.index, fc_nid, 0);
+     g.add_connection(weights_nid, 0, fc_nid, 1);
+     if(has_bias)
+@@ -495,7 +495,7 @@ NodeID GraphBuilder::add_fully_connected_layer(Graph &g, NodeParams params, Node
+ NodeID GraphBuilder::add_fully_connected_layer(Graph &g, NodeParams params, NodeIdxPair input, unsigned int num_outputs,
+                                                ITensorAccessorUPtr weights_accessor, ITensorAccessorUPtr bias_accessor,
+                                                const FullyConnectedLayerInfo fc_info,
+-                                               const QuantizationInfo &weights_quant_info, const QuantizationInfo &out_quant_info)
++                                               const QuantizationInfo &weights_quant_info, const QuantizationInfo &out_quant_info, FastMathHint fast_math_hint)
+ {
+     check_nodeidx_pair(input, g);
+     ARM_COMPUTE_ERROR_ON(num_outputs == 0);
+@@ -523,7 +523,7 @@ NodeID GraphBuilder::add_fully_connected_layer(Graph &g, NodeParams params, Node
+     }
+ 
+     // Create fully connected node and connect
+-    NodeID fc_nid = g.add_node<FullyConnectedLayerNode>(num_outputs, out_quant_info, fc_info);
++    NodeID fc_nid = g.add_node<FullyConnectedLayerNode>(num_outputs, out_quant_info, fc_info, fast_math_hint);
+     g.add_connection(input.node_id, input.index, fc_nid, 0);
+     g.add_connection(w_nid, 0, fc_nid, 1);
+     if(has_bias)
+diff --git a/src/graph/nodes/FullyConnectedLayer.cpp b/src/graph/nodes/FullyConnectedLayer.cpp
+index 442f636b6..627822787 100644
+--- a/src/graph/nodes/FullyConnectedLayer.cpp
++++ b/src/graph/nodes/FullyConnectedLayer.cpp
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2018-2020 Arm Limited.
++ * Copyright (c) 2018-2021 Arm Limited.
+  *
+  * SPDX-License-Identifier: MIT
+  *
+@@ -31,12 +31,21 @@ namespace arm_compute
+ {
+ namespace graph
+ {
+-FullyConnectedLayerNode::FullyConnectedLayerNode(unsigned int num_outputs, QuantizationInfo out_quant_info, FullyConnectedLayerInfo fc_info)
+-    : _num_outputs(num_outputs), _out_quant_info(std::move(out_quant_info)), _info(fc_info)
++FullyConnectedLayerNode::FullyConnectedLayerNode(unsigned int num_outputs, QuantizationInfo out_quant_info, FullyConnectedLayerInfo fc_info, FastMathHint fast_math_hint)
++    : _num_outputs(num_outputs), _out_quant_info(std::move(out_quant_info)), _info(fc_info), _fast_math_hint(fast_math_hint)
+ {
+     _input_edges.resize(3, EmptyEdgeID);
+     _outputs.resize(1, NullTensorID);
+ }
++void FullyConnectedLayerNode::set_fast_math_hint(FastMathHint hint)
++{
++    _fast_math_hint = hint;
++}
++
++FastMathHint FullyConnectedLayerNode::fast_math_hint() const
++{
++    return _fast_math_hint;
++}
+ 
+ void FullyConnectedLayerNode::set_fused_activation(ActivationLayerInfo fused_activation)
+ {
+diff --git a/src/runtime/cpu/operators/CpuFullyConnected.cpp b/src/runtime/cpu/operators/CpuFullyConnected.cpp
+index eeabce075..645acaa3e 100644
+--- a/src/runtime/cpu/operators/CpuFullyConnected.cpp
++++ b/src/runtime/cpu/operators/CpuFullyConnected.cpp
+@@ -108,7 +108,7 @@ Status get_gemmlowp_output_stage_info(const ITensorInfo *src, const ITensorInfo
+     return Status{};
+ }
+ 
+-Status validate_mm(const ITensorInfo *src, const ITensorInfo *weights, const ITensorInfo *biases, const ITensorInfo *dst, const ActivationLayerInfo &act)
++Status validate_mm(const ITensorInfo *src, const ITensorInfo *weights, const ITensorInfo *biases, const ITensorInfo *dst, const ActivationLayerInfo &act, bool enable_fast_math)
+ {
+     if(is_data_type_quantized_asymmetric(src->data_type()))
+     {
+@@ -122,6 +122,7 @@ Status validate_mm(const ITensorInfo *src, const ITensorInfo *weights, const ITe
+ 
+         GEMMInfo gemm_info;
+         gemm_info.set_gemmlowp_output_stage(gemmlowp_output_stage_info);
++        gemm_info.set_fast_math(enable_fast_math);
+ 
+         // Validate gemmlowp function
+         TensorInfo src_info     = src->clone()->set_quantization_info(src_quantization_info);
+@@ -134,7 +135,9 @@ Status validate_mm(const ITensorInfo *src, const ITensorInfo *weights, const ITe
+     }
+     else
+     {
+-        ARM_COMPUTE_RETURN_ON_ERROR(CpuGemm::validate(src, weights, biases, dst, 1.f, 1.0f, GEMMInfo(false, false, true /* Reshape weights only for the first run */)));
++        GEMMInfo gemm_info(false, false, true /* Reshape weights only for the first run */);
++        gemm_info.set_fast_math(enable_fast_math);
++        ARM_COMPUTE_RETURN_ON_ERROR(CpuGemm::validate(src, weights, biases, dst, 1.f, 1.0f, gemm_info));
+     }
+ 
+     return Status{};
+@@ -157,7 +160,8 @@ CpuFullyConnected::CpuFullyConnected()
+       _needs_weights_reshape(false),
+       _is_fc_after_conv(false),
+       _is_quantized_asymmetric(false),
+-      _is_prepared(false)
++      _is_prepared(false),
++      _enable_fast_math(false)
+ 
+ {
+ }
+@@ -184,6 +188,7 @@ void CpuFullyConnected::configure_mm(const ITensorInfo *src, const ITensorInfo *
+         GEMMInfo gemm_info;
+         gemm_info.set_gemmlowp_output_stage(gemmlowp_output_stage_info);
+         gemm_info.set_activation_info(act);
++        gemm_info.set_fast_math(_enable_fast_math);
+         _mm_gemmlowp = std::make_unique<CpuGemmLowpMatrixMultiplyCore>();
+         _mm_gemmlowp->configure(&src_info, &weights_info, biases, dst, gemm_info);
+     }
+@@ -192,6 +197,7 @@ void CpuFullyConnected::configure_mm(const ITensorInfo *src, const ITensorInfo *
+         // Configure matrix multiply kernel
+         GEMMInfo gemm_info(false, false, true /* Reshape weights only for the first run */);
+         gemm_info.set_activation_info(act);
++        gemm_info.set_fast_math(_enable_fast_math);
+         _mm_gemm = std::make_unique<CpuGemm>();
+         _mm_gemm->configure(src, weights, biases, dst, 1.f, 1.0f, gemm_info);
+     }
+@@ -239,6 +245,7 @@ void CpuFullyConnected::configure(const ITensorInfo *src, const ITensorInfo *wei
+     _is_quantized_asymmetric  = is_data_type_quantized_asymmetric(src->data_type());
+     _is_prepared              = false;
+     _trans_weights_idx        = AuxTensorIdx::Count;
++    _enable_fast_math         = fc_info.enable_fast_math;
+ 
+     // With the Fully Connected layer we can have 4 different cases:
+     //  1) Convolution layer -> Fully Connected layer without batches
+@@ -399,7 +406,7 @@ Status CpuFullyConnected::validate(const ITensorInfo *src, const ITensorInfo *we
+         ARM_COMPUTE_RETURN_ERROR_ON(src->dimension(0) != weights_to_use->dimension(1));
+     }
+     // Validate matrix multiply kernel
+-    ARM_COMPUTE_RETURN_ON_ERROR(validate_mm(src_to_use, weights_to_use, biases, dst, fc_info.activation_info));
++    ARM_COMPUTE_RETURN_ON_ERROR(validate_mm(src_to_use, weights_to_use, biases, dst, fc_info.activation_info, fc_info.enable_fast_math));
+ 
+     return Status{};
+ }
+diff --git a/src/runtime/cpu/operators/CpuFullyConnected.h b/src/runtime/cpu/operators/CpuFullyConnected.h
+index 498ceae68..eb0b8f677 100644
+--- a/src/runtime/cpu/operators/CpuFullyConnected.h
++++ b/src/runtime/cpu/operators/CpuFullyConnected.h
+@@ -141,6 +141,7 @@ private:
+     bool _is_fc_after_conv;
+     bool _is_quantized_asymmetric;
+     bool _is_prepared;
++    bool _enable_fast_math;
+ };
+ } // namespace cpu
+ } // namespace arm_compute

--- a/docker/tensorflow-aarch64/patches/mkldnn_acl.patch
+++ b/docker/tensorflow-aarch64/patches/mkldnn_acl.patch
@@ -1,0 +1,554 @@
+ *******************************************************************************
+ Copyright 2021 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/doc/performance_considerations/verbose.md b/doc/performance_considerations/verbose.md
+index d5e739238..fbc5f7224 100644
+--- a/doc/performance_considerations/verbose.md
++++ b/doc/performance_considerations/verbose.md
+@@ -128,6 +128,12 @@ synchronization on entry and on exit in the dnnl::primitive::execute() call.
+ The execution time is calculated based on wall time measured before and after
+ primitive execution.
+ 
++@note
++When oneDNN verbose mode is enabled for builds with
++[Compute Library for the Arm architecture](https://oneapi-src.github.io/oneDNN/dev_guide_build.html#gcc-with-arm-compute-library-acl-on-aarch64-host),
++any failures in the validation of Compute Library primitives will be detailed
++in the verbose output.
++
+ @warning
+ Verbose mode has non-negligible performance impact especially on GPU or if the
+ output rate is high.
+diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
+index d27c58d7e..ca91de49e 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.cpp
++++ b/src/cpu/aarch64/acl_convolution_utils.cpp
+@@ -214,6 +214,33 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+             && post_ops.entry_[1].is_eltwise(true);
+     acp.act_info = acl_common_utils::get_acl_act(attr);
+ 
++    if (acp.sum_with_eltwise) {
++        // clang-format off
++        // Validate activation layer manually to check for return status
++        auto acl_al_st = arm_compute::NEActivationLayer::validate(
++            &acp.dst_info,
++            &acp.dst_info,
++            acp.act_info);
++        // clang-format on
++        if (acl_al_st.error_code() != arm_compute::ErrorCode::OK) {
++            MAYBE_REPORT_ACL_ERROR(acl_al_st.error_description().c_str());
++            return status::unimplemented;
++        }
++
++        // clang-format off
++        // Validate arithmetic addition manually to check for return status
++        auto acl_aa_st = arm_compute::NEArithmeticAddition::validate(
++            &acp.dst_info,
++            &acp.dst_info,
++            &acp.dst_info,
++            arm_compute::ConvertPolicy::SATURATE);
++        // clang-format on
++        if (acl_aa_st.error_code() != arm_compute::ErrorCode::OK) {
++            MAYBE_REPORT_ACL_ERROR(acl_aa_st.error_description().c_str());
++            return status::unimplemented;
++        }
++    }
++
+     return status::success;
+ }
+ 
+@@ -239,6 +266,7 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         acp.fast_math);
+     // clang-format on
+     if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        MAYBE_REPORT_ACL_ERROR(acl_st.error_description().c_str());
+         return status::unimplemented;
+     }
+ 
+@@ -273,6 +301,7 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+                                 1));
+     // clang-format on
+     if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        MAYBE_REPORT_ACL_ERROR(acl_st.error_description().c_str());
+         return status::unimplemented;
+     }
+ 
+@@ -317,6 +346,7 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         true); // enable_fast_math flag in ACL Winograd
+     // clang-format on
+     if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        MAYBE_REPORT_ACL_ERROR(acl_st.error_description().c_str());
+         return status::unimplemented;
+     }
+ 
+diff --git a/src/cpu/aarch64/acl_inner_product_utils.cpp b/src/cpu/aarch64/acl_inner_product_utils.cpp
+index 8a8d1cc93..66e8dc643 100644
+--- a/src/cpu/aarch64/acl_inner_product_utils.cpp
++++ b/src/cpu/aarch64/acl_inner_product_utils.cpp
+@@ -134,19 +134,41 @@ status_t init_conf_ip(acl_ip_conf_t &aip, memory_desc_t &src_md,
+     const auto &post_ops = attr.post_ops_;
+     aip.with_sum = (post_ops.len() == 1) && post_ops.entry_[0].is_sum();
+ 
++    // Fast math mode
++    auto math_mode = get_fpmath_mode();
++    bool is_fastmath_enabled = one_of(math_mode, fpmath_mode::bf16, fpmath_mode::any);
++    aip.fc_info.enable_fast_math = is_fastmath_enabled;
++
+     // clang-format off
+-    // Validate convolution manually to check for return status
++    // Validate fully connected layer manually to check for return status
+     auto acl_st = arm_compute::NEFullyConnectedLayer::validate(
+         &aip.src_info,
+         &aip.wei_info,
+         aip.with_bias ? &aip.bia_info : nullptr,
+         &aip.dst_info,
+-	aip.fc_info);
++        aip.fc_info);
+     // clang-format on
+     if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        MAYBE_REPORT_ACL_ERROR(acl_st.error_description().c_str());
+         return status::unimplemented;
+     }
+ 
++    if (aip.with_sum) {
++        // clang-format off
++        // Validate arithmetic addition manually to check for return status
++        auto acl_aa_st = arm_compute::NEArithmeticAddition::validate(
++            &aip.dst_info,
++            &aip.dst_info,
++            &aip.dst_info,
++            arm_compute::ConvertPolicy::SATURATE);
++
++        // clang-format on
++        if (acl_aa_st.error_code() != arm_compute::ErrorCode::OK) {
++            MAYBE_REPORT_ACL_ERROR(acl_aa_st.error_description().c_str());
++            return status::unimplemented;
++        }
++    }
++
+     return status::success;
+ }
+ 
+diff --git a/src/cpu/aarch64/acl_softmax.cpp b/src/cpu/aarch64/acl_softmax.cpp
+new file mode 100644
+index 000000000..81935282f
+--- /dev/null
++++ b/src/cpu/aarch64/acl_softmax.cpp
+@@ -0,0 +1,56 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_softmax.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++template <impl::data_type_t data_type>
++status_t acl_softmax_fwd_t<data_type>::execute_forward(
++        const exec_ctx_t &ctx) const {
++
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
++
++    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
++    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
++
++    // Retrieve primitive resource and configured Compute Library objects
++    auto *acl_resource
++            = ctx.get_resource_mapper()->get<acl_softmax_resource_t>(this);
++    acl_softmax_obj_t &acl_obj = acl_resource->get_acl_obj();
++
++    acl_obj.src_tensor.allocator()->import_memory(const_cast<data_t *>(src));
++    acl_obj.dst_tensor.allocator()->import_memory(dst);
++
++    acl_obj.softmax.run();
++
++    acl_obj.src_tensor.allocator()->free();
++    acl_obj.dst_tensor.allocator()->free();
++
++    return status::success;
++}
++
++template struct acl_softmax_fwd_t<data_type::f32>;
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_softmax.hpp b/src/cpu/aarch64/acl_softmax.hpp
+new file mode 100644
+index 000000000..36cc73c00
+--- /dev/null
++++ b/src/cpu/aarch64/acl_softmax.hpp
+@@ -0,0 +1,216 @@
++/*******************************************************************************
++* Copyright 2021 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_SOFTMAX_HPP
++#define CPU_AARCH64_ACL_SOFTMAX_HPP
++
++#include "cpu/cpu_softmax_pd.hpp"
++
++#include "cpu/aarch64/acl_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_softmax_obj_t {
++    arm_compute::NESoftmaxLayer softmax;
++    arm_compute::Tensor src_tensor;
++    arm_compute::Tensor dst_tensor;
++};
++
++struct acl_softmax_conf_t {
++    arm_compute::TensorInfo src_info;
++    arm_compute::TensorInfo dst_info;
++    float beta;
++    int32_t axis;
++};
++
++struct acl_softmax_resource_t : public resource_t {
++    acl_softmax_resource_t()
++        : acl_obj_(utils::make_unique<acl_softmax_obj_t>()) {}
++
++    status_t configure(const acl_softmax_conf_t &asp) {
++        if (!acl_obj_) return status::out_of_memory;
++
++        // Init Compute Library tensors based on info from descriptor
++        acl_obj_->src_tensor.allocator()->init(asp.src_info);
++        acl_obj_->dst_tensor.allocator()->init(asp.dst_info);
++        // clang-format off
++        acl_obj_->softmax.configure(
++            &acl_obj_->src_tensor,
++            &acl_obj_->dst_tensor,
++            asp.beta,
++            asp.axis);
++        // clang-format on
++        return status::success;
++    }
++
++    acl_softmax_obj_t &get_acl_obj() const { return *acl_obj_; }
++
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_softmax_resource_t);
++
++private:
++    std::unique_ptr<acl_softmax_obj_t> acl_obj_;
++}; // acl_softmax_resource_t
++
++template <impl::data_type_t data_type>
++struct acl_softmax_fwd_t : public primitive_t {
++    struct pd_t : public cpu_softmax_fwd_pd_t {
++        using cpu_softmax_fwd_pd_t::cpu_softmax_fwd_pd_t;
++
++        DECLARE_COMMON_PD_T("acl", acl_softmax_fwd_t);
++
++        status_t init(engine_t *engine) {
++
++            // Forward only
++            if (desc()->prop_kind != dnnl_forward_inference)
++                return status::unimplemented;
++
++            if (src_md()->data_type != data_type) return status::unimplemented;
++
++            if (!attr()->has_default_values()) return status::unimplemented;
++
++            // Get memory desc to find sizes and dims
++            const memory_desc_wrapper src_d(src_md());
++
++            // ACL only supports plain tensors, can be permuted but not blocked
++            if (!src_d.is_plain()) return status::unimplemented;
++
++            // Guards against a 0-sized dimension
++            if (src_d.has_zero_dim()) return status::unimplemented;
++
++            // Not yet implemented using ACL
++            if (is_logsoftmax()) return status::unimplemented;
++
++            // No scaling
++            asp_.beta = 1;
++
++            // The strides give us the in memory inner size
++            dim_t inner_size_ = src_d.blocking_desc().strides[axis()];
++
++            dim_t axis_size_ = axis_size();
++
++            // The outer size is any left-over dimensions not inner or on the axis
++            dim_t outer_size_ = src_d.nelems() / (inner_size_ * axis_size_);
++
++            // In this context, NHWC tells ACL that the logical and physical
++            // dimensions are the same
++            arm_compute::DataLayout acl_layout = arm_compute::DataLayout::NHWC;
++            const arm_compute::DataType acl_data_t
++                    = acl_common_utils::get_acl_data_t(data_type);
++
++            const int threads = dnnl_get_max_threads();
++            dim_t total_size = outer_size_ * axis_size_ * inner_size_;
++            if (inner_size_ == 1) {
++                // A rough empirical heuristic created by fitting a polynomial
++                // of the tensor sizes and thread count to the run time of the
++                // ref and ACL softmax. It is greater than zero when ref is
++                // faster, and less than zero when ACL is faster. We can
++                // interpret the constant term as the constant overhead
++                // associated with calling the external library and the negative
++                // coefficient on total_size as ACL being faster at processing
++                // each element
++                if (threads == 1 || outer_size_ == 1) {
++                    if (2 + 0.03 * outer_size_ - 0.005 * total_size > 0)
++                        return status::unimplemented;
++                } else {
++                    if (20 + 0.02 * outer_size_ - 0.006 * total_size / threads
++                                    + 3 * threads
++                            > 0)
++                        return status::unimplemented;
++                }
++
++                // If the inner size is 1, we can get rid of the dimension.
++                // This stops ACL doing a unnecessary permute
++                arm_compute::TensorShape acl_tensor_shape
++                        = arm_compute::TensorShape(axis_size_, outer_size_);
++                asp_.axis = 0;
++
++                asp_.src_info = arm_compute::TensorInfo(
++                        acl_tensor_shape, 1, acl_data_t, acl_layout);
++                asp_.dst_info = arm_compute::TensorInfo(
++                        acl_tensor_shape, 1, acl_data_t, acl_layout);
++            } else {
++                // A rough empirical heuristic, see comment above
++                if (2 - 0.005 * total_size / threads + 3 * threads > 0)
++                    return status::unimplemented;
++
++                // Irrespective of the input dimensions, we construct a tensor
++                // with dimensions such that softmax can be applied over the
++                // middle axis (1), with the correct stride and vector length.
++                arm_compute::TensorShape acl_tensor_shape
++                        = arm_compute::TensorShape(
++                                inner_size_, axis_size_, outer_size_);
++                asp_.axis = 1;
++
++                asp_.src_info = arm_compute::TensorInfo(
++                        acl_tensor_shape, 1, acl_data_t, acl_layout);
++                asp_.dst_info = arm_compute::TensorInfo(
++                        acl_tensor_shape, 1, acl_data_t, acl_layout);
++            }
++
++            // Validate manually to check for return status
++            auto acl_st = arm_compute::NESoftmaxLayer::validate(
++                    &asp_.src_info, &asp_.dst_info, asp_.beta, asp_.axis);
++            if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++                MAYBE_REPORT_ACL_ERROR(acl_st.error_description().c_str());
++                return status::unimplemented;
++            }
++
++            acl_common_utils::acl_thread_bind();
++
++            return status::success;
++        }
++
++        acl_softmax_conf_t asp_;
++    }; // pd_t
++
++    acl_softmax_fwd_t(const pd_t *apd) : primitive_t(apd) {}
++
++    status_t create_resource(
++            engine_t *engine, resource_mapper_t &mapper) const override {
++        if (mapper.has_resource(this)) return status::success;
++
++        auto r = utils::make_unique<acl_softmax_resource_t>();
++        if (!r) return status::out_of_memory;
++
++        // Configure the resource based on information from primitive descriptor
++        auto st = r->configure(pd()->asp_);
++        if (st == status::success) { mapper.add(this, std::move(r)); }
++
++        return st;
++    }
++
++    typedef typename prec_traits<data_type>::type data_t;
++
++    status_t execute(const exec_ctx_t &ctx) const override {
++        return execute_forward(ctx);
++    }
++
++private:
++    // To guard the const execute_forward, the mutex must be 'mutable'
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++}; // acl_softmax_fwd_t
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif
+diff --git a/src/cpu/aarch64/acl_utils.hpp b/src/cpu/aarch64/acl_utils.hpp
+index 9bd0036cd..8dfc234f5 100644
+--- a/src/cpu/aarch64/acl_utils.hpp
++++ b/src/cpu/aarch64/acl_utils.hpp
+@@ -46,6 +46,11 @@ arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed);
+ bool acl_act_ok(alg_kind_t eltwise_activation);
+ void acl_thread_bind();
+ 
++#define MAYBE_REPORT_ACL_ERROR(msg) \
++    do { \
++        if (get_verbose()) printf("dnnl_verbose,cpu,error,acl,%s\n", (msg)); \
++    } while (0)
++
+ } // namespace acl_common_utils
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+index bf35ef83c..943e34c41 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
++++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+@@ -82,16 +82,23 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+             = arm_compute::TensorInfo(arm_compute::TensorShape(N, M, 1, batch),
+                     1, arm_compute::DataType::F32);
+ 
++    // Fast-math mode
++    auto math_mode = get_fpmath_mode();
++    bool is_fastmath_enabled = one_of(math_mode, fpmath_mode::bf16, fpmath_mode::any);
++    amp.gemm_info.set_fast_math(is_fastmath_enabled);
++
+     // Fused ReLU activation
+     amp.gemm_info.set_activation_info(get_acl_act(attr));
++
+     // Set alpha (output scaling)
+     amp.alpha = attr.output_scales_.scales_[0];
++
+     // Validate ACL transpose
+     if (amp.is_transA) {
+         auto acl_transA_st = arm_compute::NETranspose::validate(
+                 &amp.src_acc_info, &amp.src_info);
+         if (acl_transA_st.error_code() != arm_compute::ErrorCode::OK) {
+-            printf("%s\n", acl_transA_st.error_description().c_str());
++            MAYBE_REPORT_ACL_ERROR(acl_transA_st.error_description().c_str());
+             return status::unimplemented;
+         }
+     }
+@@ -99,7 +106,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+         auto acl_transB_st = arm_compute::NETranspose::validate(
+                 &amp.wei_acc_info, &amp.wei_info);
+         if (acl_transB_st.error_code() != arm_compute::ErrorCode::OK) {
+-            printf("%s\n", acl_transB_st.error_description().c_str());
++            MAYBE_REPORT_ACL_ERROR(acl_transB_st.error_description().c_str());
+             return status::unimplemented;
+         }
+     }
+@@ -107,7 +114,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+     auto acl_st = arm_compute::NEGEMM::validate(&amp.src_info, &amp.wei_info,
+             nullptr, &amp.dst_info, amp.alpha, 0.0f, amp.gemm_info);
+     if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
+-        printf("%s\n", acl_st.error_description().c_str());
++        MAYBE_REPORT_ACL_ERROR(acl_st.error_description().c_str());
+         return status::unimplemented;
+     }
+ 
+diff --git a/src/cpu/cpu_softmax_list.cpp b/src/cpu/cpu_softmax_list.cpp
+index 584b3fd75..6b9046e4c 100644
+--- a/src/cpu/cpu_softmax_list.cpp
++++ b/src/cpu/cpu_softmax_list.cpp
+@@ -1,6 +1,7 @@
+ /*******************************************************************************
+ * Copyright 2019-2021 Intel Corporation
+ * Copyright 2021 FUJITSU LIMITED
++* Copyright 2021 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -24,6 +25,9 @@
+ using namespace dnnl::impl::cpu::x64;
+ #elif DNNL_AARCH64
+ #include "cpu/aarch64/jit_uni_softmax.hpp"
++#if DNNL_AARCH64_USE_ACL
++#include "cpu/aarch64/acl_softmax.hpp"
++#endif
+ using namespace dnnl::impl::cpu::aarch64;
+ #endif
+ 
+@@ -42,10 +46,11 @@ const impl_list_item_t impl_list[] = {
+         REG_SOFTMAX_P_FWD(CPU_INSTANCE_X64(jit_uni_softmax_fwd_t<sse41>))
+         CPU_INSTANCE_AARCH64(jit_uni_softmax_fwd_t<sve_512>)
+         CPU_INSTANCE_AARCH64(jit_uni_softmax_bwd_t<sve_512>)
+-        REG_SOFTMAX_P_FWD(CPU_INSTANCE(ref_softmax_fwd_t<f32>))
+-        REG_SOFTMAX_P_BWD(CPU_INSTANCE(ref_softmax_bwd_t<f32>))
+-        REG_SOFTMAX_P_FWD(CPU_INSTANCE(ref_softmax_fwd_t<bf16>))
+-        REG_SOFTMAX_P_BWD(CPU_INSTANCE(ref_softmax_bwd_t<bf16>))
++        CPU_INSTANCE_AARCH64_ACL(acl_softmax_fwd_t<f32>)
++        CPU_INSTANCE(ref_softmax_fwd_t<f32>)
++        CPU_INSTANCE(ref_softmax_bwd_t<f32>)
++        CPU_INSTANCE(ref_softmax_fwd_t<bf16>)
++        CPU_INSTANCE(ref_softmax_bwd_t<bf16>)
+         /* eol */
+         nullptr,
+ };
+diff --git a/tests/benchdnn/inputs/softmax/test_softmax_all b/tests/benchdnn/inputs/softmax/test_softmax_all
+index fde8ac007..4e1dbbeaf 100644
+--- a/tests/benchdnn/inputs/softmax/test_softmax_all
++++ b/tests/benchdnn/inputs/softmax/test_softmax_all
+@@ -2,7 +2,7 @@
+ 
+ # f32
+ --dt=f32
+---dir=FWD_D,BWD_D
++--dir=FWD_I,FWD_D,BWD_D
+ --alg=SOFTMAX,LOGSOFTMAX
+ --inplace=true,false
+ 
+diff --git a/tests/benchdnn/inputs/softmax/test_softmax_ci b/tests/benchdnn/inputs/softmax/test_softmax_ci
+index 5b5efa41d..48c786e45 100644
+--- a/tests/benchdnn/inputs/softmax/test_softmax_ci
++++ b/tests/benchdnn/inputs/softmax/test_softmax_ci
+@@ -2,7 +2,7 @@
+ 
+ --inplace=true,false
+ 
+---dir=FWD_D,BWD_D
++--dir=FWD_I,FWD_D,BWD_D
+ --dt=f32,bf16,f16
+ --tag=abx,axb
+ --alg=SOFTMAX,LOGSOFTMAX

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -14,24 +14,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  *******************************************************************************
-diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
-index 1666feb7503..11bbc595f31 100644
---- a/tensorflow/tensorflow.bzl
-+++ b/tensorflow/tensorflow.bzl
-@@ -378,7 +378,7 @@ def tf_copts(
-         # optimizations for Intel builds using oneDNN if configured
-         if_enable_mkl(["-DENABLE_MKL"]) +
-         if_mkldnn_openmp(["-DENABLE_ONEDNN_OPENMP"]) +
--        if_mkldnn_aarch64_acl(["-DENABLE_MKL", "-DENABLE_ONEDNN_OPENMP", "-DDNNL_AARCH64_USE_ACL=1"]) +
-+        if_mkldnn_aarch64_acl(["-DENABLE_ONEDNN_OPENMP", "-DDNNL_AARCH64_USE_ACL=1"]) +
-         if_android_arm(["-mfpu=neon"]) +
-         if_linux_x86_64(["-msse3"]) +
-         if_ios_x86_64(["-msse4.1"]) +
 diff --git a/.bazelrc b/.bazelrc
-index 7724d2a6e69..8f74e580cd9 100644
+index 3425144bf9f..a07e956dc33 100644
 --- a/.bazelrc
 +++ b/.bazelrc
-@@ -217,9 +217,8 @@ build:mkl_threadpool -c opt
+@@ -219,9 +219,8 @@ build:mkl_threadpool -c opt
  
  # Config setting to build oneDNN with Compute Library for the Arm Architecture (ACL).
  # This build is for the inference regime only.
@@ -42,3 +29,28 @@ index 7724d2a6e69..8f74e580cd9 100644
  build:mkl_aarch64 --define=build_with_openmp=true
  build:mkl_aarch64 -c opt
  
+diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
+index c72a0d414bd..06e62f0c3c0 100644
+--- a/tensorflow/tensorflow.bzl
++++ b/tensorflow/tensorflow.bzl
+@@ -388,7 +388,7 @@ def tf_copts(
+         # optimizations for Intel builds using oneDNN if configured
+         if_enable_mkl(["-DENABLE_MKL"]) +
+         if_mkldnn_openmp(["-DENABLE_ONEDNN_OPENMP"]) +
+-        if_mkldnn_aarch64_acl(["-DENABLE_MKL", "-DENABLE_ONEDNN_OPENMP", "-DDNNL_AARCH64_USE_ACL=1"]) +
++        if_mkldnn_aarch64_acl(["-DENABLE_ONEDNN_OPENMP", "-DDNNL_AARCH64_USE_ACL=1"]) +
+         if_android_arm(["-mfpu=neon"]) +
+         if_linux_x86_64(["-msse3"]) +
+         if_ios_x86_64(["-msse4.1"]) +
+diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
+index eaa2863cfaa..feb3bbb6f66 100644
+--- a/tensorflow/workspace2.bzl
++++ b/tensorflow/workspace2.bzl
+@@ -199,6 +199,7 @@ def _tf_repositories():
+     tf_http_archive(
+         name = "mkl_dnn_acl_compatible",
+         build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
++        patch_file = "//third_party/mkl_dnn:mkldnn_acl.patch",
+         sha256 = "a7f2a4d80d5406d156dfc1d7b27d10b0af5ed061cf0b6197d3d12cddc6790fcb",
+         strip_prefix = "oneDNN-2.4",
+         urls = [

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -69,10 +69,13 @@ if [[ $ONEDNN_BUILD ]]; then
       sed -i '/DNNL_AARCH64_USE_ACL/d' ./third_party/mkl_dnn/mkldnn_acl.BUILD
     elif [[ $ONEDNN_BUILD == 'acl' ]]; then
       echo "TensorFlow $TF_VERSION with oneDNN backend - Compute Library build."
-      # Update Bazel build to include onednn_acl_primitives patch
+      # Patch Bazel configuration to include Arm Compute Library build
       patch -p1 < ../tf_acl.patch
-      # Patch TensorFlow to support caching of softmax primitive
-      patch -p1 < ../tf_softmax.patch
+      # Patch to enable bf16 matmul/inneprod in Compute Library
+      # Note: overrites upstream file
+      mv ../compute_library.patch ./third_party/compute_library/.
+      # Patch to enable both softmax caching and bf16 matmul/innerprod in oneDNN
+      mv ../mkldnn_acl.patch ./third_party/mkl_dnn/.
     fi
 else
     echo "TensorFlow $TF_VERSION with Eigen backend."


### PR DESCRIPTION
This patches both ComputeLibrary and oneDNN and removes patch-to-patch approach