### PR TITLE
Adds option to build a TF serving image

### DIFF
--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2020-2021 Arm Limited and affiliates.
+# Copyright 2020-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,6 +38,7 @@ RUN apt-get -y update && \
       apport \
       at \
       autoconf \
+      automake \
       bc \
       build-essential \
       cmake \
@@ -70,6 +71,7 @@ RUN apt-get -y update && \
       libreadline-dev \
       libssl-dev \
       libsqlite3-dev \
+      libtool \
       libxml2-dev \
       libxslt-dev \
       locales \
@@ -94,6 +96,7 @@ RUN apt-get -y update && \
       scons \
       ssh \
       sudo \
+      swig \
       time \
       udev \
       unzip \
@@ -303,6 +306,70 @@ COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh
 
 CMD ["bash", "-l"]
+
+# =========
+# Stage 4b: install Bazel, and build tensorflow-serving
+# =========
+FROM tensorflow-libs AS tensorflow-serving
+ARG njobs
+ARG bazel_mem
+ARG enable_onednn
+ARG onednn_opt
+ARG tfserving_version
+ARG bazel_version
+ARG default_py_version
+ARG cpu
+ARG arch
+
+ENV NP_MAKE="${njobs}" \
+    BZL_RAM="${bazel_mem}" \
+    ONEDNN_BUILD="${onednn_opt}" \
+    CPU="${cpu}" \
+    ARCH="${arch}"
+
+# Key version numbers
+ENV PY_VERSION="${default_py_version}" \
+    BZL_VERSION="${bazel_version}" \
+    TFSERVING_VERSION="${tfserving_version}"
+# Set runtime flag to enable/disable oneDNN backend
+ENV TF_ENABLE_ONEDNN_OPTS="${enable_onednn}"
+
+# gRPC port
+EXPOSE 8500
+# REST port
+EXPOSE 8501
+
+# Model store within the container
+ENV MODEL_BASE_PATH=/home/$DOCKER_USER/models
+RUN mkdir -p ${MODEL_BASE_PATH}
+# MODEL_NAME is updated at runtime with `docker run -e MODEL_NAME=<name> ...`
+ENV MODEL_NAME=model
+
+# Use a PACKAGE_DIR in userspace
+WORKDIR /home/$DOCKER_USER
+USER $DOCKER_USER
+ENV PACKAGE_DIR=/home/$DOCKER_USER/$PACKAGE_DIR
+RUN mkdir -p $PACKAGE_DIR
+
+# Copy in the Python virtual environment
+ENV VENV_DIR=/home/$DOCKER_USER/python3-venv
+COPY --chown=$DOCKER_USER:$DOCKER_USER --from=tensorflow-tools $VENV_DIR /home/$DOCKER_USER/python3-venv
+ENV PATH="$VENV_DIR/bin:$PATH"
+
+# Get Bazel binary for AArch64
+COPY scripts/get-bazel.sh $PACKAGE_DIR/.
+RUN $PACKAGE_DIR/get-bazel.sh
+ENV PATH=$PACKAGE_DIR/bazel:$PATH
+
+# Build TensorFlow Serving
+COPY scripts/build-tensorflow-io-gcs-filesystem.sh $PACKAGE_DIR/.
+RUN $PACKAGE_DIR/build-tensorflow-io-gcs-filesystem.sh
+COPY scripts/build-tensorflow-serving.sh $PACKAGE_DIR/.
+RUN $PACKAGE_DIR/build-tensorflow-serving.sh
+
+# Setup entrypoint for passing model details through `docker run`
+COPY scripts/tf_serving_entrypoint.sh /home/$DOCKER_USER/.
+ENTRYPOINT [ "/bin/bash", "-c", "exec /home/$DOCKER_USER/tf_serving_entrypoint.sh \"${@}\"", "--" ]
 
 # ========
 # Stage 5: Install benchmarks and examples

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow-serving.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow-serving.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+
+# *******************************************************************************
+# Copyright 2022 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+set -euo pipefail
+cd $PACKAGE_DIR
+readonly package=serving
+readonly version=$TFSERVING_VERSION
+readonly src_host=https://github.com/tensorflow
+readonly src_repo=serving
+
+# Clone TensorFlow Serving
+git clone ${src_host}/${src_repo}.git
+cd ${src_repo}
+git checkout $version
+
+extra_args="--verbose_failures -s"
+if [[ $BZL_RAM ]]; then extra_args="$extra_args --local_ram_resources=$BZL_RAM"; fi
+if [[ $NP_MAKE ]]; then extra_args="$extra_args --jobs=$NP_MAKE"; fi
+
+if [[ $ONEDNN_BUILD ]]; then
+    echo "$ONEDNN_BUILD build for $TFSERVING_VERSION"
+    extra_args="$extra_args --config=mkl_aarch64 --linkopt=-fopenmp"
+    if [[ $ONEDNN_BUILD == 'reference' ]]; then
+      echo "TensorFlow $TFSERVING_VERSION with oneDNN backend - reference build."
+      sed -i '/DNNL_AARCH64_USE_ACL/d' ./third_party/mkl_dnn/mkldnn_acl.BUILD
+    elif [[ $ONEDNN_BUILD == 'acl' ]]; then
+      echo "TensorFlow $TFSERVING_VERSION with oneDNN backend - Compute Library build."
+      # Patch Bazel configuration to include Arm Compute Library build
+      wget https://github.com/tensorflow/serving/pull/1953.patch -O ../tfs_acl.patch
+      patch -p1 < ../tfs_acl.patch
+    fi
+else
+    echo "TensorFlow Serving $TFSERVING_VERSION with Eigen backend."
+    extra_args="$extra_args --define tensorflow_mkldnn_contraction_kernel=0"
+fi
+
+# Build the tensorflow configuration
+bazel build $extra_args \
+        --copt="-mcpu=${CPU}" --copt="-march=${ARCH}" --copt="-O3"  --copt="-fopenmp" \
+        --copt="-Wno-maybe-uninitialized" --copt="-Wno-stringop-truncation" --copt="-Wno-deprecated-declarations"\
+        --cxxopt="-mcpu=${CPU}" --cxxopt="-march=${ARCH}" --cxxopt="-O3"  --cxxopt="-fopenmp" \
+        --cxxopt="-Wno-maybe-uninitialized" --cxxopt="-Wno-stringop-truncation" --copt="-Wno-deprecated-declarations" \
+        --linkopt="-lgomp  -lm" \
+        tensorflow_serving/model_servers:tensorflow_model_server \
+        tensorflow_serving/tools/pip_package:build_pip_package
+
+cp ./bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server /home/$DOCKER_USER/tensorflow_model_server
+
+# Install TensorFlow Serving python package via pip
+./bazel-bin/tensorflow_serving/tools/pip_package/build_pip_package $PWD/wheel-TFserving$TFSERVING_VERSION-py$PY_VERSION-$CC
+pip --no-cache-dir install --no-dependencies $(ls -tr wheel-TFserving$TFSERVING_VERSION-py$PY_VERSION-$CC/tensorflow_serving_api-*.whl | tail)
+
+# Check the installation was sucessfull
+if /home/$DOCKER_USER/tensorflow_model_server --version > version.log; then
+    cat version.log
+    echo "installed from $TFSERVING_VERSION branch."
+    bazel clean --expunge
+else
+    echo "TensorFlow Model Server installation failed."
+    exit 1
+fi
+rm version.log

