### PR TITLE
Updates frameworks, adds binary primitive and TF cache fix for memory…

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -145,7 +145,7 @@ ENV NP_MAKE="${njobs}" \
     ACL_ARCH="${acl_arch}"
 
 # Key version numbers
-ENV ACL_VERSION="v21.11" \
+ENV ACL_VERSION="v22.02" \
     OPENBLAS_VERSION=0.3.20 \
     NINJA_VERSION=1.9.0
 

--- a/docker/pytorch-aarch64/README.md
+++ b/docker/pytorch-aarch64/README.md
@@ -51,9 +51,9 @@ where `<image name>` is the name of the image, i.e. `armswdev/pytorch-arm-neover
 
   * OS: Ubuntu 20.04
   * Compiler: GCC 10.3
-  * Maths libraries: [Arm Optimized Routines](https://github.com/ARM-software/optimized-routines) and [OpenBLAS](https://www.openblas.net/) 0.3.19
+  * Maths libraries: [Arm Optimized Routines](https://github.com/ARM-software/optimized-routines) and [OpenBLAS](https://www.openblas.net/) 0.3.20
   * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.5
-    - ACL 21.11, provides optimized implementations on AArch64 for main oneDNN primitives
+    - ACL 22.02, provides optimized implementations on AArch64 for main oneDNN primitives
   * Python 3.8.10 environment containing:
     - NumPy 1.21.5
     - SciPy 1.7.3

--- a/docker/pytorch-aarch64/examples/answer_questions.py
+++ b/docker/pytorch-aarch64/examples/answer_questions.py
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,7 +109,9 @@ def main():
         "distilbert-base-uncased-distilled-squad"
     )
 
-    encoding = token.encode_plus(question, context)
+    encoding = token.encode_plus(
+        token(question, max_length=512, truncation=True).input_ids,
+        token(context, max_length=512, truncation=True).input_ids)
 
     input_ids, attention_mask = (
         encoding["input_ids"],

--- a/docker/pytorch-aarch64/scripts/build-acl.sh
+++ b/docker/pytorch-aarch64/scripts/build-acl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020-2021 Arm Limited and affiliates.
+# Copyright 2020-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -37,13 +37,13 @@ git checkout $version
 arch=${ACL_ARCH:-"arm64-v8a"}
 echo "Compute Library arch = ${arch}"
 
-fat_binary=0
+multi_isa=0
 
-[[ "$arch" == "armv8.2-a" ]] && fat_binary=1
+[[ "$arch" == "armv8.2-a" ]] || [[ "$arch" == "armv8a" ]] && multi_isa=1
 
 # Build with scons
-scons -j16  Werror=0 debug=0 neon=1 gles_compute=0 embed_kernels=0 \
-  os=linux arch=$arch build=native fat_binary=$fat_binary \
+scons -j16  Werror=0 debug=0 neon=1 opencl=0 embed_kernels=0 \
+  os=linux arch=$arch build=native multi_isa=$multi_isa \
   build_dir=$install_dir/build
 
 cp -r arm_compute $install_dir

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020-2021 Arm Limited and affiliates.
+# Copyright 2020-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -241,7 +241,7 @@ RUN pip install --no-cache-dir ck==1.55.5 absl-py pycocotools pillow==8.2.0
 RUN pip install --no-cache-dir transformers pandas
 
 # Install OpenCV into our venv (needed for MLCommons benchmarks)
-RUN pip install --no-cache-dir opencv-python-headless==4.4.0.46
+RUN pip install --no-cache-dir opencv-python-headless
 
 CMD ["bash", "-l"]
 

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -51,9 +51,9 @@ where `<image name> `is the name of the image, i.e. `armswdev/tensorflow-arm-neo
 
   * OS: Ubuntu 20.04
   * Compiler: GCC 10.3
