### PR TITLE
Update Tool-Solutions/docker for 22.05 release

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -15,18 +15,31 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Fixed
 
+## [r22.05] 2022-05-06
+https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.05/docker/pytorch-aarch64
+
+### Added
+- Python vision examples updated to allow use of a local image file.
+
+### Changed
+
+### Removed
+
+### Fixed
+- Python vision examples will not download labels and images if they are already present.
+
 ## [r22.04] 2022-04-08
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.04/docker/pytorch-aarch64
 
 ### Added
-- Adds docker/pytorch-aarch64/CHANGELOG.md
+- Adds docker/pytorch-aarch64/CHANGELOG.md.
 
 ### Changed
-- Updates oneDNN to v2.6
-- Does not download model in example scripts if it was downloaded already
+- Updates oneDNN to v2.6.
+- Does not download model in example scripts if it was downloaded already.
 
 ### Fixed
-- Fixes git submodule init in SciPy build
+- Fixes git submodule init in SciPy build.
 
 ## [r22.03] 2022-03-18
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.03/docker/pytorch-aarch64

--- a/docker/pytorch-aarch64/examples/README.md
+++ b/docker/pytorch-aarch64/examples/README.md
@@ -14,7 +14,7 @@ To run inference on an image call:
 python classify_image.py -m ./resnet_v1-50.yml -i https://upload.wikimedia.org/wikipedia/commons/3/32/Weimaraner_wb.jpg
 ```
 
-Where the `-m` flag sets the configuration file (see below) that describes the model, and `-i` sets the URL of the image to classify.
+Where the `-m` flag sets the configuration file (see below) that describes the model, and `-i` sets the URL, or filename, of the image to classify.
 
 The file [resnet_v1-50.yml](resnet_v1-50.yml) provides, in [YAML format](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html), information about the model:
 
@@ -33,7 +33,7 @@ To run inference on example image call:
 python detect_objects.py -m ./ssd_resnet34.yml -i https://raw.githubusercontent.com/zhreshold/mxnet-ssd/master/data/demo/street.jpg
 ```
 
-Where `-m` sets the configuration file (see below) that describes the model, and `-i` sets the URL of the image in which you want to detect objects. The output of the script will list what object the model detected and with what confidence. It will also draw bounding boxes around those objects in a new image.
+Where `-m` sets the configuration file (see below) that describes the model, and `-i` sets the URL, or filename, of the image in which you want to detect objects. The output of the script will list what object the model detected and with what confidence. It will also draw bounding boxes around those objects in a new image.
 
 The file [ssd_resnet34.yml](ssd_resnet34.yml) provides, in [YAML format](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html) information about the model:
 - `name`: Name of the model used for inference

--- a/docker/pytorch-aarch64/examples/executor/model.py
+++ b/docker/pytorch-aarch64/examples/executor/model.py
@@ -106,7 +106,7 @@ class Model:
                     DownloadProgressBar("Downloading: " + model_name + "..."),
                 )
             except:  # pylint: disable=bare-except
-                return False
+                sys.exit("Failed to set up the model: failed to download model from %s", model_url)
 
         if "class" in model_descriptor["model"][0]:
             model_class = model_descriptor["model"][0]["class"]

--- a/docker/pytorch-aarch64/examples/utils/image.py
+++ b/docker/pytorch-aarch64/examples/utils/image.py
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -34,18 +34,23 @@ import cv2
 from . import common
 
 
-def _download_image(image_url):
+def _download_image(image_loc):
     """
     Download image to file
-    :param image_url: URL from where to download image
+    :param image_loc: URL or path for the image
     :returns: File name of downloaded image
     """
-    image_file = image_url.split("/")[-1]  # last part of URL
-    # Download the image
-    urllib.request.urlretrieve(image_url, image_file)
+    image_file = image_loc
+
+    if image_loc.startswith('http'):
+        image_file = image_loc.split("/")[-1]  # filename
+
+        if not os.path.isfile(image_file):
+            # Download the image if required
+            urllib.request.urlretrieve(image_loc, image_file)
 
     if not os.path.isfile(image_file):
-        sys.exit("Image %s does not exists!" % image_file)
+        sys.exit("Image %s does not exist!" % image_file)
 
     return image_file
 

