### PR TITLE
Add support for gcc-9

### DIFF
--- a/fast-models-examples/cortex-m55/README.md
+++ b/fast-models-examples/cortex-m55/README.md
@@ -4,7 +4,7 @@ This example illustrates the use of the Cortex-M55 Fast Model for software devel
 
 The example is compatible with Windows and Linux host operating systems. Details of the latest supported platforms can be found in the release notes located here: https://developer.arm.com/tools-and-software/simulation-models/fast-models/release-history.
 
-This example was built and tested with Fast Models 11.10 (released in March 2020).  It will be kept current with the latest version of the tools. To build the example as  described you will need to have installed Fast Models and obtained an evaluation license.
+This example was built and tested with Fast Models 11.19 (released in September 2022).  It will be kept current with the latest version of the tools. To build the example as  described you will need to have installed Fast Models and obtained an evaluation license.
 
 * Fast Models can be downloaded from: https://developer.arm.com/tools-and-software/simulation-models/fast-models
 

--- a/fast-models-examples/cortex-m55/system/Makefile
+++ b/fast-models-examples/cortex-m55/system/Makefile
@@ -41,17 +41,19 @@ CXX_CMD = $(CXX) $(CXXFLAGS) -o $(TARGET) $(SRCS) $(LDFLAGS)
 .PHONY: dbg_gcc49_64 rel_gcc49_64
 .PHONY: dbg_gcc64_64 rel_gcc64_64
 .PHONY: dbg_gcc73_64 rel_gcc73_64
+.PHONY: dbg_gcc93_64 rel_gcc93_64
 
 .PHONY: dbg_gcc49_64_clean rel_gcc49_64_clean
 .PHONY: dbg_gcc64_64_clean rel_gcc64_64_clean
 .PHONY: dbg_gcc73_64_clean rel_gcc73_64_clean
+.PHONY: dbg_gcc93_64_clean rel_gcc93_64_clean
 
-dbg_gcc49_64 rel_gcc49_64 dbg_gcc64_64 rel_gcc64_64 dbg_gcc73_64 rel_gcc73_64:
+dbg_gcc49_64 rel_gcc49_64 dbg_gcc64_64 rel_gcc64_64 dbg_gcc73_64 rel_gcc73_64 dbg_gcc93_64 rel_gcc93_64:
 	$(SIMGEN_CMD) -b
 	cp $(BUILDDIR)/lib$(EVSLIB).so ./
 	$(CXX_CMD)
 
-dbg_gcc49_64_clean rel_gcc49_64_clean dbg_gcc64_64_clean rel_gcc64_64_clean dbg_gcc73_64_clean rel_gcc73_64_clean:
+dbg_gcc49_64_clean rel_gcc49_64_clean dbg_gcc64_64_clean rel_gcc64_64_clean dbg_gcc73_64_clean rel_gcc73_64_clean dbg_gcc93_64_clean rel_gcc93_64_clean:
 	-$(SIMGEN_CMD) --clean
 	-rm -f $(TARGET)
 	-rm -rf $(CONFIG)

--- a/fast-models-examples/cortex-m55/system/Makefile.common
+++ b/fast-models-examples/cortex-m55/system/Makefile.common
@@ -50,6 +50,7 @@ CXXFLAGS_gcc49 = -std=c++11
 CXXFLAGS_gcc54 = -std=c++11
 CXXFLAGS_gcc64 = -std=c++11
 CXXFLAGS_gcc73 = -std=c++11
+CXXFLAGS_gcc93 = -std=c++11
 CXXFLAGS += $(CXXFLAGS_$(word 2, $(subst _, ,$@)))
 
 # Determine binares and config to use from make target
@@ -61,6 +62,8 @@ GCC_VER_gcc64       = 6.4
 CONFIG_VER_gcc64    = 6.4
 GCC_VER_gcc73       = 7.3
 CONFIG_VER_gcc73    = 7.3
+GCC_VER_gcc93       = 9.3
+CONFIG_VER_gcc93    = 9.3
 
 
 GCC_VER = $(GCC_VER_$(word 2, $(subst _, ,$@)))
@@ -104,6 +107,10 @@ ifeq ($(CXX_VER),7)
 LDFLAGS += -latomic
 endif
 
