### PR TITLE
Updates Compute Library version used for pytorch and tensorflow builds

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -10,6 +10,7 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 
 ### Changed
+- Updates the Compute Library version used for PyTorch builds from 22.02 to 22.05.
 
 ### Removed
 

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -141,7 +141,7 @@ ENV NP_MAKE="${njobs}" \
     ACL_ARCH="${acl_arch}"
 
 # Key version numbers
-ENV ACL_VERSION="v22.02" \
+ENV ACL_VERSION="v22.05" \
     OPENBLAS_VERSION=0.3.20 \
     NINJA_VERSION=1.9.0
 

--- a/docker/pytorch-aarch64/README.md
+++ b/docker/pytorch-aarch64/README.md
@@ -39,7 +39,7 @@ Where `<image tag>` identifies the image version, as well as the PyTorch version
 - `<torch version>` = PyTorch version, see [image contents](#image-contents).
 - `<backend>` = `openblas` or `onednn-acl`, see [optimized backend for AArch64](#optimized-backend-for-aarch64).
 
-For example: `r22.02-torch-1.10.0-onednn-acl`.
+For example: `r22.06-torch-1.11.0-onednn-acl`.
 
 ### Running the Docker image
 To run the downloaded image:
@@ -54,12 +54,12 @@ where `<image name>` is the name of the image, i.e. `armswdev/pytorch-arm-neover
   * OS: Ubuntu 20.04
   * Compiler: GCC 10.3
   * Maths libraries: [OpenBLAS](https://www.openblas.net/) 0.3.20
-  * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.5
-    - ACL 22.02, provides optimized implementations on AArch64 for main oneDNN primitives
+  * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.6
+    - ACL 22.05, provides optimized implementations on AArch64 for main oneDNN primitives
   * Python 3.8.10 environment containing:
     - NumPy 1.21.5
     - SciPy 1.7.3
-    - PyTorch 1.10.0
+    - PyTorch 1.11.0
   * [Examples](./examples/README.md) that demonstrate how to run ML models
     - [MLCommons :tm:](https://mlcommons.org/en/) benchmarks
     - Python API examples
@@ -152,7 +152,7 @@ For example:
 
 PyTorch can optionally be built with oneDNN, using the `--onednn` flag. By default this will use AArch64 optimized primitives from ACL where available. Specifying `--onednn reference` will disable ACL primitives and use oneDNN's reference C++ kernels throughout.
 
-For builds where ACL is enabled, setting the environment variable `DNNL_DEFAULT_FPMATH_MODE` to `BF16` or `ANY` will instruct ACL to dispatch fp32 workloads to bfloat16 kernels where hardware support permits. Note: this may introduce a drop in accuracy.
+For builds where ACL is enabled, setting the environment variable `ONEDNN_DEFAULT_FPMATH_MODE` to `BF16` or `ANY` will instruct ACL to dispatch fp32 workloads to bfloat16 kernels where hardware support permits. Note: this may introduce a drop in accuracy.
 
 By default, all packages will be built with optimizations for the host machine, equivalent to setting `-mcpu=native` at compile time for each component build.
 It is possible to choose a specific build target using the `--build-target` flag:

--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -10,6 +10,7 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 
 ### Changed
+- Updates the Compute Library version used for TensorFlow builds from 22.02 to 22.05.
 
 ### Removed
 

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -38,9 +38,9 @@ Where `<image tag>` identifies the image version, as well as the TensorFlow vers
 
 - `r<yy>.<mm>` = this identifies the monthly update to the images on Docker Hub; `yy` = year (e.g. 22 for 2022) and `mm` = month (e.g. 01 for January).
 - `<TF version>` = TensorFlow version, see [image contents](#image-contents).
-- `<backend>` = `eigen` or `onednn-acl`, see [optimized backend for AArch64](#optimized-backend-for-aarch64).
+- `<backend>` = `eigen`, `onednn-acl`, or `onednn-acl_threadpool` see [optimized backend for AArch64](#optimized-backend-for-aarch64).
 
-For example: `r22.02-tf-2.8.0-onednn-acl`.
+For example: `r22.06-tf-2.9.1-onednn-acl`.
 
 ### Running the Docker image
 To run the downloaded image:
@@ -54,12 +54,12 @@ where `<image name> `is the name of the image, i.e. `armswdev/tensorflow-arm-neo
   * OS: Ubuntu 20.04
   * Compiler: GCC 10.3
   * Maths libraries: [OpenBLAS](https://www.openblas.net/) 0.3.20, used for NumPy's BLAS functionality
-  * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.5
-    - ACL 22.02, provides optimized implementations on AArch64 for main oneDNN primitives
+  * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.6
+    - ACL 22.05, provides optimized implementations on AArch64 for main oneDNN primitives
   * Python 3.8.10 environment containing:
     - NumPy 1.21.5
     - SciPy 1.7.3
-    - TensorFlow 2.8.0
+    - TensorFlow 2.9.1
   * [Examples](./examples/README.md) that demonstrate how to run ML models
     - [MLCommons :tm:](https://mlcommons.org/en/) benchmarks with an optional patch to support benchmarking for TF oneDNN builds
     - TensorFlow Benchmarks
@@ -73,11 +73,11 @@ The default user account has sudo privileges (username `ubuntu`, password `Portl
 Separate images are provided with Eigen and oneDNN backends (as given in the image tag). The scripts in this repository can be used to build either.
 
  * **Eigen:** this is the default backend for a TensorFlow build on AArch64, suitable for both training and inference workloads.
- * **oneDNN:** this uses oneDNN with ACL, providing optimized implementations on AArch64 for key oneDNN primitives. It is intended for inference workloads on infrastructure-scale platforms. oneDNN optimizations can be disabled at runtime by setting the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
+ * **oneDNN:** this uses oneDNN with ACL, providing optimized implementations on AArch64 for key oneDNN primitives. There is the option to use either an OpenMP build of oneDNN, with ACL primitives leveraging ACl's CPP scheduler, or to use TensorFlow's Eigen threadpool throughout. Use the `--onednn acl` and `--onednn acl_threadpool` respectively to select between these options. The oneDNN backend is intended for inference workloads on infrastructure-scale platforms. oneDNN optimizations can be disabled at runtime by setting the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
 
 #### oneDNN runtime flags
 
-- `DNNL_DEFAULT_FPMATH_MODE`: For builds where ACL is enabled, setting the environment variable `DNNL_DEFAULT_FPMATH_MODE` to `BF16` or `ANY` will instruct ACL to dispatch fp32 workloads to bfloat16 kernels where hardware support permits. _Note: this may introduce a drop in accuracy._
+- `ONEDNN_DEFAULT_FPMATH_MODE`: For builds where ACL is enabled, setting the environment variable `ONEDNN_DEFAULT_FPMATH_MODE` to `BF16` or `ANY` will instruct ACL to dispatch fp32 workloads to bfloat16 kernels where hardware support permits. _Note: this may introduce a drop in accuracy._
 - `ARM_COMPUTE_SPIN_WAIT_CPP_SCHEDULER`: When running models with a high core count that have layers operating on small to medium inputs, the scheduling overhead for ACL can be reduced by setting the environment variable `ARM_COMPUTE_SPIN_WAIT_CPP_SCHEDULER` to `1`. _Note: this will increase CPU utilisation as worker threads in ACL will busy wait for new work and might create contention with other threads._
 - `TF_ENABLE_ONEDNN_OPTS`: enables the oneDNN backend and is set to 1 (i.e. enabled) by default. To disable the oneDNN+ACL backend, set to `0`. _Note: this flag is only available for imaged built with the oneDNN+ACL backend._
 
@@ -155,7 +155,7 @@ For example:
 
 For the base build: This will generate an image named 'tensorflow-base-v2', hyphenated with the version of TensorFlow chosen.
 
-TensorFlow can optionally be built with oneDNN, using the `--onednn` flag; in this case the oneDNN backend will be enabled by default, but can be disabled at runtime by setting the environment variable `TF_ENABLE_ONEDNN_OPTS=0`. 
+TensorFlow can optionally be built with oneDNN, using the `--onednn` flag; in this case the oneDNN backend will be enabled by default, but can be disabled at runtime by setting the environment variable `TF_ENABLE_ONEDNN_OPTS=0`.
 The backend for oneDNN can also be selected using the `--onednn` flag:
 This defaults to using ACL, but `--onednn reference` can also be selected to use the reference C++ kernels.
 Without the `--onednn` flag, the default Eigen backend of Tensorflow is chosen. For the final TensorFlow image with oneDNN: This will generate an image `tensorflow-v2$onednn` with the type of oneDNN backend chosen.

--- a/docker/tensorflow-aarch64/patches/compute_library.patch
+++ b/docker/tensorflow-aarch64/patches/compute_library.patch
@@ -20,7 +20,7 @@ index 000000000..c986ad52a
 --- /dev/null
 +++ b/arm_compute_version.embed
 @@ -0,0 +1,1 @@
-+"arm_compute_version=v22.02 Build options: {} Git hash=b'N/A'"
++"arm_compute_version=v22.05 Build options: {} Git hash=b'N/A'"
 \ No newline at end of file
 diff --git a/arm_compute/runtime/CPP/SpinWaitCPPScheduler.h b/arm_compute/runtime/CPP/SpinWaitCPPScheduler.h
 new file mode 100644

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -15,10 +15,10 @@
  limitations under the License.
  *******************************************************************************
 diff --git a/.bazelrc b/.bazelrc
-index b6a72c1e5d3..a4b4a9c8ddb 100644
+index f95e4347537..554f750a22f 100644
 --- a/.bazelrc
 +++ b/.bazelrc
-@@ -227,6 +227,11 @@ build:mkl_aarch64 --define=build_with_mkl_aarch64=true
+@@ -229,6 +229,11 @@ build:mkl_aarch64 --define=build_with_mkl_aarch64=true
  build:mkl_aarch64 --define=build_with_openmp=true
  build:mkl_aarch64 -c opt
  
@@ -31,7 +31,7 @@ index b6a72c1e5d3..a4b4a9c8ddb 100644
  build:cuda --repo_env TF_NEED_CUDA=1
  build:cuda --crosstool_top=@local_config_cuda//crosstool:toolchain
 diff --git a/tensorflow/tensorflow.bzl b/tensorflow/tensorflow.bzl
-index 143bc0294da..1053336f92e 100644
+index ffe445dad95..67043cb12dc 100644
 --- a/tensorflow/tensorflow.bzl
 +++ b/tensorflow/tensorflow.bzl
 @@ -40,6 +40,7 @@ load(
@@ -53,10 +53,10 @@ index 143bc0294da..1053336f92e 100644
          if_linux_x86_64(["-msse3"]) +
          if_ios_x86_64(["-msse4.1"]) +
 diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
-index 77c76aa6e20..95d2c30b86d 100644
+index 77c76aa6e20..ef630894acc 100644
 --- a/tensorflow/workspace2.bzl
 +++ b/tensorflow/workspace2.bzl
-@@ -183,10 +183,10 @@ def _tf_repositories():
+@@ -183,19 +183,19 @@ def _tf_repositories():
      tf_http_archive(
          name = "mkl_dnn_acl_compatible",
          build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
@@ -69,8 +69,53 @@ index 77c76aa6e20..95d2c30b86d 100644
 +        strip_prefix = "oneDNN-96ac81552014f2c77d6409d2d5e466b78722cdb5",
 +        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/96ac81552014f2c77d6409d2d5e466b78722cdb5.tar.gz"),
      )
-
+ 
      tf_http_archive(
+         name = "compute_library",
+-        sha256 = "11244b05259fb1c4af7384d0c3391aeaddec8aac144774207582db4842726540",
+-        strip_prefix = "ComputeLibrary-22.02",
++        sha256 = "94e2e9ff87c261a9c9987bc9024c449c48014f7fe707311bdfa76b87f3dda5c5",
++        strip_prefix = "ComputeLibrary-22.05",
+         build_file = "//third_party/compute_library:BUILD",
+         patch_file = ["//third_party/compute_library:compute_library.patch", "//third_party/compute_library:activation_func_correct_args.patch"],
+-        urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.02.tar.gz"),
++        urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.05.tar.gz"),
+     )
+ 
+     tf_http_archive(
+diff --git a/third_party/compute_library/BUILD b/third_party/compute_library/BUILD
+index e4f42b46d5c..ae36a8f16ea 100644
+--- a/third_party/compute_library/BUILD
++++ b/third_party/compute_library/BUILD
+@@ -38,6 +38,7 @@ cc_library(
+             "src/core/NEON/kernels/arm_conv/depthwise/interleaves/sve_*.cpp",
+             "src/core/NEON/kernels/batchnormalization/impl/SVE/*.cpp",
+             "src/cpu/kernels/**/sve/*.cpp",
++            "src/cpu/kernels/*/sve2/.cpp",
+             "src/cpu/kernels/**/impl/sve/*.cpp",
+             "**/*.h",
+         ],
+@@ -84,9 +85,11 @@ cc_library(
+             "src/core/NEON/kernels/arm_conv/**/kernels/a64_*/*.cpp",
+             "src/core/NEON/kernels/arm_conv/depthwise/*.cpp",
+             "src/core/NEON/kernels/arm_conv/depthwise/interleaves/a64_*.cpp",
+-            "src/core/NEON/kernels/batchnormalization/impl/NEON/*.cpp",
++            "src/core/NEON/kernels/arm_conv/depthwise/interleaves/generic*.cpp",
++           "src/core/NEON/kernels/batchnormalization/impl/NEON/*.cpp",
+             "src/cpu/*.cpp",
+             "src/cpu/kernels/*.cpp",
++           "src/cpu/kernels/*/generic/*.cpp",
+             "src/cpu/operators/**/*.cpp",
+             "src/cpu/utils/*.cpp",
+             "src/cpu/kernels/internal/*.cpp",
+@@ -108,6 +111,7 @@ cc_library(
+         "src/c/operators/AclActivation.cpp",
+         "src/core/NEON/kernels/arm_conv/pooling/kernels/cpp_nhwc_1x1_stride_any_depthfirst/generic.cpp",
+         "src/core/NEON/kernels/arm_conv/depthwise/interleaves/8b_mla.cpp",
++       "src/core/NEON/kernels/arm_conv/addressing.cpp",
+     ],
+     hdrs = glob([
+         "src/core/NEON/kernels/**/*.h",
 diff --git a/third_party/mkl_dnn/BUILD b/third_party/mkl_dnn/BUILD
 index d88bb1d88fd..89f20d39477 100644
 --- a/third_party/mkl_dnn/BUILD


### PR DESCRIPTION
Compute Library version updated from 22.02 to 22.05 for the
PyTorch and TensorFlow Docker builds.

Corrects version numbers in the README.

Adds note in the README covering acl_threadpool build of Tensorflow.