--- a/docker/pytorch-aarch64/examples/utils/label.py
+++ b/docker/pytorch-aarch64/examples/utils/label.py
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,6 +18,8 @@
 Utility functions to label predictions
 """
 
+import os
+import sys
 import urllib.request
 import json
 
@@ -36,12 +38,21 @@ def classify_predictions(model_file, predictions):
     """
 
     model_descriptor = common.parse_model_file(model_file)
-    labels_url = model_descriptor["model"][0]["labels"]
+    labels_loc = model_descriptor["model"][0]["labels"]
+    labels_file = labels_loc
 
-    # Download labels
-    urllib.request.urlretrieve(labels_url, "labels.json")
+    # get labels file
+    if labels_loc.startswith('http'):
+        labels_file = labels_loc.split("/")[-1]  # filename
 
-    class_idx = json.load(open("labels.json"))
+        if not os.path.isfile(labels_file):
+            # Download the labels if required
+            urllib.request.urlretrieve(labels_loc, labels_file)
+
+    if not os.path.isfile(labels_file):
+        sys.exit("Labels file %s does not exist!" % labels_file)
+
+    class_idx = json.load(open(labels_file))
     labels = np.asarray([class_idx[str(k)][1] for k in range(len(class_idx))])
 
     probabilities = torch.nn.functional.softmax(predictions[0], dim=0)
@@ -62,12 +73,21 @@ def detected_objects(model_file, predictions):
     :param predictions: Results from running inference
     """
     model_descriptor = common.parse_model_file(model_file)
-    labels_url = model_descriptor["model"][0]["labels"]
+    labels_loc = model_descriptor["model"][0]["labels"]
+    labels_file = labels_loc
 
-    # Download labels
-    urllib.request.urlretrieve(labels_url, "detection_labels.txt")
+    # Get labels file
+    if labels_loc.startswith('http'):
+        labels_file = labels_loc.split("/")[-1]  # filename
+        if not os.path.isfile(labels_file):
+            # Download the labels if required
+            urllib.request.urlretrieve(labels_loc, labels_file)
+
+    if not os.path.isfile(labels_file):
+        sys.exit("Labels file %s does not exist!" % labels_file)
+
     labels = []
-    with open("detection_labels.txt") as labels_f:
+    with open(labels_file) as labels_f:
         for line in labels_f.readlines():
             labels.append(line.strip())
 

--- a/docker/pytorch-aarch64/examples/utils/vision_parser.py
+++ b/docker/pytorch-aarch64/examples/utils/vision_parser.py
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +42,7 @@ def parse_arguments():
         "-i",
         "--image",
         type=str,
-        help="URL to image that will be processed",
+        help="URL or filename of image to process",
         required=True,
     )
     parser.add_argument(
@@ -65,10 +65,16 @@ def parse_arguments():
         args["model"]
     ), "File describing model does not exists"
 
-    # Check whether the URL given for image exists
-    try:
-        requests.get(args["image"])
-    except requests.ConnectionError as _:
-        assert False, "Image URL is not available!"
+    # Check the image exists
+    if args["image"].startswith('http'):
+        try:
+            requests.get(args["image"])
+        except requests.ConnectionError as _:
+            assert False, "Image URL is not available!"
+    else:
+        try:
+            os.path.isfile(args["image"])
+        except:
+            assert False, "Image not found"
 
     return args

--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -15,23 +15,37 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Fixed
 
+## [r22.05] 2022-05-06
+https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.05/docker/tensorflow-aarch64
+
+### Added
+- Adds ACL-based PReLU primitive.
+- Python vision examples updated to allow use of a local image file.
+
+### Changed
+
+### Removed
+
+### Fixed
+- Python vision examples will not download labels and images if they are already present.
+
 ## [r22.04] 2022-04-08
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.04/docker/tensorflow-aarch64
 
 ### Added
-- Adds docker/tensorflow-aarch64/CHANGELOG.md
-- Adds capability to build TensorFlow with Eigen threadpool for oneDNN+ACL build
+- Adds docker/tensorflow-aarch64/CHANGELOG.md.
+- Adds capability to build TensorFlow with Eigen threadpool for oneDNN+ACL build.
 
 ### Changed
-- Updates oneDNN to v2.6
-- Does not download model in example scripts if it was downloaded already
+- Updates oneDNN to v2.6.
+- Does not download model in example scripts if it was downloaded already.
 
 ### Removed
-- Removes deprecated tensorflow/benchmarks from build
+- Removes deprecated tensorflow/benchmarks from build.
 
 ### Fixed
-- Fixes git submodule init in SciPy build
-- Fixes weight-updating when training models that have fully connected layers
+- Fixes git submodule init in SciPy build.
+- Fixes weight-updating when training models that have fully connected layers.
 
 ## [r22.03] 2022-03-18
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.03/docker/tensorflow-aarch64

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -297,6 +297,7 @@ ENV PATH=$PACKAGE_DIR/bazel:$PATH
 COPY patches/tf_acl.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_training.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_threadpool.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_prelu.patch $PACKAGE_DIR/.
 COPY patches/compute_library.patch $PACKAGE_DIR/.
 COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh

--- a/docker/tensorflow-aarch64/examples/README.md
+++ b/docker/tensorflow-aarch64/examples/README.md
@@ -14,7 +14,7 @@ To run inference on an image call:
 python classify_image.py -m ./resnet_v1-50.yml -i https://upload.wikimedia.org/wikipedia/commons/3/32/Weimaraner_wb.jpg
 ```
 
-Where the `-m` flag sets the configuration file (see below) that describes the model, and `-i` sets the URL of the image to classify.
+Where the `-m` flag sets the configuration file (see below) that describes the model, and `-i` sets the URL, or filename, of the image to classify.
 
 The file [resnet_v1-50.yml](py-api/resnet_v1-50.yml) provides, in [YAML format](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html), information about the model:
 
@@ -38,7 +38,7 @@ To run inference on example image call:
 python detect_objects.py -m ./ssd_resnet34.yml -i https://raw.githubusercontent.com/zhreshold/mxnet-ssd/master/data/demo/street.jpg
 ```
 
-Where `-m` sets the configuration file (see below) that describes the model, and `-i` sets the URL of the image in which you want to detect objects. The output of the script will list what object the model detected and with what confidence. It will also draw bounding boxes around those objects in a new image.
+Where `-m` sets the configuration file (see below) that describes the model, and `-i` sets the URL, or filename, of the image in which you want to detect objects. The output of the script will list what object the model detected and with what confidence. It will also draw bounding boxes around those objects in a new image.
 
 The file [ssd_resnet34.yml](py-api/ssd_resnet34.yml) provides, in [YAML format](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html) information about the model:
 - `name`: Name of the model used for inference

--- a/docker/tensorflow-aarch64/examples/py-api/executor/model.py
+++ b/docker/tensorflow-aarch64/examples/py-api/executor/model.py
@@ -19,6 +19,7 @@ Class that wraps around TensorFlow session and executes the frozen model
 """
 
 import os