+ifeq ($(CXX_VER),9)
+LDFLAGS += -latomic
+endif
+
 # Determine additional simgen flags
 ifneq ($(origin CXX),default)
     override SIMGENFLAGS += --gcc-path $(CXX)
@@ -141,6 +148,11 @@ endif
 ifeq ($(CXX_VER),7.4)
 DBG = dbg_gcc73_64
 REL = rel_gcc73_64
+endif
+
+ifeq ($(CXX_VER),9)
+DBG = dbg_gcc93_64
+REL = rel_gcc93_64
 endif
 
 

--- a/fast-models-examples/cortex-m55/system/build_linux.sh
+++ b/fast-models-examples/cortex-m55/system/build_linux.sh
@@ -10,6 +10,7 @@ GCC=`gcc -dumpversion 2> /dev/null |  sed -e "s/\([0-9]*\.[0-9]*\)\.[0-9]*/\1/" 
 GCC2=`gcc -dumpversion 2> /dev/null`
 
 case "$GCC" in 
+    9 ) make rel_gcc93_64 ; break ;;
     7 ) make rel_gcc73_64 ; break ;;
     6 ) make rel_gcc64_64 ; break ;;
     4 ) make rel_gcc49_64 ; break ;;

--- a/fast-models-examples/cortex-m55/system/clean_linux.sh
+++ b/fast-models-examples/cortex-m55/system/clean_linux.sh
@@ -10,6 +10,7 @@ GCC=`gcc -dumpversion 2> /dev/null |  sed -e "s/\([0-9]*\.[0-9]*\)\.[0-9]*/\1/" 
 GCC2=`gcc -dumpversion 2> /dev/null`
 
 case "$GCC" in 
+    9 ) make rel_gcc93_64_clean ; break ;;
     7 ) make rel_gcc73_64_clean ; break ;;
     6 ) make rel_gcc64_64_clean ; break ;;
     4 ) make rel_gcc49_64_clean ; break ;;

--- a/fast-models-examples/cortex-m55/system/m55.sgproj
+++ b/fast-models-examples/cortex-m55/system/m55.sgproj
@@ -1,20 +1,18 @@
 sgproject "m55.sgproj"
 {
 TOP_LEVEL_COMPONENT = "m55";
-ACTIVE_CONFIG_LINUX = "Linux64-Release-GCC-7.3";
+ACTIVE_CONFIG_LINUX = "Linux64-Release-GCC-9.3";
 ACTIVE_CONFIG_WINDOWS = "Win64-Release-VC2017";
 config "Linux64-Debug-GCC-4.9"
 {
     ADDITIONAL_COMPILER_SETTINGS = "-march=core2 -ggdb3 -Wall -std=c++11";
     ADDITIONAL_LINKER_SETTINGS = "-Wl,--no-undefined";
     BUILD_DIR = "./Linux64-Debug-GCC-4.9";
-    COMPILER = "gcc-4.9";
     CONFIG_DESCRIPTION = "Default x86_64 Linux configuration for GCC 4.9 with debug information";
     CONFIG_NAME = "Linux64-Debug-GCC-4.9";
     ENABLE_DEBUG_SUPPORT = "1";
     PLATFORM = "Linux64";
     SIMGEN_COMMAND_LINE = "--num-comps-file 10";
-    TARGET_MAXVIEW = "0";
     TARGET_SYSTEMC = "1";
 }
 config "Linux64-Debug-GCC-6.4"
@@ -22,13 +20,12 @@ config "Linux64-Debug-GCC-6.4"
     ADDITIONAL_COMPILER_SETTINGS = "-march=core2 -ggdb3 -Wall -std=c++11 -Wno-deprecated -Wno-unused-function";
     ADDITIONAL_LINKER_SETTINGS = "-Wl,--no-undefined";
     BUILD_DIR = "./Linux64-Debug-GCC-6.4";
-    COMPILER = "gcc-6.4";
+    COMPILER = "gcc-6.3";
     CONFIG_DESCRIPTION = "Default x86_64 Linux configuration for GCC 6.4 with debug information";
     CONFIG_NAME = "Linux64-Debug-GCC-6.4";
     ENABLE_DEBUG_SUPPORT = "1";
     PLATFORM = "Linux64";
     SIMGEN_COMMAND_LINE = "--num-comps-file 10";
-    TARGET_MAXVIEW = "0";
     TARGET_SYSTEMC = "1";
 }
 config "Linux64-Debug-GCC-7.3"
