### PR TITLE
Updates for r22.10 increment

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -15,6 +15,9 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Fixed
 
+## [r22.10] 2022-10-21
+https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.10/docker/pytorch-aarch64
+
 ## [r22.09] 2022-09-16
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.09/docker/pytorch-aarch64
 

--- a/docker/pytorch-aarch64/README.md
+++ b/docker/pytorch-aarch64/README.md
@@ -1,5 +1,11 @@
 # PyTorch for AArch64
 
+**⚠ Please Note:**
+
+These builds may contain features currently in active development (see the [change-log](./CHANGELOG.md) for more detail) and are intended only for evaluation purposes.
+Testing of the full stack is limited to validation against the [examples](./examples/README.md) provided on a selection of AArch64 platforms, including Neoverse-V1 and Neoverse-N1.
+Release versions of PyTorch are available from: https://pypi.org/project/torch/.
+
 ## Contents
 * [Getting started with PyTorch on AArch64](#getting-started-with-pytorch-on-aarch64)
    * [Downloading an image from Docker Hub](#downloading-an-image-from-docker-hub)

--- a/docker/pytorch-aarch64/patches/welcome.txt
+++ b/docker/pytorch-aarch64/patches/welcome.txt
@@ -5,4 +5,13 @@ PyTorch for AArch64
 
 For more details, see: https://git.io/JMESY
 
+--------------------------------------------------------------------------------
+Please Note:
+This build may contain features currently in active development
+and is intended only for evaluation purposes.
+Testing of the full stack is limited to validation against the examples provided
+on a selection of AArch64 platforms, including Neoverse-V1, Neoverse-N1 and A72.
+
+Release versions of PyTorch are available from:
+https://pypi.org/project/torch/.
 =================================================================================

--- a/docker/pytorch-aarch64/patches/welcome_verbose.txt
+++ b/docker/pytorch-aarch64/patches/welcome_verbose.txt
@@ -23,4 +23,14 @@ The default user's home (/home/ubuntu) contains:
 
 - CK/ containing Collective Knowledge (https://cknowledge.org) repositories
   used to manange datasets for the MLCommons benchmarks.
+
+--------------------------------------------------------------------------------
+Please Note:
+This build may contain features currently in active development
+and is intended only for evaluation purposes.
+Testing of the full stack is limited to validation against the examples provided
+on a selection of AArch64 platforms, including Neoverse-V1, Neoverse-N1 and A72.
+
+Release versions of PyTorch are available from:
+https://pypi.org/project/torch/.
 =================================================================================

--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -14,6 +14,15 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Removed
 
 ### Fixed
+
+## [r22.10] 2022-10-21
+https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r22.10/docker/tensorflow-aarch64
+
+### Changed
+- Installs tensorflow-io in place of tensorflow-io-gcs-filesystem (which is in turn installed).
+- Updates oneDNN to v2.7
+
+### Fixed
 - oneDNN uses indirect convolution in fast math mode when input channels require padding.
 - ACL uses correct predicate when reading bias in the merge phase of SVE kernels.
 - Convolution and matmul oneDNN primitives only cast to BF16 if selected kernel is in fast math mode.
@@ -28,7 +37,6 @@ https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--
 - Support for SVE-128 and SVE-256 enabled in JITed eltwise primitives where HW support is available.
 
 ### Changed
-
 - Updates Compute Library to v22.08.
 - Updates oneDNN to 80d45b77f1a031a99d628b27aeea45b05f16b8b5.
 - Updates TensorFlow to v2.10.

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -231,7 +231,7 @@ RUN $PACKAGE_DIR/build-scipy.sh
 # to be removed in order for the OpenCV build to complete.
 RUN pip uninstall enum34 -y
 RUN HDF5_DIR=/usr/lib/aarch64-linux-gnu/hdf5/serial pip install h5py==3.1.0
-RUN pip install --no-cache-dir grpcio tensorflow-io-gcs-filesystem pytest
+RUN pip install --no-cache-dir grpcio tensorflow-io pytest
 RUN pip install --no-cache-dir ck==1.55.5 absl-py pycocotools pillow==8.2.0
 RUN pip install --no-cache-dir transformers pandas
 

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -1,5 +1,11 @@
 # TensorFlow for AArch64
 
+**⚠ Please Note:**
+
+These builds may contain features currently in active development (see the [change-log](./CHANGELOG.md) for more detail) and are intended only for evaluation purposes.
+Testing of the full stack is limited to validation against the [examples](./examples/README.md) provided on a selection of AArch64 platforms, including Neoverse-V1, Neoverse-N1 and A72.
+Release versions of TensorFlow are available from: https://pypi.org/project/tensorflow/.
+
 ## Contents
 * [Getting started with TensorFlow on AArch64](#getting-started-with-tensorflow-on-aarch64)
    * [Downloading an image from Docker Hub](#downloading-an-image-from-docker-hub)
@@ -54,8 +60,8 @@ where `<image name> `is the name of the image, i.e. `armswdev/tensorflow-arm-neo
   * OS: Ubuntu 20.04
   * Compiler: GCC 10.3
   * Maths libraries: [OpenBLAS](https://www.openblas.net/) 0.3.20, used for NumPy's BLAS functionality
-  * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.6
-    - ACL 22.05, provides optimized implementations on AArch64 for main oneDNN primitives
+  * [oneDNN](https://github.com/oneapi-src/oneDNN) 2.7
+    - ACL 22.08 provides optimized implementations on AArch64 for main oneDNN primitives
   * Python 3.8.10 environment containing:
     - NumPy 1.21.5
     - SciPy 1.7.3

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -27,9 +27,9 @@ index e255103df98..1b0bb41201f 100644
 -        strip_prefix = "oneDNN-70d1198de554e61081147c199d661df049233279",
 -        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/70d1198de554e61081147c199d661df049233279.tar.gz"),
 +        patch_file = ["//third_party/mkl_dnn:onednn_acl_threadcap.patch", "//third_party/mkl_dnn:onednn_acl_fixed_format_kernels.patch", "//third_party/mkl_dnn:onednn_acl_depthwise_convolution.patch"],
-+        sha256 = "3b5ccfd197ac7e1618747e3388a836f5e535b7afec1ea83fcee186fa35ba6386",
-+        strip_prefix = "oneDNN-80d45b77f1a031a99d628b27aeea45b05f16b8b5",
-+        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/80d45b77f1a031a99d628b27aeea45b05f16b8b5.tar.gz"),
++        sha256 = "fc2b617ec8dbe907bb10853ea47c46f7acd8817bc4012748623d911aca43afbb",
++        strip_prefix = "oneDNN-2.7",
++        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.7.tar.gz"),
      )
  
      tf_http_archive(

--- a/docker/tensorflow-aarch64/patches/welcome.txt
+++ b/docker/tensorflow-aarch64/patches/welcome.txt
@@ -5,5 +5,14 @@ TensorFlow for AArch64
 
 For more details, see: https://git.io/JMEy5
 
+--------------------------------------------------------------------------------
+Please Note:
+This build may contain features currently in active development
+and is intended only for evaluation purposes.
+Testing of the full stack is limited to validation against the examples provided
+on a selection of AArch64 platforms, including Neoverse-V1, Neoverse-N1 and A72.
+
+Release versions of TensorFlow are available from:
+https://pypi.org/project/tensorflow/.
 ================================================================================
 

--- a/docker/tensorflow-aarch64/patches/welcome_verbose.txt
+++ b/docker/tensorflow-aarch64/patches/welcome_verbose.txt
@@ -24,5 +24,15 @@ The default user's home (/home/ubuntu) contains:
 
 - CK/ containing Collective Knowledge (https://cknowledge.org) repositories
   used to manange datasets for the MLCommons benchmarks.
+
+--------------------------------------------------------------------------------
+Please Note:
+This build may contain features currently in active development
+and is intended only for evaluation purposes.
+Testing of the full stack is limited to validation against the examples provided
+on a selection of AArch64 platforms, including Neoverse-V1, Neoverse-N1 and A72.
+
+Release versions of TensorFlow are available from:
+https://pypi.org/project/tensorflow/.
 ================================================================================
 


### PR DESCRIPTION
- Updates oneDNN to 2.7 release
- Replaces tensorflow-io-gcs with tensorflow-io package
- Updates welcome message