+import sys
 import time
 import urllib.request
 import zipfile

--- a/docker/tensorflow-aarch64/examples/py-api/resnet_v1-50.yml
+++ b/docker/tensorflow-aarch64/examples/py-api/resnet_v1-50.yml
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,7 +20,7 @@ description: >-
   pretrained on the ImageNet dataset. For details on how this model was trained please see
   <https://github.com/mlcommons/training/tree/master/image_classification> for more information
 model:
-  - name: resnet_v1-50.pb
+  - name: resnet50_v1.pb
     source: https://zenodo.org/record/2535873/files/resnet50_v1.pb
     labels: https://s3.amazonaws.com/deep-learning-models/image-models/imagenet_class_index.json
 arguments:

--- a/docker/tensorflow-aarch64/examples/py-api/utils/image.py
+++ b/docker/tensorflow-aarch64/examples/py-api/utils/image.py
@@ -30,18 +30,23 @@ import tensorflow as tf
 from . import common
 
 
-def _download_image(image_url):
+def _download_image(image_loc):
     """
     Download image to file
-    :param image_url: URL from where to download image
+    :param image_loc: URL or path for the image
     :returns: File name of downloaded image
     """
-    image_file = image_url.split("/")[-1]  # last part of URL
-    # Download the image
-    urllib.request.urlretrieve(image_url, image_file)
+    image_file = image_loc
+
+    if image_loc.startswith('http'):
+        image_file = image_loc.split("/")[-1]  # filename
+
+        if not os.path.isfile(image_file):
+            # Download the image if required
+            urllib.request.urlretrieve(image_loc, image_file)
 
     if not os.path.isfile(image_file):
-        sys.exit("Image %s does not exists!" % image_file)
+        sys.exit("Image %s does not exist!" % image_file)
 
     return image_file
 