--- a/docker/tensorflow-aarch64/scripts/tf_serving_entrypoint.sh
+++ b/docker/tensorflow-aarch64/scripts/tf_serving_entrypoint.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+
+# *******************************************************************************
+# Copyright 2022 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+# This script provides the entrypoint to serve a TF model supplied from outside
+# Docker process.
+#
+# To run a simple test model...
+#   1. Checkout TF serving:
+#      `git clone https://github.com/tensorflow/serving`
+#   2. Locate demo model to use:
+#      TESTDATA="$(pwd)/serving/tensorflow_serving/servables/tensorflow/testdata"
+#   3. Start TensorFlow Serving container:
+#      - The REST API port (8501) needs to be open.
+#      - This example uses the 'half_plus_two' model.
+#      - The saved model is mounted inside the Docker image in the models
+#         directory inside the default user's home:
+#      ```
+#      docker run -t --rm -p 8501:8501 \
+#       -v "$TESTDATA/saved_model_half_plus_two_cpu:/home/ubuntu/models/half_plus_two" \
+#       -e MODEL_NAME=half_plus_two tensorflow-serving-v2acl &
+#      ```
+#   4. Query the model using the predict API
+#      ```
+#      curl -d '{"instances": [1.0, 2.0, 5.0]}' \
+#        -X POST http://localhost:8501/v1/models/half_plus_two:predict`
+#      ```
+#      This example should return: `{ "predictions": [2.5, 3.0, 4.5] }`
+
+./tensorflow_model_server \
+  --port=8500 \ # gRPC port
+  --rest_api_port=8501 \ # REST API port
+  --model_name=${MODEL_NAME} \ # MODEL_NAME supplied via `docker run`
+  --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} \ # Location of model mounted within the container
+  "$@"


### PR DESCRIPTION
Setting `--build-type serving` when running `build.sh` will generate
a TF serving image.

See https://github.com/tensorflow/serving/blob/master/tensorflow_serving/g3doc/docker.md
for more details of TF serving with Docker.