### PR TITLE
Updates TensorFlow and PyTorch builds.

### DIFF
--- a/docker/cmsis-models/build_basic_math.sh
+++ b/docker/cmsis-models/build_basic_math.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright 2020 ARM Limited.
+# Copyright 2020-2022 ARM Limited.
 # All rights reserved.
 #
 
@@ -66,7 +66,7 @@ else
     echo "Unknown Data Type: $DATATYPE"
     exit 1
 fi
-     
+
 
 # move into the test directory
 pushd $TESTDIR
@@ -88,7 +88,7 @@ cp -r cmake_"$CPU".sh build_"$CPU"_"$DATATYPE"
 cd build_"$CPU"_"$DATATYPE"
 ./cmake_"$CPU".sh
 
-NPROC=`grep -c ^processor /proc/cpuinfo`
+NPROC=`nproc`
 make -j $NPROC
 
 # all done

--- a/docker/pytorch-aarch64/scripts/build-opencv.sh
+++ b/docker/pytorch-aarch64/scripts/build-opencv.sh
@@ -23,7 +23,7 @@ cd $PACKAGE_DIR
 readonly package=opencv
 readonly src_host=https://github.com/opencv
 readonly src_repo=opencv
-readonly num_cpus=$(grep -c ^processor /proc/cpuinfo)
+readonly num_cpus=$(nproc)
 
 git clone ${src_host}/${src_repo}.git
 

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -25,7 +25,7 @@ readonly package=pytorch
 readonly version=$TORCH_VERSION
 readonly src_host=https://github.com/pytorch
 readonly src_repo=pytorch
-readonly num_cpus=$(grep -c ^processor /proc/cpuinfo)
+readonly num_cpus=$(nproc)
 
 # Clone PyTorch
 git clone ${src_host}/${src_repo}.git

--- a/docker/tensorflow-aarch64/examples/py-api/executor/model.py
+++ b/docker/tensorflow-aarch64/examples/py-api/executor/model.py
@@ -219,7 +219,7 @@ class Model:
         if self._frozen:
             self._load_frozen_model(model_name, model_descriptor["arguments"][0])
         else:
-            self._load_saved_model(model, name, model_descriptor["arguments"][0])
+            self._load_saved_model(model_name, model_descriptor["arguments"][0])
 
         return True
 

--- a/docker/tensorflow-aarch64/patches/onednn_acl_pooling.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_pooling.patch
@@ -16,7 +16,7 @@
  *******************************************************************************
 diff --git a/src/cpu/aarch64/acl_pooling.cpp b/src/cpu/aarch64/acl_pooling.cpp
 new file mode 100644
-index 0000000000..2bd80d7144
+index 000000000..2bd80d714
 --- /dev/null
 +++ b/src/cpu/aarch64/acl_pooling.cpp
 @@ -0,0 +1,53 @@
@@ -75,10 +75,10 @@ index 0000000000..2bd80d7144
 +} // namespace dnnl
 diff --git a/src/cpu/aarch64/acl_pooling.hpp b/src/cpu/aarch64/acl_pooling.hpp
 new file mode 100644
-index 0000000000..f80e9f879f
+index 000000000..62d197a3a
 --- /dev/null
 +++ b/src/cpu/aarch64/acl_pooling.hpp