@@ -42,7 +39,19 @@ config "Linux64-Debug-GCC-7.3"
     ENABLE_DEBUG_SUPPORT = "1";
     PLATFORM = "Linux64";
     SIMGEN_COMMAND_LINE = "--num-comps-file 10";
-    TARGET_MAXVIEW = "0";
+    TARGET_SYSTEMC = "1";
+}
+config "Linux64-Debug-GCC-9.3"
+{
+    ADDITIONAL_COMPILER_SETTINGS = "-march=core2 -ggdb3 -Wall -std=c++11 -Wno-deprecated -Wno-unused-function";
+    ADDITIONAL_LINKER_SETTINGS = "-Wl,--no-undefined";
+    BUILD_DIR = "./Linux64-Debug-GCC-9.3";
+    COMPILER = "gcc-9.3";
+    CONFIG_DESCRIPTION = "Default x86_64 Linux configuration for GCC 9 with debug information";
+    CONFIG_NAME = "Linux64-Debug-GCC-9.3";
+    ENABLE_DEBUG_SUPPORT = "1";
+    PLATFORM = "Linux64";
+    SIMGEN_COMMAND_LINE = "--num-comps-file 10";
     TARGET_SYSTEMC = "1";
 }
 config "Linux64-Release-GCC-4.9"
@@ -50,13 +59,11 @@ config "Linux64-Release-GCC-4.9"
     ADDITIONAL_COMPILER_SETTINGS = "-march=core2 -O3 -Wall -std=c++11";
     ADDITIONAL_LINKER_SETTINGS = "-Wl,--no-undefined";
     BUILD_DIR = "./Linux64-Release-GCC-4.9";
-    COMPILER = "gcc-4.9";
     CONFIG_DESCRIPTION = "Default x86_64 Linux configuration for GCC 4.9, optimized for speed";
     CONFIG_NAME = "Linux64-Release-GCC-4.9";
     PLATFORM = "Linux64";
     PREPROCESSOR_DEFINES = "NDEBUG";
     SIMGEN_COMMAND_LINE = "--num-comps-file 50";
-    TARGET_MAXVIEW = "0";
     TARGET_SYSTEMC = "1";
 }
 config "Linux64-Release-GCC-6.4"
@@ -64,13 +71,12 @@ config "Linux64-Release-GCC-6.4"
     ADDITIONAL_COMPILER_SETTINGS = "-march=core2 -O3 -Wall -std=c++11 -Wno-deprecated -Wno-unused-function";
     ADDITIONAL_LINKER_SETTINGS = "-Wl,--no-undefined";
     BUILD_DIR = "./Linux64-Release-GCC-6.4";
-    COMPILER = "gcc-6.4";
+    COMPILER = "gcc-6.3";
     CONFIG_DESCRIPTION = "Default x86_64 Linux configuration for GCC 6.4, optimized for speed";
     CONFIG_NAME = "Linux64-Release-GCC-6.4";
     PLATFORM = "Linux64";
     PREPROCESSOR_DEFINES = "NDEBUG";
     SIMGEN_COMMAND_LINE = "--num-comps-file 50";
-    TARGET_MAXVIEW = "0";
     TARGET_SYSTEMC = "1";
 }
 config "Linux64-Release-GCC-7.3"
@@ -84,7 +90,19 @@ config "Linux64-Release-GCC-7.3"
     PLATFORM = "Linux64";
     PREPROCESSOR_DEFINES = "NDEBUG";
     SIMGEN_COMMAND_LINE = "--num-comps-file 50";
-    TARGET_MAXVIEW = "0";
+    TARGET_SYSTEMC = "1";
+}
+config "Linux64-Release-GCC-9.3"
+{
+    ADDITIONAL_COMPILER_SETTINGS = "-march=core2 -O3 -Wall -std=c++11 -Wno-deprecated -Wno-unused-function";
+    ADDITIONAL_LINKER_SETTINGS = "-Wl,--no-undefined";
+    BUILD_DIR = "./Linux64-Release-GCC-9.3";
+    COMPILER = "gcc-9.3";
+    CONFIG_DESCRIPTION = "Default x86_64 Linux configuration for GCC 9, optimized for speed";
+    CONFIG_NAME = "Linux64-Release-GCC-9.3";
+    PLATFORM = "Linux64";
+    PREPROCESSOR_DEFINES = "NDEBUG";
+    SIMGEN_COMMAND_LINE = "--num-comps-file 50";
     TARGET_SYSTEMC = "1";
 }
 config "Win64-Debug-VC2015"
