### PR TITLE
[pytorch-aarch64] upgrade to pytorch 1.12

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -8,9 +8,12 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [Unreleased]
 
 ### Added
+- Adds torchdata build script
 
 ### Changed
 - Updates the Compute Library version used for PyTorch builds from 22.02 to 22.05.
+- Updates PyTorch to v1.12.0, torchvision to v0.13.0, torchtext to v0.13.0 and torchdata to 0.4.0
+- Updates cmake version to 3.23.2
 
 ### Removed
 

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -1,5 +1,6 @@
 # *******************************************************************************
 # Copyright 2020-2022 Arm Limited and affiliates.
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -27,11 +28,21 @@ ENV PY_VERSION="${default_py_version}"
 
 RUN if ! [ "$(arch)" = "aarch64" ] ; then exit 1; fi
 
-#Install core OS packages
 RUN apt-get -y update && \
-    apt-get -y install software-properties-common && \
-    add-apt-repository ppa:ubuntu-toolchain-r/test && \
     apt-get -y install \
+      software-properties-common \
+      wget
+
+# Add additional repositories
+RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null \
+      | gpg --dearmor - \
+      | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null
+
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test && \
+    add-apt-repository 'deb https://apt.kitware.com/ubuntu/ focal main'
+
+# Install core OS packages
+RUN apt-get -y install \
       accountsservice \
       apport \
       at \
@@ -96,7 +107,6 @@ RUN apt-get -y update && \
       ufw \
       uuid-runtime \
       vim \
-      wget \
       xz-utils \
       zip \
       zlib1g-dev
@@ -270,10 +280,10 @@ ENV ONEDNN_BUILD="${onednn_opt}" \
 # Key version numbers
 ENV PY_VERSION="${default_py_version}" \
     ONEDNN_VERSION="v2.6" \
-    TORCH_VERSION=1.11.0 \
-    TORCHVISION_VERSION=0.12.0 \
-    TORCHDATA_VERSION=0.3.0 \
-    TORCHTEXT_VERSION=0.12.0
+    TORCH_VERSION=1.12.0 \
+    TORCHVISION_VERSION=0.13.0 \
+    TORCHDATA_VERSION=0.4.0 \
+    TORCHTEXT_VERSION=0.13.0
 
 # Use a PACKAGE_DIR in userspace
 WORKDIR /home/$DOCKER_USER
@@ -289,13 +299,18 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Build PyTorch
 COPY scripts/build-pytorch.sh $PACKAGE_DIR/.
 COPY patches/onednn.patch $PACKAGE_DIR/.
+COPY scripts/build-torchtext.sh $PACKAGE_DIR/.
+COPY scripts/build-torchdata.sh $PACKAGE_DIR/.
+
 RUN $PACKAGE_DIR/build-pytorch.sh
 # Install torchvision, torchdata and torchtext
-RUN pip install --no-cache-dir torchvision==$TORCHVISION_VERSION \
-    torchdata==$TORCHDATA_VERSION
+RUN pip install --no-cache-dir torchvision==$TORCHVISION_VERSION
+
 ENV VENV_PACKAGE_DIR=$VENV_DIR/lib/python$PY_VERSION/site-packages
-COPY scripts/build-torchtext.sh $PACKAGE_DIR/.
+# Build torchtext from source to workaround the undefined symbol issue with the wheel
 RUN $PACKAGE_DIR/build-torchtext.sh
+# Build torchdata from source because there is no wheel for v0.4.0
+RUN $PACKAGE_DIR/build-torchdata.sh
 
 CMD ["bash", "-l"]
 

--- a/docker/pytorch-aarch64/README.md
+++ b/docker/pytorch-aarch64/README.md
@@ -59,7 +59,7 @@ where `<image name>` is the name of the image, i.e. `armswdev/pytorch-arm-neover
   * Python 3.8.10 environment containing:
     - NumPy 1.21.5
     - SciPy 1.7.3
-    - PyTorch 1.11.0
+    - PyTorch 1.12.0
   * [Examples](./examples/README.md) that demonstrate how to run ML models
     - [MLCommons :tm:](https://mlcommons.org/en/) benchmarks
     - Python API examples

--- a/docker/pytorch-aarch64/scripts/build-torchdata.sh
+++ b/docker/pytorch-aarch64/scripts/build-torchdata.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2021-2022 Arm Limited and affiliates.
+# Copyright 2022 Arm Limited and affiliates.
+# Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -20,13 +21,13 @@
 set -euo pipefail
 
 cd $PACKAGE_DIR
-readonly package=torchtext
-readonly version=$TORCHTEXT_VERSION
+readonly package=torchdata
+readonly version=$TORCHDATA_VERSION
 readonly src_host=https://github.com/pytorch
-readonly src_repo=text
+readonly src_repo=data
 readonly cppflags="-I$VENV_PACKAGE_DIR/pybind11/include"
 
-# Clone TorchText
+# Clone Torchdata
 git clone ${src_host}/${src_repo}.git ${package}
 cd ${package}
 git checkout v$version -b v$version


### PR DESCRIPTION
Upgraded torch, text, vision and data versions
corresponding to pytorch 1.12 release. Additionally added 
source build support for torchdata as torchdata-0.4.0 aarch64 wheel
is not yet avaialble.