### PR TITLE
Windows pmu-to-reg to import PMU event data

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Demonstration of ETAS ASCET-DEVELOPER model based design and code generation wit
 #### mathworks-support-packages
 Support packages to enable Arm Fast Models and Arm Compiler usage with MathWorks software such as Embedded Coder, Simulink, and MATLAB.
 
+#### Windows pmu-to-reg
+Script to expose Arm Performance Monitoring Unit (PMU) events to the Windows Management Instrumentation (WMI) system, allowing collection via tools such as Windows Performance Recorder.
 
 ## Contact Us
 Have questions, comments, and/or suggestions? Contact [arm-tool-solutions@arm.com](mailto:arm-tool-solutions@arm.com).

--- a/windows-pmu-to-reg/Example.wprp
+++ b/windows-pmu-to-reg/Example.wprp
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Example Windows Performance Recorder Profile to collect L1 cache hardware PMU events.
+     Requires event to have previously been imported to the Windows registry. -->
+<WindowsPerformanceRecorder Version="1.0">
+    <Profiles>
+        <SystemCollector Id="SystemCollector_PMC" Base="" Name="PMC Counter" Realtime="false">
+            <BufferSize Value="1024" />
+            <Buffers Value="128" />
+        </SystemCollector>
+
+        <EventCollector Id="EventCollector_PMC" Name="PMC Event Collector" Realtime="false">
+            <BufferSize Value="1024" />
+            <Buffers Value="128" />
+        </EventCollector>
+
+        <SystemProvider Id="SystemProvider_ProcThread" Base="">
+            <Keywords>
+                <Keyword Value="CSwitch" />
+            </Keywords>
+        </SystemProvider>
+
+        <HardwareCounter Id="HardwareCounter_PMC">
+            <Counters>
+                <!-- Events to collect -->
+                <Counter Value="INST_RETIRED" />
+                <Counter Value="L1I_CACHE_REFILL" />
+                <Counter Value="L1I_CACHE" />
+                <Counter Value="L1D_CACHE_REFILL" />
+                <Counter Value="L1D_CACHE" />
+            </Counters>
+            <Events>
+                <!-- Collect on context switch. -->
+                <Event Value="CSwitch" />
+            </Events>
+        </HardwareCounter>
+
+        <Profile Id="PMC.Light.File" Name="PMC" Description="AAA" Strict="true" LoggingMode="File" DetailLevel="Light">
+            <Collectors Operation="Add">
+                <SystemCollectorId Value="SystemCollector_PMC">
+                    <SystemProviderId Value="SystemProvider_ProcThread" />
+                    <HardwareCounterId Value="HardwareCounter_PMC" />
+                </SystemCollectorId>
+            </Collectors>
+        </Profile>
+
+        <Profile Id="PMC.Light.Memory" Name="PMC" Description="AAA" Strict="true" LoggingMode="Memory" DetailLevel="Light">
+            <Collectors Operation="Add">
+                <SystemCollectorId Value="SystemCollector_PMC">
+                    <SystemProviderId Value="SystemProvider_ProcThread" />
+                    <HardwareCounterId Value="HardwareCounter_PMC" />
+                </SystemCollectorId>
+            </Collectors>
+        </Profile>
+    </Profiles>
+</WindowsPerformanceRecorder>