-  * Maths libraries: [OpenBLAS](https://www.openblas.net/) 0.3.19, used for NumPy's BLAS functionality
+  * Maths libraries: [OpenBLAS](https://www.openblas.net/) 0.3.20, used for NumPy's BLAS functionality
   * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.5
-    - ACL 21.11, provides optimized implementations on AArch64 for main oneDNN primitives
+    - ACL 22.02, provides optimized implementations on AArch64 for main oneDNN primitives
   * Python 3.8.10 environment containing:
     - NumPy 1.21.5
     - SciPy 1.7.3

--- a/docker/tensorflow-aarch64/examples/py-api/answer_questions.py
+++ b/docker/tensorflow-aarch64/examples/py-api/answer_questions.py
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -131,7 +131,9 @@ def main():
         "distilbert-base-uncased-distilled-squad"
     )
 
-    encoding = token.encode_plus(question, context)
+    encoding = token.encode_plus(
+        token(question, max_length=512, truncation=True).input_ids,
+        token(context, max_length=512, truncation=True).input_ids)
 
     input_ids, attention_mask = (
         encoding["input_ids"],

--- a/docker/tensorflow-aarch64/patches/compute_library.patch
+++ b/docker/tensorflow-aarch64/patches/compute_library.patch
@@ -1,5 +1,5 @@
  *******************************************************************************
- Copyright 2021 Arm Limited and affiliates.
+ Copyright 2022 Arm Limited and affiliates.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ index 000000000..c986ad52a
 --- /dev/null
 +++ b/arm_compute_version.embed
 @@ -0,0 +1,1 @@
-+"arm_compute_version=v21.11 Build options: {} Git hash=b'N/A'"
++"arm_compute_version=v22.02 Build options: {} Git hash=b'N/A'"
 \ No newline at end of file
 diff --git a/arm_compute/runtime/CPP/SpinWaitCPPScheduler.h b/arm_compute/runtime/CPP/SpinWaitCPPScheduler.h
 new file mode 100644
@@ -29,7 +29,7 @@ index 000000000..ad4d8537b
 +++ b/arm_compute/runtime/CPP/SpinWaitCPPScheduler.h
 @@ -0,0 +1,67 @@
 +/*
-+ * Copyright (c) 2021 Arm Limited.
++ * Copyright (c) 2022 Arm Limited.
 + *
 + * SPDX-License-Identifier: MIT
 + *
@@ -115,7 +115,7 @@ index 000000000..76bf9637a
 +++ b/src/runtime/CPP/SpinWaitCPPScheduler.cpp
 @@ -0,0 +1,345 @@
 +/*
-+ * Copyright (c) 2021 Arm Limited.
++ * Copyright (c) 2022 Arm Limited.
 + *
 + * SPDX-License-Identifier: MIT
 + *
@@ -317,10 +317,10 @@ index 000000000..76bf9637a
 +
 +        while(!(_thr_start->load()));
 +
-+	if(_thr_stop->load())
-+	{
-+	    break;
-+	}
++        if(_thr_stop->load())
++        {
++            break;
++        }
 +
 +        if(_info.thread_id < int(_num_threads_to_use->load()) - 1)
 +        {
@@ -350,15 +350,15 @@ index 000000000..76bf9637a
 +    {
 +        _num_threads = num_threads == 0 ? thread_hint : num_threads;
 +        _threads.resize(_num_threads - 1);
-+	auto thread_it = _threads.begin();
-+	unsigned int tid = 0;
-+	for(; thread_it != _threads.end(); ++tid, ++thread_it)
-+	{
-+	    thread_it->set_thread_info(tid, &CPUInfo::get());
-+	    thread_it->set_sched(&_thr_start, &_thr_stop, &_thr_remain, &_thr_restarts);
-+	    thread_it->set_workload(&_workloads, &_feeder);
-+	    thread_it->start(&_num_threads_to_use);
-+	}
++        auto thread_it = _threads.begin();
++        unsigned int tid = 0;
++        for(; thread_it != _threads.end(); ++tid, ++thread_it)
++        {
++            thread_it->set_thread_info(tid, &CPUInfo::get());
++            thread_it->set_sched(&_thr_start, &_thr_stop, &_thr_remain, &_thr_restarts);
++            thread_it->set_workload(&_workloads, &_feeder);
++            thread_it->start(&_num_threads_to_use);
++        }
 +
 +    }
 +

--- a/docker/tensorflow-aarch64/patches/onednn_acl.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl.patch
@@ -14,10 +14,347 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  *******************************************************************************
+diff --git a/src/cpu/aarch64/acl_binary.cpp b/src/cpu/aarch64/acl_binary.cpp
+new file mode 100644
+index 0000000000..d82e075211
+--- /dev/null
++++ b/src/cpu/aarch64/acl_binary.cpp
+@@ -0,0 +1,55 @@
++/*******************************************************************************
++* Copyright 2022 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_binary.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++status_t acl_binary_t::execute_forward(const exec_ctx_t &ctx) const {
++
++    auto src0 = CTX_IN_MEM(const void *, DNNL_ARG_SRC_0);
++    auto src1 = CTX_IN_MEM(const void *, DNNL_ARG_SRC_1);
++    auto dst = CTX_OUT_MEM(void *, DNNL_ARG_DST);
++
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
++
++    // Retrieve primitive resource and configured Compute Library objects
++    acl_binary_obj_t &acl_obj = ctx.get_resource_mapper()
++                                        ->get<acl_binary_resource_t>(this)
++                                        ->get_acl_obj();
++
++    acl_obj.src0_tensor.allocator()->import_memory(const_cast<void *>(src0));
++    acl_obj.src1_tensor.allocator()->import_memory(const_cast<void *>(src1));
++    acl_obj.dst_tensor.allocator()->import_memory(dst);
++
++    acl_obj.binary_op->run();
++
++    acl_obj.src0_tensor.allocator()->free();
++    acl_obj.src1_tensor.allocator()->free();
++    acl_obj.dst_tensor.allocator()->free();
++
++    return status::success;
++}
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_binary.hpp b/src/cpu/aarch64/acl_binary.hpp
+new file mode 100644
+index 0000000000..77adb45bef
+--- /dev/null
++++ b/src/cpu/aarch64/acl_binary.hpp
+@@ -0,0 +1,263 @@
++/*******************************************************************************
++* Copyright 2022 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed tos in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_BINARY_HPP
++#define CPU_AARCH64_ACL_BINARY_HPP
++
++#include "cpu/cpu_binary_pd.hpp"
++
++#include "cpu/aarch64/acl_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_binary_obj_t {
++    std::unique_ptr<arm_compute::IFunction> binary_op;
++    arm_compute::Tensor src0_tensor;
++    arm_compute::Tensor src1_tensor;
++    arm_compute::Tensor dst_tensor;
++};
++
++struct acl_binary_conf_t {
++    arm_compute::TensorInfo src0_info;
++    arm_compute::TensorInfo src1_info;
++    arm_compute::TensorInfo dst_info;
++    alg_kind_t alg;
++};
++
++struct acl_binary_resource_t : public resource_t {
++    acl_binary_resource_t()
++        : acl_obj_(utils::make_unique<acl_binary_obj_t>()) {}
++
++    status_t configure(const acl_binary_conf_t &asp) {
++        if (!acl_obj_) return status::out_of_memory;
++
++        // Init Compute Library tensors based on info from descriptor
++        acl_obj_->src0_tensor.allocator()->init(asp.src0_info);
++        acl_obj_->src1_tensor.allocator()->init(asp.src1_info);
++        acl_obj_->dst_tensor.allocator()->init(asp.dst_info);
++
++        switch (asp.alg) {
++            case alg_kind::binary_add: {
++                auto add_op
++                        = std::make_unique<arm_compute::NEArithmeticAddition>();
++                add_op->configure(&acl_obj_->src0_tensor,
++                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor,
++                        arm_compute::ConvertPolicy::SATURATE);
++                acl_obj_->binary_op = std::move(add_op);
++                break;
++            }
++            case alg_kind::binary_sub: {
++                auto sub_op = std::make_unique<
++                        arm_compute::NEArithmeticSubtraction>();
++                sub_op->configure(&acl_obj_->src0_tensor,
++                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor,
++                        arm_compute::ConvertPolicy::SATURATE);
++                acl_obj_->binary_op = std::move(sub_op);
++                break;
++            }
++            case alg_kind::binary_div: {
++                auto div_op = std::make_unique<
++                        arm_compute::NEElementwiseDivision>();
++                div_op->configure(&acl_obj_->src0_tensor,
++                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor);
++                acl_obj_->binary_op = std::move(div_op);
++                break;
++            }
++            case alg_kind::binary_mul: {
++                auto mul_op = std::make_unique<
++                        arm_compute::NEPixelWiseMultiplication>();
++                mul_op->configure(&acl_obj_->src0_tensor,
++                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor, 1.0f,
++                        arm_compute::ConvertPolicy::SATURATE,
++                        arm_compute::RoundingPolicy::TO_ZERO);
++                acl_obj_->binary_op = std::move(mul_op);
++                break;
++            }
++            case alg_kind::binary_min: {
++                auto min_op = std::make_unique<arm_compute::NEElementwiseMin>();
++                min_op->configure(&acl_obj_->src0_tensor,
++                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor);
++                acl_obj_->binary_op = std::move(min_op);
++                break;
++            }
++            case alg_kind::binary_max: {
++                auto max_op = std::make_unique<arm_compute::NEElementwiseMax>();
++                max_op->configure(&acl_obj_->src0_tensor,
++                        &acl_obj_->src1_tensor, &acl_obj_->dst_tensor);
++                acl_obj_->binary_op = std::move(max_op);
++                break;
++            }
++            default: return status::runtime_error;
++        }
++
++        return status::success;
++    }
++
++    acl_binary_obj_t &get_acl_obj() const { return *acl_obj_; }
++
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_binary_resource_t);
++
++private:
++    std::unique_ptr<acl_binary_obj_t> acl_obj_;
++}; // acl_binary_resource_t
++
++struct acl_binary_t : public primitive_t {
++    struct pd_t : public cpu_binary_pd_t {
++        using cpu_binary_pd_t::cpu_binary_pd_t;
++
++        DECLARE_COMMON_PD_T("acl", acl_binary_t);
++
++        status_t init(engine_t *engine) {
++
++            using namespace acl_common_utils;
++
++            // Only support f32 and s32 for now
++            data_type_t ddt = dst_md(0)->data_type;
++            if (ddt != data_type::f32 && ddt != data_type::s32)
++                return status::unimplemented;
++
++            // Only support src and dst all matching for now
++            if (ddt != src_md(0)->data_type || src_md(1)->data_type != ddt)
++                return status::unimplemented;
++
++            // Sets the memory format of dst from any to src_md(0) blocking desc
++            CHECK(set_default_params());
++
++            if (!attr()->has_default_values()) return status::unimplemented;
++
++            asp_.alg = desc()->alg_kind;
++
++            // All the algorithms we support
++            if (!utils::one_of(asp_.alg, alg_kind::binary_add,
++                        alg_kind::binary_sub, alg_kind::binary_mul,
++                        alg_kind::binary_div, alg_kind::binary_max,
++                        alg_kind::binary_min))
++                return status::unimplemented;
++
++            // s32 div in ACL does not round as oneDNN expects
++            if (ddt == data_type::s32 && asp_.alg == alg_kind::binary_div)
++                return status::unimplemented;
++
++            // ACL pointwise arithmetic operators assume that the innermost
++            // dimensions are dense for src0, src1 and dst. So we try to permute
++            // the logical dims so that the innermost dim on each desc is dense
++            // (without any data reordering)
++            memory_desc_t src_d0_permed, src_d1_permed, dst_d_permed;
++            CHECK(permute_common_dense_dimension_to_last(&src_d0_permed,
++                    &src_d1_permed, &dst_d_permed, src_md(0), src_md(1),
++                    dst_md()));
++
++            // Create ACL tensor infos with permuted descs
++            CHECK(tensor_info(asp_.src0_info, src_d0_permed));
++            CHECK(tensor_info(asp_.src1_info, src_d1_permed));
++            CHECK(tensor_info(asp_.dst_info, dst_d_permed));
++
++            // This forces ACL not to parallelise with small workloads, this is
++            // a temporary fix and should be removed in future versions (TODO)
++            memory_desc_wrapper dst_d(dst_md());
++            if (dst_d.nelems() < 40000) {
++                size_t acl_y_axis_i = 1;
++                CHECK(insert_singleton_dimension(asp_.src0_info, acl_y_axis_i));
++                CHECK(insert_singleton_dimension(asp_.src1_info, acl_y_axis_i));
++                CHECK(insert_singleton_dimension(asp_.dst_info, acl_y_axis_i));
++            }
++
++            // Call operator specific validate function to check support
++            arm_compute::Status acl_st = validate(asp_);
++            if (acl_st.error_code() != arm_compute::ErrorCode::OK) {
++                MAYBE_REPORT_ACL_ERROR(acl_st.error_description().c_str());
++                return status::unimplemented;
++            }
++
++            // Initialize the ACL threads
++            acl_thread_bind();
++
++            return status::success;
++        }
++
++        acl_binary_conf_t asp_;
++
++    private:
++        arm_compute::Status validate(const acl_binary_conf_t &asp) {
++            switch (asp.alg) {
++                case alg_kind::binary_add:
++                    return arm_compute::NEArithmeticAddition::validate(
++                            &asp.src0_info, &asp.src1_info, &asp.dst_info,
++                            arm_compute::ConvertPolicy::SATURATE);
++                case alg_kind::binary_sub:
++                    return arm_compute::NEArithmeticSubtraction::validate(
++                            &asp.src0_info, &asp.src1_info, &asp.dst_info,
++                            arm_compute::ConvertPolicy::SATURATE);
++                case alg_kind::binary_div:
++                    return arm_compute::NEElementwiseDivision::validate(
++                            &asp.src0_info, &asp.src1_info, &asp.dst_info);
++                case alg_kind::binary_mul:
++                    return arm_compute::NEPixelWiseMultiplication::validate(
++                            &asp.src0_info, &asp.src1_info, &asp.dst_info, 1.0f,
++                            arm_compute::ConvertPolicy::SATURATE,
++                            arm_compute::RoundingPolicy::TO_ZERO);
++                case alg_kind::binary_min:
++                    return arm_compute::NEElementwiseMin::validate(
++                            &asp.src0_info, &asp.src1_info, &asp.dst_info);
++                case alg_kind::binary_max:
++                    return arm_compute::NEElementwiseMax::validate(
++                            &asp.src0_info, &asp.src1_info, &asp.dst_info);
++                default:
++                    return arm_compute::Status(
++                            arm_compute::ErrorCode::RUNTIME_ERROR,
++                            "unsupported alg_kind");
++            }
++        }
++
++    }; // pd_t
++
++    acl_binary_t(const pd_t *apd) : primitive_t(apd) {}
++
++    status_t create_resource(
++            engine_t *engine, resource_mapper_t &mapper) const override {
++        if (mapper.has_resource(this)) return status::success;
++
++        auto r = utils::make_unique<acl_binary_resource_t>();
++        if (!r) return status::out_of_memory;
++
++        // Configure the resource based on information from primitive descriptor
++        auto st = r->configure(pd()->asp_);
++        if (st == status::success) { mapper.add(this, std::move(r)); }
++
++        return st;
++    }
++
++    status_t execute(const exec_ctx_t &ctx) const override {
++        return execute_forward(ctx);
++    }
++
++private:
++    // To guard the const execute_forward, the mutex must be 'mutable'
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++
++}; // acl_binary_t
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif
 diff --git a/src/cpu/aarch64/acl_utils.cpp b/src/cpu/aarch64/acl_utils.cpp
-index ed1376dbf..84a7ff639 100644
+index ed1376dbf5..978472c615 100644
 --- a/src/cpu/aarch64/acl_utils.cpp
 +++ b/src/cpu/aarch64/acl_utils.cpp
+@@ -1,5 +1,5 @@
+ /*******************************************************************************
+-* Copyright 2021 Arm Ltd. and affiliates
++* Copyright 2021-2022 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
 @@ -105,7 +105,11 @@ void acl_thread_bind() {
      static std::once_flag flag_once;
      // The threads in Compute Library are bound for the cores 0..max_threads-1
@@ -31,3 +368,213 @@ index ed1376dbf..84a7ff639 100644
      // arm_compute::Scheduler does not support concurrent access thus a
      // workaround here restricts it to only one call
      std::call_once(flag_once, [&]() {
+@@ -113,6 +117,140 @@ void acl_thread_bind() {
+     });
+ }
+ 
++status_t tensor_info(arm_compute::TensorInfo &info, const memory_desc_t &md) {
++    const memory_desc_wrapper md_wrap(&md);
++    return tensor_info(info, md_wrap);
++}
++
++status_t tensor_info(
++        arm_compute::TensorInfo &info, const memory_desc_wrapper &md) {
++
++    // All the cases we don't support
++    if (!md.is_blocking_desc() || !md.is_dense() || !md.is_plain()
++            || md.has_zero_dim())
++        return status::unimplemented;
++
++    // Set each of the dimensions in the TensorShape from the memory desc
++    // ACL indexes dimensions the opposite way to oneDNN
++    arm_compute::TensorShape shape;
++    size_t acl_dim_i = 0;
++    for (int i = md.ndims() - 1; i >= 0; --i) {
++        shape.set(acl_dim_i, md.dims()[i]);
++        acl_dim_i++;
++    }
++
++    // Set each of the ACL Strides from the memory blocking desc
++    // ACL indexes strides the opposite way to oneDNN
++    arm_compute::Strides strides_in_bytes;
++    const blocking_desc_t &blocking_desc = md.blocking_desc();
++    size_t acl_stride_i = 0;
++    for (int i = md.ndims() - 1; i >= 0; --i) {
++        // ACL strides are in bytes, oneDNN strides are in numbers of elements,
++        // multiply by data type size to convert
++        strides_in_bytes.set(
++                acl_stride_i, blocking_desc.strides[i] * md.data_type_size());
++        ++acl_stride_i;
++    }
++
++    arm_compute::DataType data_type = get_acl_data_t(md.data_type());
++    size_t num_channels = 1;
++    size_t offset_first_element_in_bytes = 0;
++    size_t total_size_in_bytes = md.size();
++
++    info.init(shape, num_channels, data_type, strides_in_bytes,
++            offset_first_element_in_bytes, total_size_in_bytes);
++
++    return status::success;
++}
++
++status_t insert_singleton_dimension(arm_compute::TensorInfo &ti, size_t dim_i) {
++
++    // Max 6 dims in ACL, so we can't insert another
++    if (ti.num_dimensions() >= 6) return status::unimplemented;
++
++    // Copy dimensions from old to new shape, inserting a dimension of size 1
++    arm_compute::TensorShape shape = ti.tensor_shape();
++    for (size_t old_i = 0, new_i = 0; old_i < ti.num_dimensions(); ++old_i) {
++        if (old_i == dim_i) {
++            shape.set(new_i, 1, false);
++            ++new_i;
++        }
++        shape.set(new_i, ti.tensor_shape()[old_i], false);
++        ++new_i;
++    }
++
++    // Copy strides from old to new tensor, inserting a duplicate stride
++    arm_compute::Strides strides;
++    for (size_t old_i = 0, new_i = 0; old_i < ti.num_dimensions(); ++old_i) {
++        if (old_i == dim_i) {
++            strides.set(new_i, ti.strides_in_bytes()[old_i], false);
++            ++new_i;
++        }
++        strides.set(new_i, ti.strides_in_bytes()[old_i], false);
++        ++new_i;
++    }
++
++    // Reinit TensorInfo with modified shape and strides
++    ti.init(shape, ti.num_channels(), ti.data_type(), strides,
++            ti.offset_first_element_in_bytes(), ti.total_size());
++
++    return status::success;
++}
++
++status_t permute_common_dense_dimension_to_last(memory_desc_t *d0_permed,
++        memory_desc_t *d1_permed, memory_desc_t *d2_permed,
++        const memory_desc_t *d0, const memory_desc_t *d1,
++        const memory_desc_t *d2) {
++
++    // Number of dimensions must match
++    int ndims = d0->ndims;
++    if (ndims != d1->ndims || ndims != d2->ndims) return status::unimplemented;
++
++    if (d0->format_kind != format_kind::blocked
++            || d1->format_kind != format_kind::blocked
++            || d2->format_kind != format_kind::blocked)
++        return status::unimplemented;
++
++    const dnnl_dims_t &d0_strides = d0->format_desc.blocking.strides;
++    const dnnl_dims_t &d1_strides = d1->format_desc.blocking.strides;
++    const dnnl_dims_t &d2_strides = d2->format_desc.blocking.strides;
++
++    int inner_dim = ndims - 1;
++
++    // descs already share a common dense axis, no need to permute, just copy
++    // By dense we mean that it has a stride of 1
++    if (d0_strides[inner_dim] == 1 && d1_strides[inner_dim] == 1
++            && d2_strides[inner_dim] == 1) {
++        *d0_permed = *d0;
++        *d1_permed = *d1;
++        *d2_permed = *d2;
++        return status::success;
++    }
++
++    // Create permutation which swaps nothing
++    std::vector<int> perm(ndims);
++    for (int i = inner_dim; i >= 0; --i) {
++        perm[i] = i;
++    }
++
++    // Look for the innermost common dense axis
++    for (int i = inner_dim; i >= 0; --i) {
++        if (d0_strides[i] == 1 && d1_strides[i] == 1 && d2_strides[i] == 1) {
++            // We have found it! Swap this dimension with inner one
++            perm[i] = inner_dim;
++            perm[inner_dim] = i;
++            break;
++        }
++        // Got to the outermost dimension without finding a common dense axis
++        if (i == 0) return status::unimplemented;
++    }
++
++    dnnl_memory_desc_permute_axes(d0_permed, d0, perm.data());
++    dnnl_memory_desc_permute_axes(d1_permed, d1, perm.data());
++    dnnl_memory_desc_permute_axes(d2_permed, d2, perm.data());
++    return status::success;
++}
++
+ } // namespace acl_common_utils
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/aarch64/acl_utils.hpp b/src/cpu/aarch64/acl_utils.hpp
+index ca4500da53..565cde66a9 100644
+--- a/src/cpu/aarch64/acl_utils.hpp
++++ b/src/cpu/aarch64/acl_utils.hpp
+@@ -1,5 +1,5 @@
+ /*******************************************************************************
+-* Copyright 2021 Arm Ltd. and affiliates
++* Copyright 2021-2022 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -46,6 +46,28 @@ arm_compute::ActivationLayerInfo get_acl_act(const eltwise_desc_t &ed);
+ bool acl_act_ok(alg_kind_t eltwise_activation);
+ void acl_thread_bind();
+ 
++// Convert a memory desc to an arm_compute::TensorInfo. Note that memory desc
++// must be blocking format, plain, dense and have no zero dimensions.
++status_t tensor_info(arm_compute::TensorInfo &info, const memory_desc_t &md);
++status_t tensor_info(
++        arm_compute::TensorInfo &info, const memory_desc_wrapper &md);
++
++// Insert a dimension of size 1 at the index dim_i of TensorInfo
++status_t insert_singleton_dimension(arm_compute::TensorInfo &ti, size_t dim_i);
++
++// Copy the memory descs {d0, d1, d2} to {d0_perm, d1_perm, d2_perm}, but with
++// the dimensions permuted so that their last logical dimensions are all dense
++// (stride of 1). The function finds the highest indexed dimension with a
++// stride of 1 for all descs (common). Then it permutes this to be the last
++// dimension. Note that the last dimension is the one that is dense in an
++// unpermuted tensor, in this case it would copy the descs unchanged. The
++// function may fail to find a common dense dimension, and will return
++// unimplemented.
++status_t permute_common_dense_dimension_to_last(memory_desc_t *d0_permed,
++        memory_desc_t *d1_permed, memory_desc_t *d2_permed,
++        const memory_desc_t *d0, const memory_desc_t *d1,
++        const memory_desc_t *d2);
++
+ #define MAYBE_REPORT_ACL_ERROR(msg) \
+     do { \
+         if (get_verbose()) printf("onednn_verbose,cpu,error,acl,%s\n", (msg)); \
+diff --git a/src/cpu/cpu_binary_list.cpp b/src/cpu/cpu_binary_list.cpp
+index 83db8d2247..99606e5866 100644
+--- a/src/cpu/cpu_binary_list.cpp
++++ b/src/cpu/cpu_binary_list.cpp
+@@ -1,5 +1,6 @@
+ /*******************************************************************************
+ * Copyright 2019-2021 Intel Corporation
++* Copyright 2022 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -21,6 +22,9 @@
+ #if DNNL_X64
+ #include "cpu/x64/jit_uni_binary.hpp"
+ using namespace dnnl::impl::cpu::x64;
++#elif DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
++#include "cpu/aarch64/acl_binary.hpp"
++using namespace dnnl::impl::cpu::aarch64;
+ #endif
+ 
+ namespace dnnl {
+@@ -33,6 +37,7 @@ using namespace dnnl::impl::data_type;
+ // clang-format off
+ const impl_list_item_t impl_list[] = REG_BINARY_P({
+         CPU_INSTANCE_X64(jit_uni_binary_t)
++        CPU_INSTANCE_AARCH64_ACL(acl_binary_t)
+         CPU_INSTANCE(ref_binary_t)
+         /* eol */
+         nullptr,

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -15,7 +15,7 @@
  limitations under the License.
  *******************************************************************************
 diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
-index 60deadb1962..ad36923363c 100644
+index 60deadb1962..1c6db042a64 100644
 --- a/tensorflow/workspace2.bzl
 +++ b/tensorflow/workspace2.bzl
 @@ -183,6 +183,7 @@ def _tf_repositories():
@@ -26,10 +26,41 @@ index 60deadb1962..ad36923363c 100644
          sha256 = "d7a47caeb28d2c67dc8fa0d0f338b11fbf25b473a608f04cfed913aea88815a9",
          strip_prefix = "oneDNN-2.5",
          urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.5.tar.gz"),
+@@ -190,11 +191,11 @@ def _tf_repositories():
+ 
+     tf_http_archive(
+         name = "compute_library",
+-        sha256 = "8322ed2e135999569082a95e7fbb2fa87786ffb1c67935b3ef71e00b53f2c887",
+-        strip_prefix = "ComputeLibrary-21.11",
++        sha256 = "11244b05259fb1c4af7384d0c3391aeaddec8aac144774207582db4842726540",
++        strip_prefix = "ComputeLibrary-22.02",
+         build_file = "//third_party/compute_library:BUILD",
+         patch_file = ["//third_party/compute_library:compute_library.patch"],
+-        urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v21.11.tar.gz"),
++        urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.02.tar.gz"),
+     )
+ 
+     tf_http_archive(
 diff --git a/third_party/compute_library/BUILD b/third_party/compute_library/BUILD
-index e15c3104c92..7aaa225ab31 100644
+index e15c3104c92..e4f42b46d5c 100644
 --- a/third_party/compute_library/BUILD
 +++ b/third_party/compute_library/BUILD
+@@ -91,6 +91,7 @@ cc_library(
+             "src/cpu/utils/*.cpp",
+             "src/cpu/kernels/internal/*.cpp",
+             "src/cpu/kernels/**/neon/*.cpp",
++            "src/cpu/kernels/**/nchw/*.cpp",
+             "src/core/NEON/kernels/arm_gemm/*.cpp",
+             "**/*.h",
+         ],
+@@ -103,7 +104,6 @@ cc_library(
+             "src/gpu/**",
+         ],
+     ) + [
+-        "src/cpu/kernels/pool2d/neon/nchw/all.cpp",
+         "src/core/CPP/CPPTypes.cpp",
+         "src/c/operators/AclActivation.cpp",
+         "src/core/NEON/kernels/arm_conv/pooling/kernels/cpp_nhwc_1x1_stride_any_depthfirst/generic.cpp",
 @@ -119,7 +119,7 @@ cc_library(
      ]) + [
          "arm_compute_version.embed",
@@ -39,3 +70,645 @@ index e15c3104c92..7aaa225ab31 100644
      defines = _COMPUTE_LIBRARY_DEFINES,
      includes = [
          "arm_compute/runtime",
+diff --git a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+index b55de4958ae..4f2657b356a 100644
+--- a/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
++++ b/tensorflow/core/kernels/mkl/mkl_batch_matmul_op.cc
+@@ -143,8 +143,8 @@ class BatchMatMulMkl : public OpKernel {
+     // For matmul, the previous approach (PR #47775) of using Tensor addresses
+     // does not work, as the addresses are re-used in matmul with different data
+     // The counter  ensure we still benefit from caching via SetMklMatmul().
+-    static int counter = 1;
+-    params->aarch64_counter = counter++;
++    params->aarch64_counter =
++      MklMatMulPrimitiveFactory<float, Tlhs, Trhs, Toutput>::IncrementCounter();
+ #endif
+     this->ExtendMklMatMulParams(ctx, *params);
+ 
+diff --git a/tensorflow/core/kernels/mkl/mkl_concat_op.cc b/tensorflow/core/kernels/mkl/mkl_concat_op.cc
+index 0d970e46ace..4d7298b5b18 100644
+--- a/tensorflow/core/kernels/mkl/mkl_concat_op.cc
++++ b/tensorflow/core/kernels/mkl/mkl_concat_op.cc
+@@ -32,6 +32,7 @@ limitations under the License.
+ #include "tensorflow/core/lib/core/status.h"
+ #include "tensorflow/core/platform/types.h"
+ #include "tensorflow/core/util/mkl_util.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::concat;
+ using dnnl::stream;
+@@ -279,6 +280,7 @@ class MklConcatFwdPrimitive : public MklPrimitive {
+                const dnnl::memory& dst_data,
+                const MklConcatFwdParams& concat_fwd_dims,
+                std::shared_ptr<stream> fwd_stream) {
++    mutex_lock lock(mu_);
+     DCHECK_EQ(in_data.size(), context_.data_mem.size());
+     for (size_t i = 0; i < concat_fwd_dims.num_inputs; i++) {
+ #ifndef ENABLE_ONEDNN_OPENMP
+@@ -375,6 +377,8 @@ class MklConcatFwdPrimitive : public MklPrimitive {
+   }
+ 
+   struct ConcatFwdContext context_;
++
++  mutex mu_;
+ };
+ 
+ // Class to create/cache the mkl concat primitives based on the
+diff --git a/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc b/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
+index 4065143bff0..54fdbe7bc82 100644
+--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
++++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_filter_ops.cc
+@@ -23,6 +23,7 @@ limitations under the License.
+ #include "tensorflow/core/kernels/mkl/mkl_conv_ops.h"
+ #include "tensorflow/core/util/use_cudnn.h"
+ #include "tensorflow/core/util/work_sharder.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::convolution_backward_weights;
+ using dnnl::memory;
+@@ -88,6 +89,7 @@ class MklConvBwdFilterPrimitive : public MklPrimitive {
+   void Execute(const T* src_data, const T* diff_filter_data,
+                const T* diff_bias_data, const T* diff_dst_data,
+                std::shared_ptr<stream> bwd_filter_stream) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     // TODO(intel-tf): Create a common function and avoid the duplicate code
+     context_.src_mem->set_data_handle(
+@@ -273,6 +275,8 @@ class MklConvBwdFilterPrimitive : public MklPrimitive {
+   }
+ 
+   struct ConvBwdFilterContext context_;
++
++  mutex mu_;
+ };
+ 
+ template <typename T>
+diff --git a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+index 76a314ca700..a2cdf17bb72 100644
+--- a/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
++++ b/tensorflow/core/kernels/mkl/mkl_conv_grad_input_ops.cc
+@@ -30,6 +30,7 @@ limitations under the License.
+ #include "tensorflow/core/kernels/mkl/mkl_conv_ops.h"
+ #include "tensorflow/core/util/use_cudnn.h"
+ #include "tensorflow/core/util/work_sharder.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::convolution_backward_data;
+ using dnnl::prop_kind;
+@@ -90,6 +91,7 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
+   void Execute(const T* diff_src_data, const T* filter_data,
+                const T* diff_dst_data,
+                std::shared_ptr<stream> bwd_input_stream) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     // TODO(intel-tf): Create a common function and avoid the duplicate code
+     context_.diff_src_mem->set_data_handle(
+@@ -219,6 +221,7 @@ class MklConvBwdInputPrimitive : public MklPrimitive {
+   }
+ 
+   struct ConvBwdInputContext context_;
++  mutex mu_;
+ };
+ 
+ template <typename T>
+diff --git a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+index bc4fddfb12c..4d44a1417d1 100644
+--- a/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
++++ b/tensorflow/core/kernels/mkl/mkl_conv_ops.cc
+@@ -26,6 +26,7 @@ limitations under the License.
+ #include "absl/strings/str_join.h"
+ #include "tensorflow/core/kernels/mkl/mkl_quantized_conv_ops.h"
+ #include "tensorflow/core/kernels/no_op.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::convolution_forward;
+ using dnnl::prop_kind;
+@@ -109,6 +110,10 @@ class MklConvFwdPrimitive : public MklPrimitive {
+                const Tinput* bn_scale_data, const Tinput* bn_mean_data,
+                const Tinput* bn_offset_data, const Tinput* bn_rsqrt_data,
+                std::shared_ptr<stream> fwd_stream) {
++    // when we are using single global cache then in this case
++    // we can have multiple threads running the same primitive
++    // that we created so this should happen under the lock
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     // TODO(intel-tf): Create a common function and avoid the duplicate code
+     context_.src_mem->set_data_handle(
+@@ -399,6 +404,9 @@ class MklConvFwdPrimitive : public MklPrimitive {
+   }
+ 
+   struct ConvFwdContext context_;
++
++  // Guards Execution()
++  mutex mu_;
+ };
+ 
+ // TODO(intel-tf): We should not require passing a type to MklPrimitiveFactory.
+diff --git a/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h b/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
+index ae6f3b0de0c..3bbd7e2f704 100644
+--- a/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
++++ b/tensorflow/core/kernels/mkl/mkl_eltwise_activation_base_op.h
+@@ -30,6 +30,7 @@ limitations under the License.
+ #include "tensorflow/core/framework/tensor.h"
+ #include "tensorflow/core/lib/core/errors.h"
+ #include "tensorflow/core/util/mkl_util.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::algorithm;
+ using dnnl::eltwise_forward;
+@@ -76,6 +77,7 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
+   //   src_data:  input data buffer of src
+   //   dst_data:  output data buffer of dst
+   void Execute(const T* src_data, T* dst_data, OpKernelContext* op_context) {
++    mutex_lock lock(mu_);
+     context_.src_mem->set_data_handle(
+         static_cast<void*>(const_cast<T*>(src_data)));
+     context_.dst_mem->set_data_handle(static_cast<void*>(dst_data));
+@@ -159,6 +161,8 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
+   }
+ 
+   struct EltwiseFwdContext context_;
++
++  mutex mu_;
+ };
+ 
+ template <typename T>
+diff --git a/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc b/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
+index f77421f5e06..ac60597be2e 100644
+--- a/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
++++ b/tensorflow/core/kernels/mkl/mkl_fused_batch_norm_op.cc
+@@ -24,6 +24,7 @@ limitations under the License.
+ #include "tensorflow/core/kernels/no_op.h"
+ #include "tensorflow/core/util/mkl_util.h"
+ #include "tensorflow/core/util/tensor_format.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ #define GET_FLAG(bn_flag) static_cast<int>(dnnl::normalization_flags::bn_flag)
+ #define IS_SET(cflag) (context_.flags & GET_FLAG(cflag))
+@@ -82,6 +83,7 @@ class MklFusedBatchNormFwdPrimitive : public MklPrimitive {
+   void Execute(const T* src_data, const U* weights_data, T* dst_data,
+                U* mean_data, U* variance_data,
+                std::shared_ptr<stream> fwd_stream, U* workspace_data) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     // TODO(intel-tf): Create a common function and avoid the duplicate code
+     context_.src_mem->set_data_handle(
+@@ -323,6 +325,8 @@ class MklFusedBatchNormFwdPrimitive : public MklPrimitive {
+   }
+ 
+   struct BatchNormFwdContext context_;
++
++  mutex mu_;
+ };
+ 
+ template <typename T, typename U>
+@@ -428,6 +432,7 @@ class MklFusedBatchNormBwdPrimitive : public MklPrimitive {
+                const T* diff_dst_data, const U* weights_data, T* diff_src_data,
+                U* diff_weights_data, U* res_space_data,
+                std::shared_ptr<stream> bwd_stream) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     // TODO(intel-tf): Create a common function and avoid the duplicate code
+     context_.src_mem->set_data_handle(
+@@ -584,6 +589,8 @@ class MklFusedBatchNormBwdPrimitive : public MklPrimitive {
+   }
+ 
+   struct BatchNormBwdContext context_;
++
++  mutex mu_;
+ };
+ 
+ template <typename T, typename U>
+diff --git a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+index 979c8b9c708..98e613acc17 100644
+--- a/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
++++ b/tensorflow/core/kernels/mkl/mkl_matmul_ops_common.h
+@@ -25,6 +25,7 @@ limitations under the License.
+ #include "tensorflow/core/framework/op.h"
+ #include "tensorflow/core/framework/op_kernel.h"
+ #include "tensorflow/core/util/mkl_util.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::inner_product_forward;
+ using dnnl::primitive_attr;
+@@ -110,6 +111,10 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
+   void Execute(const Tinput* src_data, const Tweight* weight_data,
+                const Tbias* bias_data, Toutput* dst_data,
+                std::shared_ptr<stream> fwd_stream) {
++    // when we are using single global cache then in this case
++    // we can have multiple threads running the same primitive
++    // that we created so this should happen under the lock
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     context_.src_mem->set_data_handle(
+         static_cast<void*>(const_cast<Tinput*>(src_data)), *fwd_stream);
+@@ -316,6 +321,9 @@ class MklDnnMatMulFwdPrimitive : public MklPrimitive {
+   }
+ 
+   struct MklDnnMatMulFwdContext context_;
++
++  // Guards Execution()
++  mutex mu_;
+ };
+ 
+ template <typename T, typename Tinput, typename Tweight, typename Tbias,
+@@ -589,6 +597,7 @@ class MklMatMulPrimitive : public MklPrimitive {
+   void Execute(const std::shared_ptr<stream>& stream, const Tlhs* a_data,
+                const Trhs* b_data, const Toutput* c_data,
+                void* mul_data = nullptr, void* add_data = nullptr) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     context_.a_mem->set_data_handle(
+         static_cast<void*>(const_cast<Tlhs*>(a_data)), *stream);
+@@ -749,6 +758,7 @@ class MklMatMulPrimitive : public MklPrimitive {
+   }
+ 
+   struct MklMatMulContext context_;
++  mutex mu_;
+ };
+ 
+ template <typename T, typename Tlhs, typename Trhs, typename Toutput>
+@@ -776,6 +786,13 @@ class MklMatMulPrimitiveFactory : public MklPrimitiveFactory<T> {
+     return matmul_prim;
+   }
+ 
++#ifdef DNNL_AARCH64_USE_ACL
++  static int IncrementCounter() {
++    static std::atomic_int counter{1};
++    return counter.fetch_add(1);
++  }
++#endif
++
+  private:
+   MklMatMulPrimitiveFactory() {}
+   ~MklMatMulPrimitiveFactory() {}
+diff --git a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
+index 58a7c0e3be7..807cc36a987 100644
+--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
++++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.cc
+@@ -86,6 +86,7 @@ template <typename T>
+ void MklPoolingFwdPrimitive<T>::Execute(const T* src_data, T* dst_data,
+                                         void* ws_data,
+                                         std::shared_ptr<stream> fwd_stream) {
++  mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+   context_.src_mem->set_data_handle(
+       static_cast<void*>(const_cast<T*>(src_data)), *fwd_stream);
+@@ -186,6 +187,7 @@ template <typename T>
+ void MklPoolingBwdPrimitive<T>::Execute(const T* diff_dst_data,
+                                         T* diff_src_data, const void* ws_data,
+                                         std::shared_ptr<stream> bwd_stream) {
++  mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+   context_.diff_dst_mem->set_data_handle(
+       static_cast<void*>(const_cast<T*>(diff_dst_data)), *bwd_stream);
+diff --git a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
+index 933037dbeb5..227544ed6ea 100644
+--- a/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
++++ b/tensorflow/core/kernels/mkl/mkl_pooling_ops_common.h
+@@ -25,6 +25,7 @@ limitations under the License.
+ #include "dnnl.hpp"
+ #include "tensorflow/core/util/mkl_util.h"
+ #include "tensorflow/core/util/padding.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ namespace tensorflow {
+ 
+@@ -147,6 +148,8 @@ class MklPoolingFwdPrimitive : public MklPrimitive {
+   };
+ 
+   struct PoolingFwdContext context_;
++
++  mutex mu_;
+ };
+ 
+ template <typename T>
+@@ -292,6 +295,7 @@ class MklPoolingBwdPrimitive : public MklPrimitive {
+   };
+ 
+   struct PoolingBwdContext context_;
++  mutex mu_;
+ };
+ 
+ template <typename T>
+diff --git a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+index 78734e81a90..096d57bc750 100644
+--- a/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
++++ b/tensorflow/core/kernels/mkl/mkl_quantize_op.cc
+@@ -25,6 +25,7 @@ limitations under the License.
+ #include "tensorflow/core/graph/mkl_graph_util.h"
+ #include "tensorflow/core/lib/core/errors.h"
+ #include "tensorflow/core/util/mkl_util.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::primitive_attr;
+ using dnnl::prop_kind;
+@@ -86,6 +87,7 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
+ 
+   void Execute(void* src_data, void* dst_data,
+                std::shared_ptr<stream> reorder_stream) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     context_.src_mem->set_data_handle(src_data, *reorder_stream);
+     context_.dst_mem->set_data_handle(dst_data, *reorder_stream);
+@@ -149,6 +151,8 @@ class MklReorderWithScalePrimitive : public MklPrimitive {
+     context_.prim_args.insert({DNNL_ARG_FROM, *context_.src_mem});
+     context_.prim_args.insert({DNNL_ARG_TO, *context_.dst_mem});
+   }
++
++  mutex mu_;
+ };
+ 
+ template <typename T>
+diff --git a/tensorflow/core/kernels/mkl/mkl_relu_op.cc b/tensorflow/core/kernels/mkl/mkl_relu_op.cc
+index 057d6621138..197d318edc3 100644
+--- a/tensorflow/core/kernels/mkl/mkl_relu_op.cc
++++ b/tensorflow/core/kernels/mkl/mkl_relu_op.cc
+@@ -26,6 +26,7 @@ limitations under the License.
+ #include "tensorflow/core/framework/tensor.h"
+ #include "tensorflow/core/lib/core/errors.h"
+ #include "tensorflow/core/util/mkl_util.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::algorithm;
+ using dnnl::eltwise_forward;
+@@ -74,6 +75,7 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
+   //   dst_data:  output data buffer of dst
+   void Execute(const T* src_data, T* dst_data,
+                std::shared_ptr<stream> fwd_stream) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     context_.src_mem->set_data_handle(
+         static_cast<void*>(const_cast<T*>(src_data)), *fwd_stream);
+@@ -153,6 +155,8 @@ class MklEltwiseFwdPrimitive : public MklPrimitive {
+   }
+ 
+   struct EltwiseFwdContext context_;
++
++  mutex mu_;
+ };
+ 
+ template <typename T>
+@@ -249,6 +253,7 @@ class MklEltwiseBwdPrimitive : public MklPrimitive {
+   //   diff_src_data:  output data buffer of diff_src
+   void Execute(const T* src_data, const T* diff_dst_data, T* diff_src_data,
+                std::shared_ptr<stream> bwd_stream) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     context_.src_mem->set_data_handle(
+         static_cast<void*>(const_cast<T*>(src_data)), *bwd_stream);
+@@ -354,6 +359,8 @@ class MklEltwiseBwdPrimitive : public MklPrimitive {
+   }
+ 
+   struct EltwiseBwdContext context_;
++
++  mutex mu_;
+ };
+ 
+ template <typename T>
+diff --git a/tensorflow/core/kernels/mkl/mkl_slice_op.cc b/tensorflow/core/kernels/mkl/mkl_slice_op.cc
+index 2db8e4c3be1..01ffb5d543d 100644
+--- a/tensorflow/core/kernels/mkl/mkl_slice_op.cc
++++ b/tensorflow/core/kernels/mkl/mkl_slice_op.cc
+@@ -27,6 +27,7 @@ limitations under the License.
+ #include "tensorflow/core/lib/gtl/array_slice.h"
+ #include "tensorflow/core/platform/prefetch.h"
+ #include "tensorflow/core/util/mkl_util.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::stream;
+ 
+@@ -185,6 +186,7 @@ class MklSlicePrimitive : public MklPrimitive {
+ 
+   void Execute(const MklSliceParams& sliceParams,
+                std::shared_ptr<stream> slice_stream) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     context_.src_mem->set_data_handle(sliceParams.from->get_data_handle(),
+                                       *slice_stream);
+@@ -243,6 +245,8 @@ class MklSlicePrimitive : public MklPrimitive {
+         {{DNNL_ARG_SRC, *context_.src_mem}, {DNNL_ARG_DST, *context_.dst_mem}});
+     context_.slice_primitives.push_back(*context_.reorder_prim);
+   }
++
++  mutex mu_;
+ };
+ 
+ template <typename T>
+diff --git a/tensorflow/core/kernels/mkl/mkl_softmax_op.cc b/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
+index cd4605a04d0..8cfc5937b45 100644
+--- a/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
++++ b/tensorflow/core/kernels/mkl/mkl_softmax_op.cc
+@@ -26,6 +26,7 @@ limitations under the License.
+ #include "tensorflow/core/lib/core/errors.h"
+ #include "tensorflow/core/util/mkl_util.h"
+ #include "tensorflow/core/util/tensor_format.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::prop_kind;
+ using dnnl::softmax_forward;
+@@ -60,6 +61,7 @@ class MklSoftmaxPrimitive : public MklPrimitive {
+   //   dst_data:  output data buffer of dst
+   void Execute(const T* src_data, T* dst_data,
+                std::shared_ptr<stream> fwd_cpu_stream) {
++    mutex_lock lock(mu_);
+ #ifndef ENABLE_ONEDNN_OPENMP
+     context_.src_mem->set_data_handle(
+         static_cast<void*>(const_cast<T*>(src_data)), *fwd_cpu_stream);
+@@ -140,6 +142,8 @@ class MklSoftmaxPrimitive : public MklPrimitive {
+   }
+ 
+   struct SoftmaxFwdContext context_;
++
++  mutex mu_;
+ };
+ 
+ template <typename T>
+@@ -164,6 +168,13 @@ class MklSoftmaxPrimitiveFactory : public MklPrimitiveFactory<T> {
+     return instance_;
+   }
+ 
++#ifdef DNNL_AARCH64_USE_ACL
++  static int IncrementCounter() {
++    static std::atomic_int counter{1};
++    return counter.fetch_add(1);
++  }
++#endif
++
+  private:
+   MklSoftmaxPrimitiveFactory() {}
+   ~MklSoftmaxPrimitiveFactory() {}
+@@ -278,8 +289,8 @@ class MklSoftmaxOp : public OpKernel {
+       // For softmax, the previous approach (PR #47775) of using Tensor addresses
+       // does not work, as the addresses are re-used in matmul with different data
+       // The counter ensures we still benefit from caching via SetSoftmaxFwd().
+-      static int counter = 1;
+-      fwdParams.aarch64_counter = counter++;
++      fwdParams.aarch64_counter =
++	MklSoftmaxPrimitiveFactory<T>::IncrementCounter();
+ #endif
+       MklSoftmaxPrimitive<T>* softmax_fwd =
+           MklSoftmaxPrimitiveFactory<T>::Get(fwdParams);
+diff --git a/tensorflow/core/util/mkl_util.h b/tensorflow/core/util/mkl_util.h
+index 8b351a767c6..b3597988d5f 100644
+--- a/tensorflow/core/util/mkl_util.h
++++ b/tensorflow/core/util/mkl_util.h
+@@ -39,6 +39,7 @@ limitations under the License.
+ #include "tensorflow/core/util/mkl_threadpool.h"
+ #include "tensorflow/core/util/padding.h"
+ #include "tensorflow/core/util/tensor_format.h"
++#include "tensorflow/core/platform/mutex.h"
+ 
+ using dnnl::engine;
+ using dnnl::memory;
+@@ -1728,6 +1729,27 @@ class LRUCache {
+   }
+ 
+   T* GetOp(const string& key) {
++    mutex_lock lock(mu_);
++    return GetOpLocked(key);
++  }
++
++  void SetOp(const string &key, T* op) {
++    mutex_lock lock(mu_);
++    SetOpLocked(key, op);
++  }
++
++  bool IsAllocating(const string& key) {
++    mutex_lock lock(mu_);
++    return in_flight_.find(key) != in_flight_.end();
++  }
++
++  void Allocate(const string& key) {
++    mutex_lock lock(mu_);
++    in_flight_.insert(key);
++  }
++
++ private:
++  T* GetOpLocked(const string& key) {
+     auto it = cache_.find(key);
+     if (it == cache_.end()) {
+       return nullptr;
+@@ -1740,7 +1762,7 @@ class LRUCache {
+     return it->second.op;
+   }
+ 
+-  void SetOp(const string& key, T* op) {
++  void SetOpLocked(const string& key, T* op) {
+     if (lru_list_.size() >= capacity_) {
+       Delete();
+     }
+@@ -1749,6 +1771,7 @@ class LRUCache {
+     lru_list_.push_front(key);
+     Entry entry(op, lru_list_.begin());
+     cache_.emplace(std::make_pair(key, std::move(entry)));
++    in_flight_.erase(key);
+   }
+ 
+   void Clear() {
+@@ -1759,7 +1782,6 @@ class LRUCache {
+     lru_list_.clear();
+   }
+ 
+- private:
+   struct Entry {
+     // The entry's value.
+     T* op;
+@@ -1799,6 +1821,9 @@ class LRUCache {
+   // Cache capacity
+   size_t capacity_;
+ 
++  // Guards access to the cache and LRU list
++  mutex mu_;
++
+   // The cache, a map from string key to a LRU entry.
+   std::unordered_map<string, Entry> cache_;
+ 
+@@ -1806,6 +1831,9 @@ class LRUCache {
+   // The front of the list contains the key of the most recently accessed
+   // entry, while the back of the list is the least recently accessed entry.
+   std::list<string> lru_list_;
++
++  // The keys that are currently under creation
++  std::set<string> in_flight_;
+ };
+ 
+ template <typename T>
+@@ -1816,13 +1844,49 @@ class MklPrimitiveFactory {
+   ~MklPrimitiveFactory() {}
+ 
+   MklPrimitive* GetOp(const string& key) {
+-    auto& lru_cache = MklPrimitiveFactory<T>::GetLRUCache();
+-    return lru_cache.GetOp(key);
++    while(true) {
++      mutex_lock lock(mtx_);
++      auto& lru_cache = MklPrimitiveFactory<T>::GetLRUCache();
++
++      // check to see whether primitive already exists
++      MklPrimitive *primitive = lru_cache.GetOp(key);
++      if(primitive != nullptr) {
++        return primitive;
++      }
++
++      // now check whether some other thread is
++      // creating this primitive
++      if(!lru_cache.IsAllocating(key)) {
++        // this thread is going to pick it up and
++        // and create the primitive
++        lru_cache.Allocate(key);
++        return nullptr;
++        // now we release lock
++        // as primitive creating might take long time
++      }
++
++      // at this point we cannot create primitive
++      // as someone else is creating so we
++      // should wait for primitive to get created and
++      // then return created primitive
++      cv_.wait(lock);
++
++      // now the primitive is in cache so now
++      // when should try to retrieve it again
++      // after getting a lock on it
++    }
+   }
+ 
+   void SetOp(const string& key, MklPrimitive* op) {
+-    auto& lru_cache = MklPrimitiveFactory<T>::GetLRUCache();
+-    lru_cache.SetOp(key, op);
++    {
++      mutex_lock lock(mtx_);
++      auto& lru_cache = MklPrimitiveFactory<T>::GetLRUCache();
++      lru_cache.SetOp(key, op);
++    }
++
++    // now we can inform all waiting threads that
++    // primitive is in cache and that they can get it
++    cv_.notify_all();
+   }
+ 
+   /// Function to decide whether HW has AVX512 or AVX2
+@@ -1849,9 +1913,12 @@ class MklPrimitiveFactory {
+  private:
+   static inline LRUCache<MklPrimitive>& GetLRUCache() {
+     static const int kCapacity = 1024;  // cache capacity
+-    static thread_local LRUCache<MklPrimitive> lru_cache_(kCapacity);
++    static LRUCache<MklPrimitive> lru_cache_(kCapacity);
+     return lru_cache_;
+   }
++
++  mutex mtx_;
++  condition_variable cv_;
+ };
+ 
+ // utility class for creating keys of MKL primitive pool.
+@@ -1982,5 +2049,8 @@ class MklReorderPrimitiveFactory : public MklPrimitiveFactory<T> {
+                                          &to_strides[to_desc.ndims]);
+ 
+     key_creator.AddAsKey(prefix);
++    // Since reorder primitive SetMemory we need to make sure
++    // that we cache memory per thread
++    key_creator.AddAsKey(std::this_thread::get_id());
+     key_creator.AddAsKey(static_cast<int>(from_desc.extra.flags));
+     key_creator.AddAsKey(static_cast<int>(from_inner_nblks));
+     key_creator.AddAsKey(from_inner_blks_1);

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -74,7 +74,7 @@ if [[ $ONEDNN_BUILD ]]; then
       # Patch to add experimental spin-wait scheduler to Compute Library
       # Note: overwrites upstream version
       mv ../compute_library.patch ./third_party/compute_library/.
-      # Patch to improve resource allocation for ACL primitives
+      # Patch to improve resource allocation for ACL primitives and add binary primitive
       mv ../onednn_acl.patch ./third_party/mkl_dnn/.
     fi
 else

--- a/docker/tensorflow-lite-aarch64/Dockerfile
+++ b/docker/tensorflow-lite-aarch64/Dockerfile
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,7 +91,7 @@ COPY patches/welcome.txt /home/$DOCKER_USER/.
 RUN echo '[ ! -z "$TERM" -a -r /home/$DOCKER_USER/welcome.txt ] && \
   cat /home/$DOCKER_USER/welcome.txt' >> /etc/bash.bashrc
 
-ENV TF_VERSION=2.4.1
+ENV TF_VERSION=2.8.0
 
 # Package build parameters
 ENV PROD_DIR=/opt \
@@ -105,10 +105,12 @@ RUN mkdir -p $PACKAGE_DIR && \
 # Build tensorflow
 COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 COPY patches/tflite.patch $PACKAGE_DIR/.
+COPY scripts/libruy.mri $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh
 
 # Build Arm Compute Library
 COPY scripts/build-armcl.sh $PACKAGE_DIR/.
+# This patch adds support for spin wait scheduler to ACL
 COPY patches/acl.patch $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-armcl.sh
 

--- a/docker/tensorflow-lite-aarch64/README.md
+++ b/docker/tensorflow-lite-aarch64/README.md
@@ -1,4 +1,4 @@
-# Build TensorFlow Lite 2.4.1 and ArmNN for Arm AArch64
+# Build TensorFlow Lite 2.8 and ArmNN 22.02 for Arm AArch64
 
 This folder contains scripts and patches to build a Docker image that contains [TensorFlow Lite](https://www.tensorflow.org/lite) and [ArmNN](https://developer.arm.com/ip-products/processors/machine-learning/arm-nn) for Arm AArch64 execution.
 

--- a/docker/tensorflow-lite-aarch64/patches/acl.patch
+++ b/docker/tensorflow-lite-aarch64/patches/acl.patch
@@ -1,5 +1,5 @@
  *******************************************************************************
- Copyright 2021 Arm Limited and affiliates.
+ Copyright 2022 Arm Limited and affiliates.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,37 +14,485 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  *******************************************************************************
-
-diff --git a/src/runtime/CPP/CPPScheduler.cpp b/src/runtime/CPP/CPPScheduler.cpp
-index 3bd80eb51..f590cd67f 100644
---- a/src/runtime/CPP/CPPScheduler.cpp
-+++ b/src/runtime/CPP/CPPScheduler.cpp
-@@ -34,6 +34,7 @@
-
- #include <atomic>
- #include <condition_variable>
-+#include <cstdlib>
- #include <iostream>
- #include <list>
- #include <memory>
-@@ -350,14 +351,18 @@ struct CPPScheduler::Impl final
-     {
-         _num_threads = num_threads == 0 ? thread_hint : num_threads;
-
-+	int start_core = 0;
-+	if(const char* env_c = std::getenv("START_CORE"))
-+	  start_core = std::atoi(env_c);
+diff --git a/arm_compute/runtime/CPP/SpinWaitCPPScheduler.h b/arm_compute/runtime/CPP/SpinWaitCPPScheduler.h
+new file mode 100644
+index 000000000..e5de2349a
+--- /dev/null
++++ b/arm_compute/runtime/CPP/SpinWaitCPPScheduler.h
+@@ -0,0 +1,75 @@
++/*
++ * Copyright (c) 2016-2022 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++#ifndef ARM_COMPUTE_SPIN_WAIT_CPPSCHEDULER_H
++#define ARM_COMPUTE_SPIN_WAIT_CPPSCHEDULER_H
 +
-         // Set affinity on main thread
--        set_thread_affinity(func(0, thread_hint));
-+        set_thread_affinity(func(start_core, thread_hint));
-
-         // Set affinity on worked threads
-         _threads.clear();
-         for(auto i = 1U; i < _num_threads; ++i)
-         {
--            _threads.emplace_back(func(i, thread_hint));
-+	  _threads.emplace_back(func(start_core + i, thread_hint));
-         }
-         auto_switch_mode(_num_threads);
++#include "arm_compute/core/experimental/Types.h"
++#include "arm_compute/runtime/IScheduler.h"
++
++#include <memory>
++
++namespace arm_compute
++{
++class SpinWaitCPPScheduler final : public IScheduler
++{
++public:
++    /** Constructor: create a pool of threads. */
++    SpinWaitCPPScheduler();
++    /** Default destructor */
++    ~SpinWaitCPPScheduler();
++
++    /** Access the scheduler singleton
++     *
++     * @note this method has been deprecated and will be remover in future releases
++     * @return The scheduler
++     */
++    static SpinWaitCPPScheduler &get();
++
++    // Inherited functions overridden
++    void set_num_threads(unsigned int num_threads) override;
++    void set_num_threads_with_affinity(unsigned int num_threads, BindFunc func) override {
++        // On high-core count we noticed that affinity doesn't affect performance so
++        // the method is called without thread affinity
++        (void)func;
++        set_num_threads(num_threads);
++    }
++
++    unsigned int num_threads() const override;
++
++    void schedule(ICPPKernel *kernel, const Hints &hints) override;
++    void schedule_op(ICPPKernel *kernel, const Hints &hints, const Window &window, ITensorPack &tensors) override;
++
++protected:
++    /** Will run the workloads in parallel using num_threads
++     *
++     * @param[in] workloads Workloads to run
++     */
++    void run_workloads(std::vector<Workload> &workloads) override;
++
++private:
++    struct Impl;
++    std::unique_ptr<Impl> _impl;
++};
++} // namespace arm_compute
++#endif /* ARM_COMPUTE_CPPSCHEDULER_H */
+diff --git a/filelist.json b/filelist.json
+index ba19321a5..e29b71087 100644
+--- a/filelist.json
++++ b/filelist.json
+@@ -78,7 +78,7 @@
+   ],
+   "scheduler": {
+     "single": [ "src/runtime/CPP/SingleThreadScheduler.cpp" ],
+-    "threads": [ "src/runtime/CPP/CPPScheduler.cpp" ],
++    "threads": [ "src/runtime/CPP/CPPScheduler.cpp", "src/runtime/CPP/SpinWaitCPPScheduler.cpp" ],
+     "omp": [ "src/runtime/OMP/OMPScheduler.cpp"]
+   },
+   "c_api": {
+@@ -1989,4 +1989,4 @@
+       }
      }
+   }
+-}
+\ No newline at end of file
++}
+diff --git a/src/runtime/CPP/SpinWaitCPPScheduler.cpp b/src/runtime/CPP/SpinWaitCPPScheduler.cpp
+new file mode 100644
+index 000000000..b5683b0e5
+--- /dev/null
++++ b/src/runtime/CPP/SpinWaitCPPScheduler.cpp
+@@ -0,0 +1,346 @@
++/*
++ * Copyright (c) 2016-2022 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++#include "arm_compute/runtime/CPP/SpinWaitCPPScheduler.h"
++
++#include "arm_compute/core/CPP/ICPPKernel.h"
++#include "arm_compute/core/Error.h"
++#include "arm_compute/core/Helpers.h"
++#include "arm_compute/core/Log.h"
++#include "arm_compute/core/Utils.h"
++#include "arm_compute/core/utils/misc/Utility.h"
++#include "support/Mutex.h"
++
++#include <atomic>
++#include <condition_variable>
++#include <iostream>
++#include <list>
++#include <memory>
++#include <mutex>
++#include <system_error>
++#include <thread>
++#include <vector>
++
++namespace arm_compute
++{
++namespace
++{
++class ThreadFeeder
++{
++public:
++    /** Constructor
++     *
++     * @param[in] start First value that will be returned by the feeder
++     * @param[in] end   End condition (The last value returned by get_next() will be end - 1)
++     */
++    explicit ThreadFeeder(unsigned int start = 0, unsigned int end = 0)
++        : _atomic_counter(start), _end(end)
++    {
++    }
++    /** Return the next element in the range if there is one.
++     *
++     * @param[out] next Will contain the next element if there is one.
++     *
++     * @return False if the end of the range has been reached and next wasn't set.
++     */
++    bool get_next(unsigned int &next)
++    {
++        next = atomic_fetch_add_explicit(&_atomic_counter, 1u, std::memory_order_relaxed);
++        return next < _end;
++    }
++
++private:
++    std::atomic_uint   _atomic_counter;
++    const unsigned int _end;
++};
++
++/** Execute workloads[info.thread_id] first, then call the feeder to get the index of the next workload to run.
++ *
++ * Will run workloads until the feeder reaches the end of its range.
++ *
++ * @param[in]     workloads The array of workloads
++ * @param[in,out] feeder    The feeder indicating which workload to execute next.
++ * @param[in]     info      Threading and CPU info.
++ */
++void process_workloads(std::vector<IScheduler::Workload> &workloads, ThreadFeeder &feeder, const ThreadInfo &info)
++{
++    unsigned int workload_index = info.thread_id;
++    do
++    {
++        ARM_COMPUTE_ERROR_ON(workload_index >= workloads.size());
++        workloads[workload_index](info);
++    }
++    while(feeder.get_next(workload_index));
++}
++
++class Thread final
++{
++public:
++    /** Start a new thread
++     *
++     * Thread will be pinned to a given core id if value is non-negative
++     *
++     * @param[in] core_pin Core id to pin the thread on. If negative no thread pinning will take place
++     */
++    explicit Thread();
++
++    Thread(const Thread &) = delete;
++    Thread &operator=(const Thread &) = delete;
++    Thread(Thread &&)                 = delete;
++    Thread &operator=(Thread &&) = delete;
++
++    /** Destructor. Make the thread join. */
++    ~Thread();
++
++    /** Sets internal information for the thread: unique identifier and CPU information */
++    void set_thread_info(unsigned int tid, const CPUInfo* cpu_info);
++
++    /** Sets atomic variables that are used to schedule the work
++     *
++     * Each thread waits for go to change from false to true. Once it is set to true if fin
++     * is set to true the thread will finish execution otherwise it will check whether there
++     * there is enough work for the thread to do and if it is it will process workload. Once
++     * the workload is processed it will reduce by one number (atomic variable left) of threads
++     * that are yet to finish and  spin wait for all other threads to finish their execution
++     * (atomic variable resets will increment by one in the main thread once all children have finished).
++     */
++    void set_sched(std::atomic_bool* go, std::atomic_bool* fin, std::atomic_int* left, std::atomic_uint* resets);
++
++    /** Sets workload information */
++    void set_workload(std::vector<IScheduler::Workload>** workload, ThreadFeeder** feeder);
++
++    /** Request the worker thread to start executing workloads.
++     *
++     * The thread will start by executing workloads[info.thread_id] and will then call the feeder to
++     * get the index of the following workload to run.
++     *
++     * @note This function will return as soon as the workloads have been sent to the worker thread.
++     * wait() needs to be called to ensure the execution is complete.
++     */
++    void start(std::atomic_uint* threads);
++
++    /** Function ran by the worker thread. */
++    void worker_thread();
++
++private:
++    std::thread                        _thread{};
++    ThreadInfo                         _info{};
++
++    std::atomic_bool                   *_go{nullptr};
++    std::atomic_bool                   *_finished{nullptr};
++    std::atomic_int                    *_left{nullptr};
++    std::atomic_uint                   *_resets{nullptr};
++
++    std::atomic_uint*                  _num_threads_to_use{nullptr};
++
++    unsigned int                       _reps{0};
++
++    std::vector<IScheduler::Workload>  **_workloads{nullptr};
++    ThreadFeeder                       **_feeder{nullptr};
++};
++
++Thread::Thread()
++{
++}
++
++Thread::~Thread()
++{
++    // Make sure worker thread has ended
++    if(_thread.joinable())
++    {
++	_thread.join();
++    }
++}
++
++void Thread::set_thread_info(unsigned int tid, const CPUInfo* cpu_info) {
++    _info.thread_id = tid;
++    _info.cpu_info = cpu_info;
++}
++
++
++void Thread::set_sched(std::atomic_bool* go, std::atomic_bool* fin, std::atomic_int* left, std::atomic_uint* resets) {
++    _go = go;
++    _finished = fin;
++    _left = left;
++    _resets = resets;
++}
++
++void Thread::set_workload(std::vector<IScheduler::Workload>** workload, ThreadFeeder** feeder) {
++    _workloads = workload;
++    _feeder = feeder;
++}
++
++void Thread::start(std::atomic_uint* threads) {
++    _num_threads_to_use = threads;
++    _thread = std::thread(&Thread::worker_thread, this);
++}
++
++void Thread::worker_thread()
++{
++    while(true)
++    {
++
++        while(!(_go->load()));
++
++	if(_finished->load())
++	{
++	    break;
++	}
++
++	if(_info.thread_id < int(_num_threads_to_use->load() - 1))
++	{
++	    _info.num_threads = _num_threads_to_use->load();
++	    process_workloads(**_workloads, **_feeder, _info);
++	}
++
++	_left->fetch_sub(1);
++
++	while(_reps == _resets->load());
++	++_reps;
++    }
++}
++} //namespace
++
++struct SpinWaitCPPScheduler::Impl final
++{
++    explicit Impl(unsigned int thread_hint)
++        : _num_threads(thread_hint), _threads(_num_threads - 1)
++    {
++    }
++
++    Impl(const SpinWaitCPPScheduler::Impl& other) = delete;
++    SpinWaitCPPScheduler::Impl& operator=(const SpinWaitCPPScheduler::Impl& other) = delete;
++
++    void set_num_threads(unsigned int num_threads, unsigned int thread_hint)
++    {
++        _num_threads = num_threads == 0 ? thread_hint : num_threads;
++	_threads.resize(_num_threads-1);
++	auto thread_it = _threads.begin();
++	unsigned int t = 0;
++	for(; thread_it != _threads.end(); ++t, ++thread_it)
++	{
++	    thread_it->set_thread_info(t, &CPUInfo::get());
++	    thread_it->set_sched(&_go, &_finished, &_left, &_resets);
++	    thread_it->set_workload(&_workloads, &_feeder);
++	    thread_it->start(&_num_threads_to_use);
++	}
++
++    }
++
++    unsigned int num_threads() const
++    {
++        return _num_threads;
++    }
++
++
++    void run_workloads(std::vector<IScheduler::Workload> &workloads);
++    void set_workloads(std::vector<IScheduler::Workload> *workloads, ThreadFeeder *feeder)
++    {
++      _workloads = workloads;
++      _feeder = feeder;
++    }
++
++    unsigned int       _num_threads;
++    std::list<Thread>  _threads;
++    arm_compute::Mutex _run_workloads_mutex{};
++    std::atomic_bool   _go{false};
++    std::atomic_bool   _finished{false};
++    std::atomic_int    _left{0};
++    std::atomic_uint   _resets{0};
++    std::atomic_uint   _num_threads_to_use{0};
++
++    std::vector<IScheduler::Workload> *_workloads{nullptr};
++    ThreadFeeder                      *_feeder{nullptr};
++};
++
++SpinWaitCPPScheduler::SpinWaitCPPScheduler()
++    : _impl(std::make_unique<Impl>(num_threads_hint()))
++{
++}
++
++SpinWaitCPPScheduler::~SpinWaitCPPScheduler()
++{
++    _impl->_finished.store(true);
++    _impl->_go.store(true);
++}
++
++void SpinWaitCPPScheduler::set_num_threads(unsigned int num_threads)
++{
++    // No changes in the number of threads while current workloads are running
++    arm_compute::lock_guard<std::mutex> lock(_impl->_run_workloads_mutex);
++    _impl->set_num_threads(num_threads, num_threads_hint());
++}
++
++unsigned int SpinWaitCPPScheduler::num_threads() const
++{
++    return _impl->num_threads();
++}
++
++#ifndef DOXYGEN_SKIP_THIS
++void SpinWaitCPPScheduler::run_workloads(std::vector<IScheduler::Workload> &workloads)
++{
++    // Mutex to ensure other threads won't interfere with the setup of the current thread's workloads
++    // Other thread's workloads will be scheduled after the current thread's workloads have finished
++    // This is not great because different threads workloads won't run in parallel but at least they
++    // won't interfere each other and deadlock.
++    arm_compute::lock_guard<std::mutex> lock(_impl->_run_workloads_mutex);
++    const unsigned int                  num_threads_to_use = std::min(_impl->num_threads(), static_cast<unsigned int>(workloads.size()));
++    if(num_threads_to_use < 1)
++    {
++        return;
++    }
++    // Re-adjust the mode if the actual number of threads to use is different from the number of threads created
++    _impl->_num_threads_to_use.store(num_threads_to_use);
++    _impl->_left = _impl->num_threads() - 1;
++
++
++    ThreadFeeder feeder(num_threads_to_use, workloads.size());
++    ThreadInfo   info;
++    info.cpu_info          = &cpu_info();
++    info.num_threads       = num_threads_to_use;
++
++    info.thread_id = num_threads_to_use - 1;                         // Set main thread's thread_id
++
++    _impl->set_workloads(&workloads, &feeder);
++
++    _impl->_go.store(true);
++
++    process_workloads(workloads, feeder, info); // Main thread processes workloads
++    while(_impl->_left.load());
++
++    _impl->_go.store(false);
++    _impl->_resets.fetch_add(1);
++}
++#endif /* DOXYGEN_SKIP_THIS */
++
++void SpinWaitCPPScheduler::schedule_op(ICPPKernel *kernel, const Hints &hints, const Window &window, ITensorPack &tensors)
++{
++    schedule_common(kernel, hints, window, tensors);
++}
++
++void SpinWaitCPPScheduler::schedule(ICPPKernel *kernel, const Hints &hints)
++{
++    ITensorPack tensors;
++    schedule_common(kernel, hints, kernel->window(), tensors);
++}
++} // namespace arm_compute
+diff --git a/src/runtime/Scheduler.cpp b/src/runtime/Scheduler.cpp
+index 0713b9a2a..42049021d 100644
+--- a/src/runtime/Scheduler.cpp
++++ b/src/runtime/Scheduler.cpp
+@@ -27,6 +27,7 @@
+ 
+ #if ARM_COMPUTE_CPP_SCHEDULER
+ #include "arm_compute/runtime/CPP/CPPScheduler.h"
++#include "arm_compute/runtime/CPP/SpinWaitCPPScheduler.h"
+ #endif /* ARM_COMPUTE_CPP_SCHEDULER */
+ 
+ #include "arm_compute/runtime/SingleThreadScheduler.h"
+@@ -56,7 +57,15 @@ std::map<Scheduler::Type, std::unique_ptr<IScheduler>> init()
+     std::map<Scheduler::Type, std::unique_ptr<IScheduler>> m;
+     m[Scheduler::Type::ST] = std::make_unique<SingleThreadScheduler>();
+ #if defined(ARM_COMPUTE_CPP_SCHEDULER)
+-    m[Scheduler::Type::CPP] = std::make_unique<CPPScheduler>();
++    /* check whether we want to use spin scheduler */
++    const char* value = std::getenv("ARM_COMPUTE_SPIN_WAIT_CPP_SCHEDULER");
++    int use_spin_wait = value == nullptr ? 0 : atoi(value);
++    if(use_spin_wait) {
++      m[Scheduler::Type::CPP] = std::make_unique<SpinWaitCPPScheduler>();
++    }
++    else {
++      m[Scheduler::Type::CPP] = std::make_unique<CPPScheduler>();
++    }
+ #endif // defined(ARM_COMPUTE_CPP_SCHEDULER)
+ #if defined(ARM_COMPUTE_OPENMP_SCHEDULER)
+     m[Scheduler::Type::OMP] = std::make_unique<OMPScheduler>();

--- a/docker/tensorflow-lite-aarch64/patches/armnn.patch
+++ b/docker/tensorflow-lite-aarch64/patches/armnn.patch
@@ -1,5 +1,5 @@
  *******************************************************************************
- Copyright 2021 Arm Limited and affiliates.
+ Copyright 2021-2022 Arm Limited and affiliates.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,166 +14,62 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  *******************************************************************************
-
-diff --git a/delegate/CMakeLists.txt b/delegate/CMakeLists.txt
-index 707877fc1..95afa12bd 100644
---- a/delegate/CMakeLists.txt
-+++ b/delegate/CMakeLists.txt
-@@ -67,6 +67,8 @@ target_link_libraries(armnnDelegate PUBLIC Armnn::Armnn)
- find_package(TfLite REQUIRED MODULE)
-
- target_link_libraries(armnnDelegate PUBLIC ${TfLite_LIB})
-+target_link_libraries(armnnDelegate PUBLIC -lpthread)
-+target_link_libraries(armnnDelegate PUBLIC -ldl)
-
- # Various tflite header files are not warning clean
- # We can't change compilation flags on header files directly, so we need to add them to an interface library first
 diff --git a/delegate/cmake/Modules/FindTfLite.cmake b/delegate/cmake/Modules/FindTfLite.cmake
-index 41f55e3e8..9d7283141 100644
+index 907c3847c..b22772c92 100644
 --- a/delegate/cmake/Modules/FindTfLite.cmake
 +++ b/delegate/cmake/Modules/FindTfLite.cmake
-@@ -14,24 +14,43 @@ find_path(TfLite_INCLUDE_DIR
-             ${TENSORFLOW_ROOT})
+@@ -28,18 +28,26 @@ if (TfLite_LIB MATCHES .a$)
+                  PATH ${TFLITE_LIB_ROOT}/_deps/farmhash-build)
+     find_library(TfLite_fftsg_LIB "libfft2d_fftsg.a"
+                  PATH ${TFLITE_LIB_ROOT}/_deps/fft2d-build)
++    find_library(TfLite_xnnpack_LIB "libXNNPACK.a"
++                 PATH ${TFLITE_LIB_ROOT}/_deps/xnnpack-build)
+     find_library(TfLite_fftsg2d_LIB "libfft2d_fftsg2d.a"
+-                 PATH ${TFLITE_LIB_ROOT}/_deps/fft2d-build)
++                PATH ${TFLITE_LIB_ROOT}/_deps/fft2d-build)
+     find_library(TfLite_ruy_LIB "libruy.a" PATH
+                  ${TFLITE_LIB_ROOT}/_deps/ruy-build)
+     find_library(TfLite_flatbuffers_LIB "libflatbuffers.a"
+                  PATH ${TFLITE_LIB_ROOT}/_deps/flatbuffers-build)
++    find_library(TfLite_pthreadpool_LIB "libpthreadpool.a"
++                 PATH ${TFLITE_LIB_ROOT}/pthreadpool)
++    find_library(TfLite_cpuinfo_LIB "libcpuinfo.a"
++                 PATH ${TFLITE_LIB_ROOT}/_deps/cpuinfo-build)
++    find_library(TfLite_clog_LIB "libclog.a"
++                 PATH ${TFLITE_LIB_ROOT}/_deps/clog-build)
+ 
+     ## Set TFLITE_FOUND if all libraries are satisfied for static lib
+-    find_package_handle_standard_args(TfLite DEFAULT_MSG TfLite_LIB TfLite_abseilstrings_LIB TfLite_ruy_LIB TfLite_fftsg_LIB TfLite_fftsg2d_LIB TfLite_farmhash_LIB TfLite_flatbuffers_LIB)
++    find_package_handle_standard_args(TfLite DEFAULT_MSG TfLite_LIB TfLite_abseilstrings_LIB TfLite_xnnpack_LIB TfLite_ruy_LIB TfLite_fftsg_LIB TfLite_fftsg2d_LIB TfLite_farmhash_LIB TfLite_flatbuffers_LIB TfLite_pthreadpool_LIB TfLite_cpuinfo_LIB TfLite_clog_LIB)
+     # Set external variables for usage in CMakeLists.txt
+     if (TFLITE_FOUND)
+-        set(TfLite_LIB ${TfLite_LIB} ${TfLite_abseilstrings_LIB} ${TfLite_ruy_LIB} ${TfLite_fftsg_LIB} ${TfLite_fftsg2d_LIB} ${TfLite_farmhash_LIB} ${TfLite_flatbuffers_LIB})
++        set(TfLite_LIB ${TfLite_LIB} ${TfLite_abseilstrings_LIB} ${TfLite_xnnpack_LIB} ${TfLite_fftsg_LIB} ${TfLite_ruy_LIB} ${TfLite_fftsg2d_LIB} ${TfLite_farmhash_LIB} ${TfLite_flatbuffers_LIB} ${TfLite_pthreadpool_LIB} ${TfLite_cpuinfo_LIB} ${TfLite_clog_LIB})
+     endif ()
+ elseif (TfLite_LIB MATCHES .so$)
+     message("-- Dynamic tensorflow lite library found, using for ArmNN build")
+diff --git a/src/backends/neon/NeonWorkloadFactory.cpp b/src/backends/neon/NeonWorkloadFactory.cpp
+index 19d322b75..b09dbc4be 100644
+--- a/src/backends/neon/NeonWorkloadFactory.cpp
++++ b/src/backends/neon/NeonWorkloadFactory.cpp
+@@ -58,6 +58,7 @@ void NeonWorkloadFactory::SetNumberOfThreads()
+         const unsigned int MIN_THREADS = 1;
+         const unsigned int MAX_THREADS = 64;
 
- find_library(TfLite_LIB
--        NAMES
--            "libtensorflow_lite_all.so"
--            "libtensorflowlite.so"
-+       NAMES
-+           "libtensorflow-lite.a"
-         HINTS
-             ${TFLITE_LIB_ROOT}
-             ${TFLITE_LIB_ROOT}/tensorflow/lite)
++        static std::once_flag flag_once;
+         // Set the number of threads to be used if the user has set NumberOfThreads param
+         // Only set if within limit or valid input
+         auto modelOptions = dynamic_cast<NeonBackendModelContext*>(m_ModelContextPtr.get());
+@@ -65,7 +66,10 @@ void NeonWorkloadFactory::SetNumberOfThreads()
 
-+find_library(TfLite_ruy_LIB
-+            "libruy.a"
-+        PATH
-+            ${TFLITE_LIB_ROOT}/_deps/ruy-build)
+         if (numberOfThreads != 0 && numberOfThreads >= MIN_THREADS && numberOfThreads <= MAX_THREADS)
+         {
+-            arm_compute::Scheduler::get().set_num_threads(numberOfThreads);
 +
-+find_library(TfLite_fft2d_LIB
-+            "libfft2d_fftsg.a"
-+        PATH
-+            ${TFLITE_LIB_ROOT}/_deps/fft2d-build)
-+
-+find_library(TfLite_farmhash_LIB
-+            "libfarmhash.a"
-+        PATH
-+            ${TFLITE_LIB_ROOT}/_deps/farmhash-build)
-+
-+find_library(TfLite_flatbuffers_LIB
-+            "libflatbuffers.a"
-+        PATH
-+            ${TFLITE_LIB_ROOT}/_deps/flatbuffers-build)
-+
- find_path(TfLite_Schema_INCLUDE_PATH
-             schema_generated.h
-         HINTS
--            ${TFLITE_LIB_ROOT}/tensorflow/lite/schema)
-+            ${TENSORFLOW_ROOT}/tensorflow/lite/schema)
-
- ## Set TFLITE_FOUND
--find_package_handle_standard_args(TfLite DEFAULT_MSG TfLite_INCLUDE_DIR TfLite_LIB TfLite_Schema_INCLUDE_PATH)
-+find_package_handle_standard_args(TfLite DEFAULT_MSG TfLite_INCLUDE_DIR TfLite_LIB TfLite_ruy_LIB TfLite_fft2d_LIB TfLite_farmhash_LIB TfLite_flatbuffers_LIB TfLite_Schema_INCLUDE_PATH)
-
- ## Set external variables for usage in CMakeLists.txt
- if(TFLITE_FOUND)
--    set(TfLite_LIB ${TfLite_LIB})
-+    set(TfLite_LIB ${TfLite_LIB} ${TfLite_ruy_LIB} ${TfLite_fft2d_LIB} ${TfLite_farmhash_LIB} ${TfLite_flatbuffers_LIB})
-     set(TfLite_INCLUDE_DIR ${TfLite_INCLUDE_DIR})
-     set(TfLite_Schema_INCLUDE_PATH ${TfLite_Schema_INCLUDE_PATH})
--endif()
-\ No newline at end of file
-+endif()
-diff --git a/delegate/src/FullyConnected.hpp b/delegate/src/FullyConnected.hpp
-index e94304fb2..85d1635eb 100644
---- a/delegate/src/FullyConnected.hpp
-+++ b/delegate/src/FullyConnected.hpp
-@@ -31,7 +31,7 @@ TfLiteStatus VisitFullyConnectedOperator(DelegateData& delegateData,
-         return kTfLiteError;
++            std::call_once(flag_once, [&]() {
++                arm_compute::Scheduler::get().set_num_threads(numberOfThreads);
++            });
+         }
      }
-     TF_LITE_ENSURE_STATUS(ValidateNumOutputs(tfLiteContext, tfLiteNode, 1, nodeIndex));
--    bool biasEnabled = (numInputs == 3);
-+    bool biasEnabled = (numInputs == 3) && tfLiteNode->inputs->data[2] > 0;
-
-     const TfLiteTensor* tfLiteTensors = tfLiteContext->tensors;
-     const TfLiteTensor& tfLiteInputTensor = tfLiteTensors[tfLiteNode->inputs->data[0]];
-@@ -199,4 +199,4 @@ TfLiteStatus VisitFullyConnectedOperator(DelegateData& delegateData,
-     return FusedActivation(tfLiteContext, tfLiteNode, activationType, layer, 0, delegateData);
  }
 
--} // namespace armnnDelegate
-\ No newline at end of file
-+} // namespace armnnDelegate
-diff --git a/src/armnnTfLiteParser/TfLiteParser.cpp b/src/armnnTfLiteParser/TfLiteParser.cpp
-index 5070d5b22..2145c9d15 100644
---- a/src/armnnTfLiteParser/TfLiteParser.cpp
-+++ b/src/armnnTfLiteParser/TfLiteParser.cpp
-@@ -717,8 +717,8 @@ INetworkPtr TfLiteParserImpl::CreateNetworkFromModel()
-             for (OperatorPtr const& op : subgraph->operators)
-             {
-                 auto const& opCodePtr = m_Model->operator_codes[op->opcode_index];
--                auto builtinCode = opCodePtr->builtin_code;
--
-+		auto builtinCode = std::max(opCodePtr->builtin_code,
-+                        static_cast<tflite::BuiltinOperator>(opCodePtr->deprecated_builtin_code));
-                 if (builtinCode > tflite::BuiltinOperator_MAX)
-                 {
-                     throw ParseException(fmt::format("Operator code {} is out of range 0-{}. "
-@@ -837,7 +837,8 @@ void TfLiteParserImpl::ParseUnsupportedOperator(size_t subgraphIndex, size_t ope
-     const auto & operatorPtr = m_Model->subgraphs[subgraphIndex]->operators[operatorIndex];
-
-     auto opcodeIndex = operatorPtr->opcode_index;
--    auto opcode      = m_Model->operator_codes[opcodeIndex]->builtin_code;
-+    auto opcode      = std::max(m_Model->operator_codes[opcodeIndex]->builtin_code,
-+            static_cast<tflite::BuiltinOperator>(m_Model->operator_codes[opcodeIndex]->deprecated_builtin_code));
-
-     if (!m_Options || !m_Options.value().m_StandInLayerForUnsupported)
-     {
-diff --git a/src/backends/backendsCommon/WorkloadData.cpp b/src/backends/backendsCommon/WorkloadData.cpp
-index 100d23ee3..10af3a736 100644
---- a/src/backends/backendsCommon/WorkloadData.cpp
-+++ b/src/backends/backendsCommon/WorkloadData.cpp
-@@ -1096,7 +1096,7 @@ void FullyConnectedQueueDescriptor::Validate(const WorkloadInfo& workloadInfo) c
-             biasTensorInfo  = workloadInfo.m_InputTensorInfos[2];
-         }
-         // Validates type and quantization values.
--        ValidateBiasTensorQuantization(biasTensorInfo, inputTensorInfo, weightTensorInfo, descriptorName);
-+        //ValidateBiasTensorQuantization(biasTensorInfo, inputTensorInfo, weightTensorInfo, descriptorName);
-         ValidateTensorDataType(biasTensorInfo, GetBiasDataType(inputTensorInfo.GetDataType()), descriptorName, "bias");
-         ValidateTensorNumDimensions(biasTensorInfo, descriptorName, 1, "bias");
-     }
-diff --git a/tests/ExecuteNetwork/ExecuteNetwork.cpp b/tests/ExecuteNetwork/ExecuteNetwork.cpp
-index 2bbb51783..51cafa7bc 100644
---- a/tests/ExecuteNetwork/ExecuteNetwork.cpp
-+++ b/tests/ExecuteNetwork/ExecuteNetwork.cpp
-@@ -398,15 +398,12 @@ int MainImpl(const ExecuteNetworkParams& params,
-                 // model.Run returns the inference time elapsed in EnqueueWorkload (in milliseconds)
-                 auto inference_duration = model.Run(inputs[0], outputs[0]);
-
--                if (params.m_GenerateTensorData)
--                {
--                    ARMNN_LOG(warning) << "The input data was generated, note that the output will not be useful";
--                }
--
--                // Print output tensors
--                const auto& infosOut = model.GetOutputBindingInfos();
--                for (size_t i = 0; i < numOutputs; i++)
-+                if (!params.m_GenerateTensorData)
-                 {
-+		  // Print output tensors
-+		  const auto& infosOut = model.GetOutputBindingInfos();
-+		  for (size_t i = 0; i < numOutputs; i++)
-+		  {
-                     const armnn::TensorInfo& infoOut = infosOut[i].second;
-                     auto outputTensorFile = params.m_OutputTensorFiles.empty() ? "" : params.m_OutputTensorFiles[i];
-
-@@ -415,7 +412,8 @@ int MainImpl(const ExecuteNetworkParams& params,
-                                           outputTensorFile,
-                                           params.m_DequantizeOutput);
-                     mapbox::util::apply_visitor(printer, outputs[0][i]);
--                }
-+		  }
-+		}
-
-                 ARMNN_LOG(info) << "\nInference time: " << std::setprecision(2)
-                                 << std::fixed << inference_duration.count() << " ms\n";

--- a/docker/tensorflow-lite-aarch64/patches/tflite.patch
+++ b/docker/tensorflow-lite-aarch64/patches/tflite.patch
@@ -1,5 +1,5 @@
  *******************************************************************************
- Copyright 2021 Arm Limited and affiliates.
+ Copyright 2021-2022 Arm Limited and affiliates.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,27 +15,24 @@
  limitations under the License.
  *******************************************************************************
 
-diff --git a/tensorflow/lite/CMakeLists.txt b/tensorflow/lite/CMakeLists.txt
-index ae956a747dd..4cbae4604de 100644
---- a/tensorflow/lite/CMakeLists.txt
-+++ b/tensorflow/lite/CMakeLists.txt
-@@ -446,6 +446,11 @@ if(TFLITE_ENABLE_GPU)
-   )
- endif()  # TFLITE_ENABLE_GPU
-
-+list(APPEND TFLITE_BENCHMARK_SRCS
+diff --git a/tensorflow/lite/tools/benchmark/CMakeLists.txt b/tensorflow/lite/tools/benchmark/CMakeLists.txt
+index d66af0dcd4a..8eeb215b5a6 100644
+--- a/tensorflow/lite/tools/benchmark/CMakeLists.txt
++++ b/tensorflow/lite/tools/benchmark/CMakeLists.txt
+@@ -33,6 +33,8 @@ list(APPEND TFLITE_BENCHMARK_SRCS
+   ${TFLITE_SOURCE_DIR}/tools/delegates/delegate_provider.cc
+   ${TFLITE_SOURCE_DIR}/tools/evaluation/utils.cc
+   ${TFLITE_SOURCE_DIR}/tools/tool_params.cc
 +  ${TFLITE_SOURCE_DIR}/tools/delegates/external_delegate_provider.cc
 +  ${TFLITE_SOURCE_DIR}/delegates/external/external_delegate.cc
-+)
-+
- add_executable(benchmark_model
-   EXCLUDE_FROM_ALL
-   ${TFLITE_BENCHMARK_SRCS}
+ )
+
+ list(APPEND TFLITE_BENCHMARK_LIBS
 diff --git a/tensorflow/lite/tools/benchmark/benchmark_model.cc b/tensorflow/lite/tools/benchmark/benchmark_model.cc
-index 617fa7d84b6..f77f1c87e02 100644
+index 610afe273bc..bb7355036e9 100644
 --- a/tensorflow/lite/tools/benchmark/benchmark_model.cc
 +++ b/tensorflow/lite/tools/benchmark/benchmark_model.cc
-@@ -55,7 +55,8 @@ void BenchmarkLoggingListener::OnBenchmarkEnd(const BenchmarkResults& results) {
+@@ -63,7 +63,8 @@ void BenchmarkLoggingListener::OnBenchmarkEnd(const BenchmarkResults& results) {
                     << "Init: " << init_us << ", "
                     << "First inference: " << warmup_us.first() << ", "
                     << "Warmup (avg): " << warmup_us.avg() << ", "
@@ -45,47 +42,3 @@ index 617fa7d84b6..f77f1c87e02 100644
 
    if (!init_mem_usage.IsSupported()) return;
    TFLITE_LOG(INFO)
-diff --git a/tensorflow/lite/tools/benchmark/benchmark_tflite_model.cc b/tensorflow/lite/tools/benchmark/benchmark_tflite_model.cc
-index 511244cee88..bf4636b9351 100644
---- a/tensorflow/lite/tools/benchmark/benchmark_tflite_model.cc
-+++ b/tensorflow/lite/tools/benchmark/benchmark_tflite_model.cc
-@@ -610,6 +610,7 @@ TfLiteStatus BenchmarkTfLiteModel::Init() {
-   interpreter_->SetAllowFp16PrecisionForFp32(params_.Get<bool>("allow_fp16"));
-
-   owned_delegates_.clear();
-+  std::unordered_set<int> checked_node_ids;
-   for (const auto& delegate_provider :
-        tools::GetRegisteredDelegateProviders()) {
-     auto delegate = delegate_provider->CreateTfLiteDelegate(params_);
-@@ -626,12 +627,17 @@ TfLiteStatus BenchmarkTfLiteModel::Init() {
-       int num_delegated_kernels = 0;
-       for (int i = 0; i < interpreter_->execution_plan().size(); ++i) {
-         int node_id = interpreter_->execution_plan()[i];
-+	if(checked_node_ids.find(node_id) != checked_node_ids.end()) {
-+	  continue;
-+	}
-         const TfLiteNode& node =
-             interpreter_->node_and_registration(node_id)->first;
--        if (delegate.get() == node.delegate) {
-+	if(node.delegate != nullptr) {
-           num_delegated_kernels++;
-+	  checked_node_ids.insert(node_id);
-         }
-       }
-+
-       bool fully_delegated = (num_delegated_kernels == 1 &&
-                               interpreter_->execution_plan().size() == 1);
-
-diff --git a/tensorflow/lite/tools/cmake/modules/xnnpack.cmake b/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
-index e5f205c0b0b..b6f8772dd27 100644
---- a/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
-+++ b/tensorflow/lite/tools/cmake/modules/xnnpack.cmake
-@@ -22,7 +22,7 @@ include(FetchContent)
- OverridableFetchContent_Declare(
-   xnnpack
-   GIT_REPOSITORY https://github.com/google/xnnpack
--  GIT_TAG 0af63ab36b899559bd1a92bbc327f8137e53c15c
-+  GIT_TAG be3d8fdffe8eb71b80835f168d4a550bb5d80f12
-   GIT_PROGRESS TRUE
-   PREFIX "${CMAKE_BINARY_DIR}"
-   SOURCE_DIR "${CMAKE_BINARY_DIR}/xnnpack"

--- a/docker/tensorflow-lite-aarch64/scripts/build-armcl.sh
+++ b/docker/tensorflow-lite-aarch64/scripts/build-armcl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,9 +23,10 @@ cd $PACKAGE_DIR
 
 git clone https://review.mlplatform.org/ml/ComputeLibrary
 cd ComputeLibrary/
-git checkout ee301b384f4aeb697a5c249b8bb848d784146582
+git checkout tags/v22.02 -b v22.02
 
+# This patch adds support for spin wait scheduler to ACL
 patch -p1 < ../acl.patch
 
 readonly num_cpus=$(grep -c ^processor /proc/cpuinfo)
-scons -j ${num_cpus} arch=arm64-v8.2-a build=native os=linux neon=1 extra_cxx_flags="-fPIC" benchmark_tests=0 validation_tests=0
+scons -j ${num_cpus} arch=armv8.2-a build=native os=linux neon=1 extra_cxx_flags="-fPIC" benchmark_tests=0 validation_tests=0 multi_isa=1

--- a/docker/tensorflow-lite-aarch64/scripts/build-armnn.sh
+++ b/docker/tensorflow-lite-aarch64/scripts/build-armnn.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -36,8 +36,8 @@ make install
 cd $PACKAGE_DIR
 git clone https://review.mlplatform.org/ml/armnn
 cd armnn
-git checkout 1625efc870f1a8b7c6e6382277ddbb245f91a294
+git checkout tags/v22.02 -b v22.02
 patch -p1 < ../armnn.patch
 mkdir build && cd build
-cmake .. -DARMCOMPUTE_ROOT=$PACKAGE_DIR/ComputeLibrary -DARMCOMPUTE_BUILD_DIR=$PACKAGE_DIR/ComputeLibrary/build -DSHARED_BOOST=ON -DBUILD_TF_LITE_PARSER=1 -DTF_LITE_GENERATED_PATH=$PACKAGE_DIR/tensorflow_src/tensorflow/lite/schema -DFLATBUFFERS_ROOT=$PACKAGE_DIR/flatbuffers -DFLATC_DIR=$PACKAGE_DIR/flatbuffers-1.12.0/build -DARMCOMPUTENEON=1 -DARMNNREF=1 -DBUILD_TESTS=1 -DBUILD_ARMNN_TFLITE_DELEGATE=1 -DTENSORFLOW_ROOT=$PACKAGE_DIR/tensorflow_src -DTFLITE_LIB_ROOT=$PACKAGE_DIR/tflite_build -DFLATBUFFERS_ROOT=$PACKAGE_DIR/flatbuffers
+cmake .. -DARMCOMPUTE_ROOT=$PACKAGE_DIR/ComputeLibrary -DARMCOMPUTE_BUILD_DIR=$PACKAGE_DIR/ComputeLibrary/build -DBUILD_TF_LITE_PARSER=1 -DTF_LITE_GENERATED_PATH=$PACKAGE_DIR/tensorflow_src/tensorflow/lite/schema -DFLATBUFFERS_ROOT=$PACKAGE_DIR/flatbuffers -DFLATC_DIR=$PACKAGE_DIR/flatbuffers-1.12.0/build -DARMCOMPUTENEON=1 -DARMNNREF=1 -DBUILD_TESTS=1 -DBUILD_ARMNN_TFLITE_DELEGATE=1 -DTENSORFLOW_ROOT=$PACKAGE_DIR/tensorflow_src -DTFLITE_LIB_ROOT=$PACKAGE_DIR/tflite_build -DFLATBUFFERS_ROOT=$PACKAGE_DIR/flatbuffers
 make -j ${num_cpus}

--- a/docker/tensorflow-lite-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-lite-aarch64/scripts/build-tensorflow.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@ git clone ${src_host}/${src_repo}.git ${dst_repo}
 cd ${dst_repo}
 git checkout tags/v${version}
 
-echo 'Using the latest commit for XNNPACK fetch'
+echo 'Enabling benchmark_model to use external delegate'
 patch -p1 < ../tflite.patch
 
 cd ..
@@ -43,3 +43,9 @@ cmake ../${dst_repo}/tensorflow/lite -DTFLITE_ENABLE_RUY=ON
 cmake --build . -j ${num_cpus}
 
 cmake --build . -j ${num_cpus} -t benchmark_model
+
+# We need to build single RUY library to use from ArmNN
+cp ../libruy.mri _deps/ruy-build
+pushd _deps/ruy-build
+ar -M <libruy.mri
+popd

--- a/docker/tensorflow-lite-aarch64/scripts/libruy.mri
+++ b/docker/tensorflow-lite-aarch64/scripts/libruy.mri
@@ -1,0 +1,39 @@
+; *******************************************************************************
+; Copyright 2022 Arm Limited and affiliates.
+; SPDX-License-Identifier: Apache-2.0
+;
+; Licensed under the Apache License, Version 2.0 (the "License");
+; you may not use this file except in compliance with the License.
+; You may obtain a copy of the License at
+;
+;     http://www.apache.org/licenses/LICENSE-2.0
+;
+; Unless required by applicable law or agreed to in writing, software
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
+; *******************************************************************************
+
+create libruy.a
+addlib ruy/libruy_system_aligned_alloc.a
+addlib ruy/libruy_apply_multiplier.a
+addlib ruy/libruy_denormal.a
+addlib ruy/libruy_wait.a
+addlib ruy/libruy_block_map.a
+addlib ruy/libruy_prepacked_cache.a
+addlib ruy/libruy_allocator.a
+addlib ruy/libruy_blocking_counter.a
+addlib ruy/libruy_cpuinfo.a
+addlib ruy/libruy_thread_pool.a
+addlib ruy/libruy_tune.a
+addlib ruy/libruy_kernel_arm.a
+addlib ruy/libruy_pack_arm.a
+addlib ruy/libruy_ctx.a
+addlib ruy/libruy_prepare_packed_matrices.a
+addlib ruy/libruy_trmul.a
+addlib ruy/libruy_context.a
+addlib ruy/libruy_frontend.a
+addlib ruy/libruy_context_get_ctx.a
+save
+end

--- a/docker/tensorflow-lite-aarch64/scripts/run_mobilenet.sh
+++ b/docker/tensorflow-lite-aarch64/scripts/run_mobilenet.sh
@@ -15,4 +15,4 @@ echo 'Executing MobileNetV1 ten times with ArmNN as standalone...'
 taskset -c 0-$((num_cpus-1)) /packages/armnn/build/tests/ExecuteNetwork -c CpuAcc -f tflite-binary -m mobilenet_v1_1.0_224.tflite -T parser -i input -o MobilenetV1/Predictions/Reshape_1 --number-of-threads ${num_cpus} --iterations 10
 
 echo 'Executing MobileNetV1 ten times with ArmNN as delegate...'
-taskset -c 0-$((num_cpus-1)) /packages/tflite_build/benchmark_model --graph=mobilenet_v1_1.0_224.tflite --external_delegate_path=/packages/armnn/build/delegate/libarmnnDelegate.so --external_delegate_options="backends:CpuAcc;number-of-threads:${num_cpus}" --num_runs=10 --warmup_runs=5
+taskset -c 0-$((num_cpus-1)) /packages/tflite_build/tools/benchmark/benchmark_model --graph=mobilenet_v1_1.0_224.tflite --external_delegate_path=/packages/armnn/build/delegate/libarmnnDelegate.so --external_delegate_options="backends:CpuAcc;number-of-threads:${num_cpus}" --num_runs=10 --warmup_runs=5


### PR DESCRIPTION
… optimization

- Truncate question to 512 tokens in question answering examples
- Use global cache to save oneDNN primitives in TensorFlow
- Update TF and PyTorch builds to use ACL 22.02
- Updates TF build to use prebuilt wheel for OpenCV headless
- Update in TensorFlow-Lite Docker package TF to 2.8 and ArmNN to 22.02
- Adds spin wait scheduler for ArmNN+ACL builds
- Adds binary primitive support for oneDNN+ACL builds

Co-authored-by: Nathan Sircombe <nathan.sircombe@arm.com>
Co-authored-by: Milos Puzovic <milos.puzovic@arm.com>