--- a/docker/tensorflow-aarch64/examples/py-api/utils/vision_parser.py
+++ b/docker/tensorflow-aarch64/examples/py-api/utils/vision_parser.py
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -42,7 +42,7 @@ def parse_arguments():
         "-i",
         "--image",
         type=str,
-        help="URL to image that will be processed",
+        help="URL or filename of image to process",
         required=True,
     )
     parser.add_argument(
@@ -93,10 +93,16 @@ def parse_arguments():
         args["model"]
     ), "File describing model does not exists"
 
-    # Check whether the URL given for image exists
-    try:
-        requests.get(args["image"])
-    except requests.ConnectionError as _:
-        assert False, "Image URL is not available!"
+    # Check the image exists
+    if args["image"].startswith('http'):
+        try:
+            requests.get(args["image"])
+        except requests.ConnectionError as _:
+            assert False, "Image URL is not available!"
+    else:
+        try:
+            os.path.isfile(args["image"])
+        except:
+            assert False, "Image not found"
 
     return args

--- a/docker/tensorflow-aarch64/patches/onednn_acl_prelu.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_prelu.patch
@@ -1,0 +1,318 @@
+ *******************************************************************************
+ Copyright 2022 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/src/cpu/aarch64/acl_prelu.cpp b/src/cpu/aarch64/acl_prelu.cpp
+new file mode 100644
+index 000000000..6e431bed0
+--- /dev/null
++++ b/src/cpu/aarch64/acl_prelu.cpp
+@@ -0,0 +1,61 @@
++/*******************************************************************************
++* Copyright 2022 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_prelu.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++template <data_type_t data_type>
++status_t acl_prelu_fwd_t<data_type>::execute_forward(
++        const exec_ctx_t &ctx) const {
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
++
++    status_t status = status::success;
++
++    auto src = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
++    auto weights = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
++    auto dst = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
++
++    // Retrieve primitive resource and configured Compute Library objects
++    auto *acl_resource
++            = ctx.get_resource_mapper()->get<acl_prelu_resource_t>(this);
++
++    acl_prelu_obj_t &acl_obj = acl_resource->get_acl_obj();
++
++    acl_obj.src_tensor.allocator()->import_memory(const_cast<data_t *>(src));
++    acl_obj.weights_tensor.allocator()->import_memory(
++            const_cast<data_t *>(weights));
++    acl_obj.dst_tensor.allocator()->import_memory(dst);
++
++    acl_obj.prelu.run();
++
++    acl_obj.src_tensor.allocator()->free();
++    acl_obj.weights_tensor.allocator()->free();
++    acl_obj.dst_tensor.allocator()->free();
++    return status;
++}
++
++template struct acl_prelu_fwd_t<data_type::f32>;
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_prelu.hpp b/src/cpu/aarch64/acl_prelu.hpp
+new file mode 100644
+index 000000000..e4e582e91
+--- /dev/null
++++ b/src/cpu/aarch64/acl_prelu.hpp
+@@ -0,0 +1,161 @@
++/*******************************************************************************
++* Copyright 2022 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++#ifndef CPU_AARCH64_ACL_PRELU_HPP
++#define CPU_AARCH64_ACL_PRELU_HPP
++
++#include "cpu/aarch64/acl_utils.hpp"
++#include "cpu/cpu_prelu_pd.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_prelu_obj_t {
++    arm_compute::NEPReluLayer prelu;
++    arm_compute::Tensor src_tensor;
++    arm_compute::Tensor weights_tensor;
++    arm_compute::Tensor dst_tensor;
++};
++
++struct acl_prelu_conf_t {
++    arm_compute::TensorInfo src_info;
++    arm_compute::TensorInfo weights_info;
++    arm_compute::TensorInfo dst_info;
++};
++
++struct acl_prelu_resource_t : public resource_t {
++    acl_prelu_resource_t() : acl_obj_(utils::make_unique<acl_prelu_obj_t>()) {}
++
++    status_t configure(const acl_prelu_conf_t &app) {
++        if (!acl_obj_) return status::out_of_memory;
++
++        // Init Compute Library tensors based on info from descriptor
++        acl_obj_->src_tensor.allocator()->init(app.src_info);
++        acl_obj_->weights_tensor.allocator()->init(app.weights_info);
++        acl_obj_->dst_tensor.allocator()->init(app.dst_info);
++
++        // clang-format off
++        acl_obj_->prelu.configure(
++            &acl_obj_->src_tensor,
++            &acl_obj_->weights_tensor,
++            &acl_obj_->dst_tensor);
++        // clang-format on
++
++        return status::success;
++    }
++
++    acl_prelu_obj_t &get_acl_obj() const { return *acl_obj_; }
++
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_prelu_resource_t);
++
++private:
++    std::unique_ptr<acl_prelu_obj_t> acl_obj_;
++}; // acl_prelu_resource_t
++
++template <data_type_t data_type>
++struct acl_prelu_fwd_t : public primitive_t {
++    struct pd_t : public cpu_prelu_fwd_pd_t {
++        using cpu_prelu_fwd_pd_t::cpu_prelu_fwd_pd_t;
++
++        DECLARE_COMMON_PD_T("acl", acl_prelu_fwd_t);
++
++        status_t init(engine_t *engine) {
++            using namespace format_tag;
++            using namespace acl_common_utils;
++
++            // Forward only
++            if (!prelu_pd_t::is_fwd()) return status::unimplemented;
++
++            // Only support f32 for now
++            data_type_t ddt = dst_md(0)->data_type;
++            if (ddt != data_type::f32) return status::unimplemented;
++
++            if (!set_default_formats()) return status::unimplemented;
++
++            if (!attr()->has_default_values()) return status::unimplemented;
++
++            // ACL pointwise arithmetic operators assume that the innermost
++            // dimensions are dense for src, weights and dst. So we try to permute
++            // the logical dims so that the innermost dim on each desc is dense
++            // (without any data reordering)
++            memory_desc_t src_d_permed, weights_d_permed, dst_d_permed;
++            CHECK(permute_common_dense_dimension_to_last(&src_d_permed,
++                    &weights_d_permed, &dst_d_permed, src_md(0), weights_md(0),
++                    dst_md(0)));
++
++            // Create ACL tensor infos with permuted descs
++            CHECK(tensor_info(app_.src_info, src_d_permed));
++            CHECK(tensor_info(app_.weights_info, weights_d_permed));
++            CHECK(tensor_info(app_.dst_info, dst_d_permed));
++
++            // This forces ACL not to parallelise with small workloads, this is
++            // a temporary fix and should be removed in future versions (TODO)
++            memory_desc_wrapper dst_d(dst_md(0));
++            if (dst_d.nelems() < 40000) {
++                size_t acl_y_axis_i = 1;
++                CHECK(insert_singleton_dimension(app_.src_info, acl_y_axis_i));
++                CHECK(insert_singleton_dimension(
++                        app_.weights_info, acl_y_axis_i));
++                CHECK(insert_singleton_dimension(app_.dst_info, acl_y_axis_i));
++            }
++
++            ACL_CHECK_VALID(arm_compute::NEPReluLayer::validate(
++                    &app_.src_info, &app_.weights_info, &app_.dst_info));
++
++            return status::success;
++        }
++
++        acl_prelu_conf_t app_;
++    }; // pd_t
++
++    acl_prelu_fwd_t(const pd_t *apd) : primitive_t(apd) {}
++
++    status_t create_resource(
++            engine_t *engine, resource_mapper_t &mapper) const override {
++        if (mapper.has_resource(this)) return status::success;
++
++        auto r = utils::make_unique<acl_prelu_resource_t>();
++        if (!r) return status::out_of_memory;
++
++        // Configure the resource based on information from primitive descriptor
++        auto status = r->configure(pd()->app_);
++
++        if (status != status::success) return status;
++
++        mapper.add(this, std::move(r));
++        return status;
++    }
++
++    typedef typename prec_traits<data_type>::type data_t;
++
++    status_t execute(const exec_ctx_t &ctx) const override {
++        return execute_forward(ctx);
++    }
++
++private:
++    // To guard the const execute_forward, the mutex must be 'mutable'
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++}; // acl_prelu_fwd_t
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_PRELU_HPP
+diff --git a/src/cpu/aarch64/acl_utils.hpp b/src/cpu/aarch64/acl_utils.hpp
+index 6480c8de6..07ad4010c 100644
+--- a/src/cpu/aarch64/acl_utils.hpp
++++ b/src/cpu/aarch64/acl_utils.hpp
+@@ -70,6 +70,32 @@ status_t permute_common_dense_dimension_to_last(memory_desc_t *d0_permed,
+         if (get_verbose()) printf("onednn_verbose,cpu,error,acl,%s\n", (msg)); \
+     } while (0)
+ 
++// Logs a custom 'info' line describing an unsupported case
++#define LOG_ACL_UNSUPPORTED(msg) \
++    do { \
++        if (get_verbose() >= 2) \
++            printf("onednn_verbose,cpu,acl,unsupported: %s\n", (msg)); \
++    } while (0)
++
++// Returns unimplemented if error code x is NOT OK
++#define ACL_CHECK_VALID(x) \
++    do { \
++        arm_compute::Status s = x; \
++        if (s.error_code() != arm_compute::ErrorCode::OK) { \
++            LOG_ACL_UNSUPPORTED(s.error_description().c_str()); \
++            return dnnl::impl::status::unimplemented; \
++        } \
++    } while (0)
++
++// Returns unimplemented on condition x == true
++#define ACL_CHECK_SUPPORT(x, msg) \
++    do { \
++        if (x) { \
++            LOG_ACL_UNSUPPORTED(msg); \
++            return dnnl::impl::status::unimplemented; \
++        } \
++    } while (0)
++
+ } // namespace acl_common_utils
+ 
+ } // namespace aarch64
+diff --git a/src/cpu/cpu_prelu_list.cpp b/src/cpu/cpu_prelu_list.cpp
+index a156e1ab1..90398507f 100644
+--- a/src/cpu/cpu_prelu_list.cpp
++++ b/src/cpu/cpu_prelu_list.cpp
+@@ -1,5 +1,6 @@
+ /*******************************************************************************
+ * Copyright 2020-2022 Intel Corporation
++* Copyright 2022 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -24,6 +25,11 @@
+ using namespace dnnl::impl::cpu::x64;
+ #endif
+ 
++#if DNNL_AARCH64_USE_ACL
++#include "cpu/aarch64/acl_prelu.hpp"
++using namespace dnnl::impl::cpu::aarch64;
++#endif
++
+ namespace dnnl {
+ namespace impl {
+ namespace cpu {
+@@ -37,6 +43,7 @@ const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map() {
+     static const std::map<pk_impl_key_t, std::vector<impl_list_item_t>> the_map = REG_PRELU_P({
+         {{forward}, {
+             CPU_INSTANCE_X64(jit_prelu_fwd_t)
++            CPU_INSTANCE_AARCH64_ACL(acl_prelu_fwd_t<f32>)
+             CPU_INSTANCE(ref_prelu_fwd_t)
+             nullptr,
+         }},

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -25,7 +25,7 @@ index 60deadb1962..82ab4c01098 100644
 -        sha256 = "d7a47caeb28d2c67dc8fa0d0f338b11fbf25b473a608f04cfed913aea88815a9",
 -        strip_prefix = "oneDNN-2.5",
 -        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.5.tar.gz"),
-+        patch_file = ["//third_party/mkl_dnn:onednn_acl_training.patch", "//third_party/mkl_dnn:onednn_acl_threadpool.patch"],
++        patch_file = ["//third_party/mkl_dnn:onednn_acl_training.patch", "//third_party/mkl_dnn:onednn_acl_threadpool.patch", "//third_party/mkl_dnn:onednn_acl_prelu.patch"],
 +        sha256 = "9695640f55acd833ddcef4776af15e03446c4655f9296e5074b1b178dd7a4fb2",
 +        strip_prefix = "oneDNN-2.6",
 +        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.6.tar.gz"),


### PR DESCRIPTION
Squashed commits:
* Adds ACL based prelu primitive
* adds missing 'import s' in several files
* adds missing error report for file-not-found
* fixes typo in variable name for label file location
* Minor fixes to python examples.
    * adds missing 'import sys' in several files
    * adds missing error report for file-not-found
    * fixes typo in variable name for label file location
* Allows Python examples to use local copies of models, images and
labels
* Simplifies the bazel build flags for TF.
    * cxxopts duplicating copts aren't required
    * `--config=noaws` is not required (default builds without issue)
    * `--config=v2` is now the default and doesn't need to be set
    * explicit linking to libm is not needed
    * passing `-fopenmp` through linkopts is not required

Co-authored-by: Nathan John Sircombe <nathan.sircombe@arm.com>
Co-authored-by: Alexandru Marian Bojan <alexandrumarian.bojan@arm.com>