@@ -92,13 +110,11 @@ config "Win64-Debug-VC2015"
     ADDITIONAL_COMPILER_SETTINGS = "/Od /RTCsu /Zi";
     ADDITIONAL_LINKER_SETTINGS = "/DEBUG";
     BUILD_DIR = "./Win64-Debug-VC2015";
-    COMPILER = "VC2015";
     CONFIG_DESCRIPTION = "Default x86_64 Windows configuration for Visual Studio 2015 with debug information";
     CONFIG_NAME = "Win64-Debug-VC2015";
     ENABLE_DEBUG_SUPPORT = "1";
     PLATFORM = "Win64D";
     SIMGEN_WARNINGS_AS_ERRORS = "1";
-    TARGET_MAXVIEW = "0";
     TARGET_SYSTEMC = "1";
     TARGET_SYSTEMC_AUTO = "0";
     TARGET_SYSTEMC_ISIM = "0";
@@ -108,13 +124,11 @@ config "Win64-Debug-VC2017"
     ADDITIONAL_COMPILER_SETTINGS = "/Od /RTCsu /Zi";
     ADDITIONAL_LINKER_SETTINGS = "/DEBUG";
     BUILD_DIR = "./Win64-Debug-VC2017";
-    COMPILER = "VC2017";
     CONFIG_DESCRIPTION = "Default x86_64 Windows configuration for Visual Studio 2017 with debug information";
     CONFIG_NAME = "Win64-Debug-VC2017";
     ENABLE_DEBUG_SUPPORT = "1";
     PLATFORM = "Win64D";
     SIMGEN_WARNINGS_AS_ERRORS = "1";
-    TARGET_MAXVIEW = "0";
     TARGET_SYSTEMC = "1";
     TARGET_SYSTEMC_AUTO = "0";
     TARGET_SYSTEMC_ISIM = "0";
@@ -123,13 +137,11 @@ config "Win64-Release-VC2015"
 {
     ADDITIONAL_COMPILER_SETTINGS = "/O2";
     BUILD_DIR = "./Win64-Release-VC2015";
-    COMPILER = "VC2015";
     CONFIG_DESCRIPTION = "Default x86_64 Windows configuration for Visual Studio 2015, optimized for speed";
     CONFIG_NAME = "Win64-Release-VC2015";
     PLATFORM = "Win64";
     PREPROCESSOR_DEFINES = "NDEBUG";
     SIMGEN_WARNINGS_AS_ERRORS = "1";
-    TARGET_MAXVIEW = "0";
     TARGET_SYSTEMC = "1";
     TARGET_SYSTEMC_AUTO = "0";
     TARGET_SYSTEMC_ISIM = "0";
@@ -138,13 +150,11 @@ config "Win64-Release-VC2017"
 {
     ADDITIONAL_COMPILER_SETTINGS = "/O2";
     BUILD_DIR = "./Win64-Release-VC2017";
-    COMPILER = "VC2017";
     CONFIG_DESCRIPTION = "Default x86_64 Windows configuration for Visual Studio 2017, optimized for speed";
     CONFIG_NAME = "Win64-Release-VC2017";
     PLATFORM = "Win64";
     PREPROCESSOR_DEFINES = "NDEBUG";
     SIMGEN_WARNINGS_AS_ERRORS = "1";
-    TARGET_MAXVIEW = "0";
     TARGET_SYSTEMC = "1";
     TARGET_SYSTEMC_AUTO = "0";
     TARGET_SYSTEMC_ISIM = "0";


### PR DESCRIPTION
In Ubuntu-20.04 LTS, gcc-9 is installed by default. Add gcc-9 support for Cortex-M55 example.

Signed-off-by: Devaraj Ranganna <devaraj.ranganna@arm.com>