--- a/windows-pmu-to-reg/README.md
+++ b/windows-pmu-to-reg/README.md
@@ -1,0 +1,82 @@
+
+Script to expose Arm Performance Monitoring Unit (PMU) events to the [Windows Management Instrumentation (WMI)](https://docs.microsoft.com/en-us/windows/win32/wmisdk/wmi-start-page) system.
+
+A Microsoft Windows registry file is generated for the specified CPU. Once imported, the PMU events will be available to the WMI system, and can be collected via tools such as [Windows Performance Recorder](https://docs.microsoft.com/en-us/windows-hardware/test/wpt/windows-performance-recorder).
+
+PMU event information is sourced from the [Arm Data repository](https://github.com/ARM-software/data). For event descriptions, see comments in the registry file, or the technical reference manual for your CPU on the [Arm Developer website](developer.arm.com).
+
+Usage
+=====
+```
+usage: pmu-to-reg.py [-h] cpu output
+
+Generate registry file for aarch64 PMU events
+
+positional arguments:
+  cpu         CPU to read PMU events for - e.g. "neoverse-n1". See https://github.com/ARM-software/data/ for more information
+  output      output (.reg) file for the PMU event data
+
+optional arguments:
+  -h, --help  show this help message and exit
+```
+Where CPU corresponds to a CPU filename in the [Arm Data repository](https://github.com/ARM-software/data/tree/master/pmu) - e.g.
+
+    $ python pmu-to-reg.py neoverse-n1 events.reg
+
+Collecting PMU events with Windows Performance Recorder
+=======================================================
+
+### Import event data
+
+    regedit events.reg
+
+### Reboot
+
+Reboot your system for the changes to take effect.
+
+### Verify events
+
+Verify that Windows Performance Recorder is now aware of the new events.
+
+```
+wpr -pmcsources
+Id  Name                        Interval  Min      Max
+--------------------------------------------------------------
+  0 Timer                          10000  1221    1000000
+...
+ 73 ASE_SPEC                       65536  4096 2147483647
+ 74 BR_IMMED_RETIRED               65536  4096 2147483647
+ 75 BR_INDIRECT_SPEC               65536  4096 2147483647
+ ...
+```
+
+### Create Windows Performance Recorder profile
+
+[Create a WPR profile](https://docs.microsoft.com/en-us/windows-hardware/test/wpt/authoring-recording-profiles) to specify which events to collect.
+
+[Example.wprp](Example.wprp) shows a profile named "PMC" that collects events for L1 cache analysis:
+* ``INST_RETIRED``
+* ``L1I_CACHE_REFILL``
+* ``L1I_CACHE``
+* ``L1D_CACHE_REFILL``
+* ``L1D_CACHE``
+
+### Collect a profile
+
+Using an administrator Command Prompt or PowerShell:
+
+Start recording:
+
+    wpr -start Example.wprp!PMC
+
+and later stop recording:
+
+    wpr -stop cache.etl
+
+### Analyse results
+
+e.g. by converting to a CSV file
+
+    xperf -i cache.etl -o cache.csv
+
+See the "Pmc" data rows.

--- a/windows-pmu-to-reg/pmu-to-reg.py
+++ b/windows-pmu-to-reg/pmu-to-reg.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+
+# Copyright 2022 Arm Limited
+
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import json
+import urllib
+from urllib.request import urlopen
+import sys
+
+ARM_ARCHITECTURE_ID = 0
+BASE_PATH = r"HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\WMI\ProfileSource"
+GITHUB_URL = "https://github.com/ARM-software/data"
+NEWLINE_PLACEHOLDER = " +//0 "
+
+
+def reg_path(*path_components):
+    return "[%s]" % "\\".join(path_components)
+
+
+def reg_dword(key, value):
+    return '"%s"=dword:%s' % (key, format(value, "08x"))
+
+
+def reg_comment(comment):
+    return "\n".join(["; " + x for x in comment.split(NEWLINE_PLACEHOLDER)])
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate registry file for aarch64 PMU events")
+    parser.add_argument("cpu", help='CPU to read PMU events for - e.g. "neoverse-n1". See %s for more information' % GITHUB_URL)
+    parser.add_argument("output", help="output (.reg) file for the PMU event data")
+    args = parser.parse_args()
+
+    # Fetch PMU events
+    json_data_url = "%s/raw/HEAD/pmu/%s.json" % (GITHUB_URL, args.cpu)
+    json_github_url = "%s/blob/HEAD/pmu/%s.json" % (GITHUB_URL, args.cpu)
+    pmu_tree_url = "%s/tree/HEAD/pmu" % GITHUB_URL
+    try:
+        root = json.load(urlopen(json_data_url))
+    except urllib.error.HTTPError:
+        print('Could not fetch PMU data for CPU "%s". See %s for available CPUs' % (args.cpu, pmu_tree_url), file=sys.stderr)
+        sys.exit(1)
+
+    events = root["events"]
+
+    # Write to registry file
+    with open(args.output, "w", newline="\r\n") as f:
+        def output(s=""):
+            print(s, file=f)
+
+        output("Windows Registry Editor Version 5.00")
+        output()
+        output(reg_comment("WMI profile source data for %s hardware PMU events." % args.cpu))
+        output(reg_comment("Generated from %s" % json_github_url))
+        output()
+        output(reg_path(BASE_PATH, args.cpu))
+        output(reg_dword("Architecture", ARM_ARCHITECTURE_ID), )
+        output()
+
+        for e in events:
+            if e["name"] != "CHAIN":  # Skip CHAIN meta-event
+                output(reg_path(BASE_PATH, args.cpu, e["name"]))
+                output(reg_comment(e["description"]))
+                output(reg_dword("Event", e["code"]))
+                output()


### PR DESCRIPTION
Script to expose Arm Performance Monitoring Unit (PMU) events to the
Windows Management Instrumentation (WMI) system, allowing collection via
tools such as Windows Performance Recorder.