-@@ -0,0 +1,241 @@
+@@ -0,0 +1,223 @@
 +/*******************************************************************************
 +* Copyright 2022 Arm Ltd. and affiliates
 +*
@@ -113,7 +113,6 @@ index 0000000000..f80e9f879f
 +};
 +
 +struct acl_pooling_conf_t {
-+    bool is_max_pool;
 +    arm_compute::PoolingLayerInfo pool_info;
 +    arm_compute::TensorInfo src_info;
 +    arm_compute::TensorInfo dst_info;
@@ -165,15 +164,37 @@ index 0000000000..f80e9f879f
 +
 +            const pooling_v2_desc_t *pod = desc();
 +
-+            const bool is_training
-+                    = pod->prop_kind == prop_kind::forward_training;
-+            if (pod->alg_kind == alg_kind::pooling_max && is_training)
-+                init_default_ws();
++            // Choose the pooling type
++            const alg_kind_t alg = pod->alg_kind;
++            const bool is_max_pool = (alg == alg_kind::pooling_max);
++            app.pool_info.pool_type = is_max_pool
++                    ? arm_compute::PoolingType::MAX
++                    : arm_compute::PoolingType::AVG;
++
++            // Max forward training requires a worksace tensor.
++            // For this workspace tensor, oneDNN uses pool window coordinates,
++            // Whereas ACL uses absolute image coordinates.
++            // Due to this mismatch, reject max forward training cases
++            ACL_CHECK_SUPPORT(
++                    (is_max_pool
++                            && pod->prop_kind == prop_kind::forward_training),
++                    "ACL does not support training for max pooling in oneDNN");
++
++            // When padding is larger than the kernel, infinite values are
++            // produced.
++            // ACL and oneDNN use different values to represent infinity
++            // which is difficult to account for, so return unimplemented.
++            // See https://github.com/oneapi-src/oneDNN/issues/1205
++            ACL_CHECK_SUPPORT(KH() <= padT() || KH() <= padB() || KW() <= padL()
++                            || KW() <= padR(),
++                    "ACL does not support pooling cases where padding >= kernel"
++                    " in oneDNN");
 +
 +            auto src_tag = memory_desc_matches_one_of_tag(
 +                    *src_md(), format_tag::nhwc, format_tag::nchw);
 +            auto dst_tag = memory_desc_matches_one_of_tag(
 +                    *dst_md(), format_tag::nhwc, format_tag::nchw);
++
 +            ACL_CHECK_SUPPORT(
 +                    utils::one_of(format_tag::undef, src_tag, dst_tag),
 +                    "src or dst is not format nhwc or nchw");
@@ -185,47 +206,8 @@ index 0000000000..f80e9f879f
 +            const int ndims = src_d.ndims();
 +            ACL_CHECK_SUPPORT(ndims != 4, "Tensor is not 4d");
 +
-+            // batch size
-+            const int mb = MB();
-+
-+            // src/input  channels, height, width
-+            const int ic = IC();
-+            const int ih = IH();
-+            const int iw = IW();
-+
-+            // dst/output channels, height, width
-+            const int oc = OC();
-+            const int oh = OH();
-+            const int ow = OW();
-+
-+            // weights height and width
-+            const int kh = KH();
-+            const int kw = KW();
-+
-+            // height and width strides
-+            const int stride_h = KSH();
-+            const int stride_w = KSW();
-+
-+            // Padding
-+            // left, right, top, bottom padding
-+            const unsigned int l_pad
-+                    = static_cast<unsigned int>(pod->padding[0][1]);
-+            const unsigned int t_pad
-+                    = static_cast<unsigned int>(pod->padding[0][0]);
-+            const unsigned int r_pad
-+                    = static_cast<unsigned int>(pod->padding[1][1]);
-+            const unsigned int b_pad
-+                    = static_cast<unsigned int>(pod->padding[1][0]);
-+
-+            // Choose the pooling type
-+            const alg_kind_t alg = pod->alg_kind;
-+            app.is_max_pool = (alg == alg_kind::pooling_max);
-+            app.pool_info.pool_type = app.is_max_pool
-+                    ? arm_compute::PoolingType::MAX
-+                    : arm_compute::PoolingType::AVG;
-+
 +            // Pooling window
-+            app.pool_info.pool_size = arm_compute::Size2D(kw, kh);
++            app.pool_info.pool_size = arm_compute::Size2D(KW(), KH());
 +            // Choose the data layout
 +            bool is_nspc = utils::one_of(src_tag, format_tag::nhwc);
 +            const auto acl_layout = is_nspc ? arm_compute::DataLayout::NHWC
@@ -235,24 +217,24 @@ index 0000000000..f80e9f879f
 +                    = acl_utils::get_acl_data_t(src_d.data_type());
 +
 +            ACL_CHECK_SUPPORT(
-+                    !use_acl_heuristic(mb * ic * oh * ow * kh * kw,
-+                            dnnl_get_max_threads(), app.is_max_pool, is_nspc),
++                    !use_acl_heuristic(MB() * IC() * OH() * OW() * KH() * KW(),
++                            dnnl_get_max_threads(), is_max_pool, is_nspc),
 +                    "ACL is unoptimal in this case");
 +
 +            app.pool_info.exclude_padding
 +                    = (alg == alg_kind::pooling_avg_exclude_padding);
 +
-+            app.pool_info.pad_stride_info = arm_compute::PadStrideInfo(stride_w,
-+                    stride_h, l_pad, r_pad, t_pad, b_pad,
++            app.pool_info.pad_stride_info = arm_compute::PadStrideInfo(KSW(),
++                    KSH(), padL(), padR(), padT(), padB(),
 +                    arm_compute::DimensionRoundingType::FLOOR);
 +
 +            app.src_info = arm_compute::TensorInfo(is_nspc
-+                            ? arm_compute::TensorShape(ic, iw, ih, mb)
-+                            : arm_compute::TensorShape(iw, ih, ic, mb),
++                            ? arm_compute::TensorShape(IC(), IW(), IH(), MB())
++                            : arm_compute::TensorShape(IW(), IH(), IC(), MB()),
 +                    1, acl_data_t, acl_layout);
 +            app.dst_info = arm_compute::TensorInfo(is_nspc
-+                            ? arm_compute::TensorShape(oc, ow, oh, mb)
-+                            : arm_compute::TensorShape(ow, oh, oc, mb),
++                            ? arm_compute::TensorShape(OC(), OW(), OH(), MB())
++                            : arm_compute::TensorShape(OW(), OH(), OC(), MB()),
 +                    1, acl_data_t, acl_layout);
 +
 +            ACL_CHECK_VALID(arm_compute::NEPoolingLayer::validate(
@@ -321,7 +303,7 @@ index 0000000000..f80e9f879f
 +
 +#endif // CPU_AARCH64_ACL_POOLING_HPP
 diff --git a/src/cpu/cpu_pooling_list.cpp b/src/cpu/cpu_pooling_list.cpp
-index 7cf93dd297..584f685bff 100644
+index 7cf93dd29..584f685bf 100644
 --- a/src/cpu/cpu_pooling_list.cpp
 +++ b/src/cpu/cpu_pooling_list.cpp
 @@ -1,6 +1,7 @@
@@ -351,7 +333,7 @@ index 7cf93dd297..584f685bff 100644
              CPU_INSTANCE(nchw_pooling_fwd_t<f32>)
              CPU_INSTANCE(nhwc_pooling_fwd_t<bf16>)
 diff --git a/tests/benchdnn/pool/pool.cpp b/tests/benchdnn/pool/pool.cpp
-index 734a282259..fc497d7115 100644
+index 734a28225..5517a131a 100644
 --- a/tests/benchdnn/pool/pool.cpp
 +++ b/tests/benchdnn/pool/pool.cpp
 @@ -1,5 +1,6 @@
@@ -361,9 +343,9 @@ index 734a282259..fc497d7115 100644
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
-@@ -150,6 +151,15 @@ void skip_invalid_prb(const prb_t *prb, res_t *res) {
-             return;
-         }
+@@ -134,6 +135,15 @@ void skip_unimplemented_prb(const prb_t *prb, res_t *res) {
+         res->state = SKIPPED, res->reason = CASE_NOT_SUPPORTED;
+         return;
      }
 +
 +#if DNNL_AARCH64_USE_ACL
@@ -376,85 +358,9 @@ index 734a282259..fc497d7115 100644
 +#endif
  }
  
- void setup_cmp(compare::compare_t &cmp, const prb_t *prb, data_kind_t kind,
-@@ -282,6 +292,11 @@ int doit(const prb_t *prb, res_t *res) {
-             ref_args.set(DNNL_ARG_DIFF_DST, d_dst_fp);
-             ref_args.set(DNNL_ARG_DIFF_SRC, d_src_fp);
- 
-+#if DNNL_AARCH64_USE_ACL
-+            // This is needed for pool::get_initial_min_value()
-+            // See https://github.com/oneapi-src/oneDNN/issues/1205
-+            const_cast<prb_t *>(prb)->is_acl = (res->impl_name == "acl");
-+#endif
-             check_correctness(prb, {SRC}, args, ref_args, setup_cmp, res);
-         }
-     }
-diff --git a/tests/benchdnn/pool/pool.hpp b/tests/benchdnn/pool/pool.hpp
-index b72807fb0d..3a58d9628b 100644
---- a/tests/benchdnn/pool/pool.hpp
-+++ b/tests/benchdnn/pool/pool.hpp
-@@ -1,5 +1,6 @@
- /*******************************************************************************
- * Copyright 2019-2022 Intel Corporation
-+* Copyright 2022 Arm Ltd. and affiliates
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
-@@ -153,6 +154,11 @@ struct prb_t : public desc_t {
-     alg_t alg;
-     attr_t attr;
-     int64_t user_mb;
-+#if DNNL_AARCH64_USE_ACL
-+    // This is needed for pool::get_initial_min_value()
-+    // See https://github.com/oneapi-src/oneDNN/issues/1205
-+    bool is_acl = false;
-+#endif
- 
-     int64_t kernel_size() const { return kd * kh * kw; }
- 
-diff --git a/tests/benchdnn/pool/ref_pool.cpp b/tests/benchdnn/pool/ref_pool.cpp
-index ce4c2b27cb..b69bb90035 100644
---- a/tests/benchdnn/pool/ref_pool.cpp
-+++ b/tests/benchdnn/pool/ref_pool.cpp
-@@ -1,5 +1,6 @@
- /*******************************************************************************
- * Copyright 2019-2022 Intel Corporation
-+* Copyright 2022 Arm Ltd. and affiliates
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
-@@ -20,6 +21,20 @@
- 
- namespace pool {
- 
-+float get_initial_min_value(const prb_t *prb) {
-+#if DNNL_AARCH64_USE_ACL
-+    // Ref: https://github.com/oneapi-src/oneDNN/issues/1205
-+    // Changes required to support ACL which use std::numeric_limits<float>::infinity()
-+    // for the minimum value of type float.
-+    if (prb->cfg[DST].dt == dnnl_f32 && prb->is_acl == true)
-+        return -std::numeric_limits<float>::infinity();
-+    else
-+        return lowest_dt(prb->cfg[DST].dt);
-+#else
-+    return lowest_dt(prb->cfg[DST].dt);
-+#endif
-+}
-+
- void compute_ref_fwd(const prb_t *prb, const args_t &args) {
-     const dnn_mem_t &src = args.find(DNNL_ARG_SRC);
-     const dnn_mem_t &dst = args.find(DNNL_ARG_DST);
-@@ -38,7 +53,7 @@ void compute_ref_fwd(const prb_t *prb, const args_t &args) {
- 
-         // XXX: this is a hack to let tests with padded area to pass for bf16
-         // dt due to the library initialize values with -max_dt, but not -INF.
--        float max_value = lowest_dt(prb->cfg[DST].dt);
-+        float max_value = get_initial_min_value(prb);
-         float avg_value = 0.;
-         // Set initial value based on ws data type
-         int ws_off = prb->kernel_size() <= UINT8_MAX ? UINT8_MAX : INT_MAX;
+ void skip_invalid_prb(const prb_t *prb, res_t *res) {
 diff --git a/tests/gtests/test_pooling_backward.cpp b/tests/gtests/test_pooling_backward.cpp
-index e33ee8683e..b74a50c09f 100644
+index e33ee8683..b74a50c09 100644
 --- a/tests/gtests/test_pooling_backward.cpp
 +++ b/tests/gtests/test_pooling_backward.cpp
 @@ -1,5 +1,6 @@
@@ -478,133 +384,26 @@ index e33ee8683e..b74a50c09f 100644
  } // namespace dnnl
 +#endif // DNNL_AARCH64_USE_ACL
 diff --git a/tests/gtests/test_pooling_forward.cpp b/tests/gtests/test_pooling_forward.cpp
-index 93f81e8149..45bbe35ee9 100644
+index 93f81e814..9252c48c9 100644
 --- a/tests/gtests/test_pooling_forward.cpp
 +++ b/tests/gtests/test_pooling_forward.cpp
-@@ -1,5 +1,6 @@
- /*******************************************************************************
- * Copyright 2016-2021 Intel Corporation
-+* Copyright 2022 Arm Ltd. and affiliates
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
-@@ -78,7 +79,14 @@ bool cuda_check_format_tags(memory::format_tag format) {
- 
- template <typename data_t>
- void check_pool_fwd(const pool_test_params_t &p, const memory &src,
--        const memory &dst, const memory &ws) {
-+        const memory &dst, const memory &ws
-+// Changes required to support ACL which use std::numeric_limits<float>::infinity()
-+// for the minimum value of type float. //Ref: https://github.com/oneapi-src/oneDNN/issues/1205
-+#if DNNL_AARCH64_USE_ACL
-+        ,
-+        const bool is_acl
-+#endif
-+) {
-     auto src_data = map_memory<data_t>(src);
-     auto dst_data = map_memory<data_t>(dst);
-     auto ws_data_ptr = map_memory<unsigned char>(ws);
-@@ -105,6 +113,12 @@ void check_pool_fwd(const pool_test_params_t &p, const memory &src,
- 
-     const bool is_cudnn_gpu = is_nvidia_gpu(src.get_engine());
- 
-+#if DNNL_AARCH64_USE_ACL
-+    // Changes required to support ACL which use std::numeric_limits<float>::infinity()
-+    // for the minimum value of type float
-+    const bool is_float = (src_d.data_type() == dnnl_f32);
-+#endif
-+
-     dnnl::impl::parallel_nd(pd.mb, pd.c, pd.od, pd.oh, pd.ow,
-             [&](memory::dim n, memory::dim c, memory::dim od, memory::dim oh,
-                     memory::dim ow) {
-@@ -125,7 +139,13 @@ void check_pool_fwd(const pool_test_params_t &p, const memory &src,
-                 // the padding area entirely
-                 typename acc_t<data_t>::type acc_ref
-                         = (p.aalgorithm == algorithm::pooling_max)
--                        ? std::numeric_limits<data_t>::lowest()
-+                        ?
-+#if DNNL_AARCH64_USE_ACL
-+                        (is_acl && is_float)
-+                                ? -std::numeric_limits<float>::infinity()
-+                                :
-+#endif
-+                                std::numeric_limits<data_t>::lowest()
-                         : data_t(0);
-                 int out_ref_index = 0;
-                 bool is_initialized = false;
-@@ -185,9 +205,22 @@ void check_pool_fwd(const pool_test_params_t &p, const memory &src,
-                 }
- 
-                 const data_t out_ref = (data_t)acc_ref;
-+
-+#if DNNL_AARCH64_USE_ACL
-+                // ACL returns out -Inf when data type is float and in cases where kh==ph
-+                if (out == -std::numeric_limits<float>::infinity()) {
-+                    // when data type is float. Compare out and out_ref when both are -Inf
-+                    ASSERT_EQ(out, out_ref);
-+                } else {
-+                    // For ACL builds that fallback to reference oneDNN kernels
-+                    ASSERT_NEAR(out, out_ref, 1e-6);
-+                }
-+#else
-                 ASSERT_NEAR(out, out_ref, 1e-6);
-+#endif
-                 // The workspace layout is different when the cuDNN backend is used
-                 // and therefore this check must be skipped
-+
-                 if ((p.aalgorithm == algorithm::pooling_max
-                             && p.aprop_kind == prop_kind::forward_training)
-                         && !is_cudnn_gpu) {
-@@ -278,6 +311,9 @@ class pooling_test_t : public ::testing::TestWithParam<pool_test_params_t> {
-         }
- 
-         memory p_src, p_dst;
-+#if DNNL_AARCH64_USE_ACL
-+        std::string impl {};
-+#endif
-         if (pd.dd == 0 && pd.dh == 0 && pd.dw == 0) {
-             auto pool_desc = pooling_forward::desc(p.aprop_kind, p.aalgorithm,
-                     p_src_desc, p_dst_desc, strides, ker, pad_l, pad_r);
-@@ -286,7 +322,9 @@ class pooling_test_t : public ::testing::TestWithParam<pool_test_params_t> {
+@@ -286,7 +289,6 @@ protected:
              // test construction from a C pd
              pool_prim_desc
                      = pooling_forward::primitive_desc(pool_prim_desc.get());
 -
-+#if DNNL_AARCH64_USE_ACL
-+            impl = query_impl_info(pool_prim_desc.get());
-+#endif
              check_prim_desc<pooling_forward::primitive_desc>(pool_prim_desc);
              if (p.src_format != memory::format_tag::any) {
                  ASSERT_TRUE(p_src_desc == pool_prim_desc.src_desc());
-@@ -318,6 +356,9 @@ class pooling_test_t : public ::testing::TestWithParam<pool_test_params_t> {
-             // test construction from a C pd
-             pool_prim_desc
-                     = pooling_v2_forward::primitive_desc(pool_prim_desc.get());
-+#if DNNL_AARCH64_USE_ACL
-+            impl = query_impl_info(pool_prim_desc.get());
-+#endif
- 
-             check_prim_desc<pooling_v2_forward::primitive_desc>(pool_prim_desc);
-             if (p.src_format != memory::format_tag::any) {
-@@ -343,8 +384,15 @@ class pooling_test_t : public ::testing::TestWithParam<pool_test_params_t> {
+@@ -343,7 +345,6 @@ protected:
                                      {DNNL_ARG_WORKSPACE, workspace}});
          }
          strm.wait();
 -
--        check_pool_fwd<data_t>(p, p_src, p_dst, workspace);
-+#if DNNL_AARCH64_USE_ACL
-+        const bool is_acl = (impl == "acl");
-+#endif
-+        check_pool_fwd<data_t>(p, p_src, p_dst, workspace
-+#if DNNL_AARCH64_USE_ACL
-+                ,
-+                is_acl
-+#endif
-+        );
+         check_pool_fwd<data_t>(p, p_src, p_dst, workspace);
          check_zero_tail<data_t>(0, p_dst);
      }
- };
-@@ -355,6 +403,11 @@ using pooling_test_u8 = pooling_test_t<uint8_t>;
+@@ -355,6 +356,11 @@ using pooling_test_u8 = pooling_test_t<uint8_t>;
  using pooling_test_s32 = pooling_test_t<int32_t>;
  using pool_test_params_float = pool_test_params_t;
  

--- a/docker/tensorflow-aarch64/scripts/build-boost.sh
+++ b/docker/tensorflow-aarch64/scripts/build-boost.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -25,7 +25,7 @@ mkdir -p $PACKAGE_DIR
 cd $PACKAGE_DIR
 readonly package=boost
 readonly boost_src=https://boostorg.jfrog.io/artifactory/main/release/1.70.0/source/boost_1_70_0.tar.bz2
-readonly num_cpus=$(grep -c ^processor /proc/cpuinfo)
+readonly num_cpus=$(nproc)
 wget $boost_src
 tar --bzip2 -xf boost_1_70_0.tar.bz2
 cd boost_1_70_0

--- a/docker/tensorflow-aarch64/scripts/build-opencv.sh
+++ b/docker/tensorflow-aarch64/scripts/build-opencv.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020-2021 Arm Limited and affiliates.
+# Copyright 2020-2022 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,7 +24,7 @@ cd $PACKAGE_DIR
 readonly package=opencv
 readonly src_host=https://github.com/opencv
 readonly src_repo=opencv
-readonly num_cpus=$(grep -c ^processor /proc/cpuinfo)
+readonly num_cpus=$(nproc)
 
 git clone ${src_host}/${src_repo}.git
 cd $src_repo

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -86,7 +86,7 @@ if [[ $ONEDNN_BUILD ]]; then
         ## Apply patches to the TensorFlow, Compute Library and oneDNN builds
         # Patches from upstream PRs to address a number of issues exposed by TF unit tests.
         # tf_test_fix_prs lists the upstream PRs from which to take patches.
-        readonly tf_test_fix_prs="56150 56218 56219 56086 56371"
+        readonly tf_test_fix_prs="56218 56219 56086 56371"
         for pr in ${tf_test_fix_prs}; do
             echo "Patching from upstream PR https://github.com/tensorflow/tensorflow/pull/${pr}."
             wget https://github.com/tensorflow/tensorflow/pull/${pr}.patch -O ../tf_test_fix-${pr}.patch

--- a/docker/tensorflow-lite-aarch64/scripts/build-armcl.sh
+++ b/docker/tensorflow-lite-aarch64/scripts/build-armcl.sh
@@ -28,5 +28,5 @@ git checkout tags/v22.02 -b v22.02
 # This patch adds support for spin wait scheduler to ACL
 patch -p1 < ../acl.patch
 
-readonly num_cpus=$(grep -c ^processor /proc/cpuinfo)
+readonly num_cpus=$(nproc)
 scons -j ${num_cpus} arch=armv8.2-a build=native os=linux neon=1 extra_cxx_flags="-fPIC" benchmark_tests=0 validation_tests=0 multi_isa=1

--- a/docker/tensorflow-lite-aarch64/scripts/build-armnn.sh
+++ b/docker/tensorflow-lite-aarch64/scripts/build-armnn.sh
@@ -19,7 +19,7 @@
 
 set -euo pipefail
 
-readonly num_cpus=$(grep -c ^processor /proc/cpuinfo)
+readonly num_cpus=$(nproc)
 
 cd $PACKAGE_DIR
 

--- a/docker/tensorflow-lite-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-lite-aarch64/scripts/build-tensorflow.sh
@@ -24,7 +24,7 @@ readonly version=$TF_VERSION
 readonly src_host=https://github.com/tensorflow
 readonly src_repo=tensorflow
 readonly dst_repo=tensorflow_src
-readonly num_cpus=$(grep -c ^processor /proc/cpuinfo)
+readonly num_cpus=$(nproc)
 
 # Clone tensorflow, build it and build benchmark_model binary
 git clone ${src_host}/${src_repo}.git ${dst_repo}

--- a/docker/tensorflow-lite-aarch64/scripts/run_mobilenet.sh
+++ b/docker/tensorflow-lite-aarch64/scripts/run_mobilenet.sh
@@ -5,7 +5,7 @@ wget https://zenodo.org/record/2269307/files/mobilenet_v1_1.0_224.tgz
 tar -xzf mobilenet_v1_1.0_224.tgz ./mobilenet_v1_1.0_224.tflite
 rm -f mobilenet_v1_1.0_224.tgz
 
-num_cpus=`grep -c ^processor /proc/cpuinfo`
+num_cpus=`nproc`
 if [ ${num_cpus} > 8 ];
 then
     num_cpus=8;


### PR DESCRIPTION
 - Updates pooling patch in TF build with latest changes to
   https://github.com/oneapi-src/oneDNN/pull/1387.
 - Removes patch based on https://github.com/tensorflow/tensorflow/pull/56150 
   from TF build since this has been abandoned due to a regression.
 - Fixes typo in Python examples.
 - Updates scripts to use nproc instead of working out core counts from proc/cpuinfo.

Co-authored-by: Amy Wignall <amy.wignall@arm.com>
Co-authored-by: Crefeda Rodrigues <crefeda.rodrigues@arm.com>
Co-authored-by: Diana Bite <diana.bite@arm.com>
Co-authored-by: Ramana Radhakrishnan <ramana.radhakrishnan@arm.com>