### PR TITLE
Improvements to PyTorch performance

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -8,6 +8,10 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [Unreleased]
 
 ### Added
+ - Fixed format kernels in oneDNN and ACL.
+ - Convolution caching at PyTorch level.
+ - Call oneDNN matrix multiplication for BLAS operation when LHS is transposed, but not RHS.
+ - Jitted reorder when destination tensor is BF16.
 
 ### Changed
 

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -179,6 +179,7 @@ ENV LD_LIBRARY_PATH=$OPENBLAS_DIR/lib:$LD_LIBRARY_PATH
 
 # Build Arm Compute Library from source
 COPY scripts/build-acl.sh $PACKAGE_DIR/.
+COPY patches/acl_fixed_format_kernels_striding.patch $PACKAGE_DIR/.
 COPY patches/acl_openmp_fix.patch $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-acl.sh
 ENV ACL_ROOT_DIR=$PROD_DIR/ComputeLibrary
@@ -304,7 +305,14 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
 # Build PyTorch
 COPY scripts/build-pytorch.sh $PACKAGE_DIR/.
+COPY patches/ideep.patch $PACKAGE_DIR/.
 COPY patches/onednn.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_fixed_format_kernels.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_depthwise_convolution.patch $PACKAGE_DIR/.
+COPY patches/onednn_reorder_padded.patch $PACKAGE_DIR/.
+COPY patches/onednn_reorder_to_bf16.patch $PACKAGE_DIR/.
+COPY patches/blas_to_mkl_acl.patch $PACKAGE_DIR/.
+
 COPY scripts/build-torchtext.sh $PACKAGE_DIR/.
 COPY scripts/build-torchdata.sh $PACKAGE_DIR/.
 

--- a/docker/pytorch-aarch64/patches/acl_fixed_format_kernels_striding.patch
+++ b/docker/pytorch-aarch64/patches/acl_fixed_format_kernels_striding.patch
@@ -1,0 +1,70 @@
+ *******************************************************************************
+ Copyright 2022 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+index 77da83070..985f96761 100644
+--- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
++++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+@@ -495,48 +495,6 @@ void Fallback<TypeInput, TypeOutput, OutputStage>::run(ITensorPack &tensors)
+     {
+         ldb                                = b->info()->strides_in_bytes().y() / sizeof(TypeInput);
+         multi_stride_b                     = b->info()->strides_in_bytes().z() / sizeof(TypeInput);
+-        const arm_compute::WeightFormat wf = assembly_utils::map_to_arm_compute_weight_format(_gemm_kernel_asm->get_config().weight_format);
+-        if(is_fixed_format(wf))
+-        {
+-            // The 4D tensor of dimension O'HWI' created for the
+-            // OHWIo<interleave_by>i<block_by> format is in reality seen
+-            // as a 2D tensor at arm_gemm level, where the rows are
+-            // O'/<interleave_by> and the columns are <interleave_by> *
+-            // H * W * I'.
+-            ITensorInfo      *tensor_info     = b->info();
+-            const DataLayout  data_layout     = tensor_info->data_layout();
+-            const TensorShape tensor_shape    = tensor_info->tensor_shape();
+-            const int         tensor_height   = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::HEIGHT)];
+-            const int         tensor_width    = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::WIDTH)];
+-            int               tensor_channels = tensor_shape[get_data_layout_dimension_index(data_layout, DataLayoutDimension::CHANNEL)];
+-            const int         interleave_by   = arm_compute::interleave_by(wf);
+-            const int         blocked_by      = arm_compute::block_by(wf);
+-            // We need to find a new stride that is distance from the data for one
+-            // set of output channels to the next
+-            if(ldb == tensor_channels && multi_stride_b == tensor_channels * tensor_width)
+-            {
+-                // In this case dimensions that are packed are height, width and channel
+-                // so we need to stride it by interleave_by
+-                if(tensor_channels % blocked_by != 0)
+-                {
+-                    // We need to pad
+-                    tensor_channels = arm_gemm::iceildiv(tensor_channels, blocked_by) * blocked_by;
+-                }
+-                ldb = interleave_by * tensor_height * tensor_width * tensor_channels;
+-            }
+-            else if(multi_stride_b == 0 || (ldb == tensor_width && multi_stride_b == tensor_height * tensor_width))
+-            {
+-                // In this case dimension that is packed is only height
+-                // so we need to stride only height by interleave_by
+-                ldb = interleave_by * tensor_height;
+-            }
+-            else
+-            {
+-                // If dimensions are not packed as above error is thrown
+-                // as at the moment other forms of packing are not supported
+-                ARM_COMPUTE_ERROR("Unsupported packing for fixed format kernel");
+-            }
+-        }
+         in1_ptr = reinterpret_cast<const TypeInput *>(b->buffer() + b->info()->offset_first_element_in_bytes());
+     }
+ 

--- a/docker/pytorch-aarch64/patches/blas_to_mkl_acl.patch
+++ b/docker/pytorch-aarch64/patches/blas_to_mkl_acl.patch
@@ -1,0 +1,54 @@
+# *******************************************************************************
+# Copyright 2022 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+diff --git a/aten/src/ATen/native/LinearAlgebra.cpp b/aten/src/ATen/native/LinearAlgebra.cpp
+index c658d4427c..5c792f0e73 100644
+--- a/aten/src/ATen/native/LinearAlgebra.cpp
++++ b/aten/src/ATen/native/LinearAlgebra.cpp
+@@ -1308,6 +1308,16 @@ static void addmm_impl_cpu_(
+   AT_DISPATCH_ALL_TYPES_AND_COMPLEX_AND(kBFloat16,
+       result.scalar_type(), "addmm_impl_cpu_",
+       [&]{
++        #if defined(__aarch64__) && AT_MKLDNN_ENABLED()
++        // On AArch64 if LHS matrix in BLAS routine is tranposed but RHS is not then
++        // it is faster to call oneDNN matrix multiplication primitive with RHS*LHS
++        // that will call then into ACL GEMM kernel and also additionaly have support
++        // for running kernel with BF16 instructions
++        if(transpose_a && !transpose_b) {
++            mkldnn_matmul(b, a, c, beta.to<float>(), alpha.to<float>());
++            return;
++        }
++        #endif
+         using opmath_t = at::opmath_type<scalar_t>;
+         at::native::cpublas::gemm(
+             transpose_a ? a.is_conj() ? TransposeType::ConjTranspose : TransposeType::Transpose : TransposeType::NoTranspose,
+diff --git a/aten/src/ATen/native/quantized/cpu/qconv.cpp b/aten/src/ATen/native/quantized/cpu/qconv.cpp
+index 125e45267a..584d8eea23 100644
+--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
++++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
+@@ -1299,9 +1299,9 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+             op_attr, dnnl::algorithm::convolution_direct,
+             dnnl::prop_kind::forward_inference,
+             ideep::u8s8, ideep::engine::cpu_engine());
+-        get_conv_cache() = ConvPrimitiveCache(cache_key, params.pd, b, params.bias_attr);
++        get_conv_cache() = ConvPrimitiveCache(cache_key, params.pd.first, b, params.bias_attr);
+         onednn_utils::try_reorder(
+-            weights, (ideep::tensor::desc)params.pd.weights_desc(), weights_scales);
++            weights, (ideep::tensor::desc)params.pd.first.weights_desc(), weights_scales);
+     });
+     // If hit, use cached data. If miss, fall back to normal path.
+     if (get_conv_cache().hit(cache_key)) {

--- a/docker/pytorch-aarch64/patches/ideep.patch
+++ b/docker/pytorch-aarch64/patches/ideep.patch
@@ -1,0 +1,231 @@
+# *******************************************************************************
+# Copyright 2022 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+
+diff --git a/include/ideep/operators/conv.hpp b/include/ideep/operators/conv.hpp
+index bf5b4ef..871afcd 100644
+--- a/include/ideep/operators/conv.hpp
++++ b/include/ideep/operators/conv.hpp
+@@ -4,7 +4,7 @@
+ namespace ideep {
+ 
+ struct convolution_forward_params {
+-  dnnl::convolution_forward::primitive_desc pd;
++  std::pair<dnnl::convolution_forward::primitive_desc, dnnl::convolution_forward> pd;
+   // bias_attr contains requantization scales for bias
+   attr_t bias_attr;
+   scale_t dst_scales;
+@@ -218,7 +218,7 @@ struct conv_deconv_utils {
+ 
+ struct convolution_forward
+     : public dnnl::convolution_forward,
+-      utils::computation_cache<dnnl::convolution_forward::primitive_desc> {
++      utils::computation_cache<std::pair<dnnl::convolution_forward::primitive_desc, dnnl::convolution_forward> > {
+ 
+   using super = dnnl::convolution_forward;
+ 
+@@ -647,7 +647,7 @@ struct convolution_forward
+         padding_l, padding_r, is_channels_last, attr, aalgorithm, apkind);
+ 
+     // embed group info into weights_desc
+-    return tensor::desc(pd.weights_desc(), groups);
++    return tensor::desc(pd.first.weights_desc(), groups);
+   }
+ 
+   // [keep_format]
+@@ -658,7 +658,7 @@ struct convolution_forward
+   //   the dst to be plain as src, so that it would also instruct onednn
+   //   to use gemm-based conv implementation. Apply to both NCHW and NHWC.
+   template <bool with_bias, bool keep_format = false>
+-  static primitive_desc get_primitive_desc(
++  static std::pair<primitive_desc, dnnl::convolution_forward> get_primitive_desc(
+       const tensor::desc& src_desc,
+       const tensor::desc& weights_desc,
+       const tensor::desc& bias_desc,
+@@ -702,6 +702,7 @@ struct convolution_forward
+       }
+     }
+ 
++
+     auto key = utils::create_key(
+         aprop_kind,
+         aalgorithm,
+@@ -714,35 +715,38 @@ struct convolution_forward
+         padding_r,
+         attr,
+         omp_get_max_threads());
+-    return fetch_or_create(key, [&]() {
+-      if (with_bias) {
+-        return primitive_desc(
+-            {aprop_kind,
+-             aalgorithm,
+-             src_desc_query,
+-             weights_desc_query,
+-             bias_desc_query,
+-             dst_desc_query,
+-             strides,
+-             dilates,
+-             padding_l,
+-             padding_r},
+-            attr,
+-            aengine);
+-      } else {
+-        return primitive_desc(
+-            {aprop_kind,
+-             aalgorithm,
+-             src_desc_query,
+-             weights_desc_query,
+-             dst_desc_query,
+-             strides,
+-             dilates,
+-             padding_l,
+-             padding_r},
+-            attr,
+-            aengine);
+-      }
++    dnnl::convolution_forward::primitive_desc pd;
++    if (with_bias) {
++      pd = primitive_desc(
++          {aprop_kind,
++           aalgorithm,
++           src_desc_query,
++           weights_desc_query,
++           bias_desc_query,
++           dst_desc_query,
++           strides,
++           dilates,
++           padding_l,
++           padding_r},
++          attr,
++          aengine);
++    } else {
++      pd = primitive_desc(
++          {aprop_kind,
++           aalgorithm,
++           src_desc_query,
++           weights_desc_query,
++           dst_desc_query,
++           strides,
++           dilates,
++           padding_l,
++           padding_r},
++          attr,
++          aengine);
++    }
++
++     return fetch_or_create(key, [&]() {
++       return std::make_pair(pd, super(pd));
+     });
+   }
+ 
+@@ -861,7 +865,7 @@ private:
+         padding_l, padding_r, is_channels_last, op_attr, aalgorithm, aprop_kind, aengine);
+ 
+     // allocate scratchpad
+-    tensor scratchpad(pd.scratchpad_desc());
++    tensor scratchpad(pd.first.scratchpad_desc());
+ 
+     params = {std::move(pd), bias_attr, scale_t(), zero_point_t(),
+              groups, std::move(scratchpad)};
+@@ -941,7 +945,7 @@ private:
+         padding_l, padding_r, is_channels_last, op_attr, aalgorithm, aprop_kind, aengine);
+ 
+     // allocate scratchpad
+-    tensor scratchpad(pd.scratchpad_desc());
++    tensor scratchpad(pd.first.scratchpad_desc());
+ 
+     param = {std::move(pd), bias_attr, std::move(dst_scales), std::move(src_zero_point),
+              groups, std::move(scratchpad)};
+@@ -951,7 +955,7 @@ private:
+   static void do_compute(const convolution_forward_params& param,
+                          const tensor& src, const tensor& weights,
+                          const tensor& bias, tensor& dst) {
+-    auto& pd = param.pd;
++    auto& pd = param.pd.first;
+     auto& scratchpad = param.scratchpad;
+     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
+     auto expected_weights = weights.make_grouped_weights(param.groups)
+@@ -968,7 +972,7 @@ private:
+         ideep::engine(pd.get_engine().get_kind()), src_zero_point_m);
+     if (with_bias) {
+       auto expected_bias = bias.reorder_if_differ_in(pd.bias_desc(), param.bias_attr);
+-      super(pd).execute(stream::default_stream(), 
++      param.pd.second.execute(stream::default_stream(),
+                         {{DNNL_ARG_SRC, expected_src},
+                          {DNNL_ARG_WEIGHTS, expected_weights},
+                          {DNNL_ARG_BIAS, expected_bias},
+@@ -976,7 +980,7 @@ private:
+                          {DNNL_ARG_SCRATCHPAD, scratchpad},
+                          {DNNL_ARG_ATTR_ZERO_POINTS | DNNL_ARG_SRC, src_zero_point_m}});
+     } else {
+-      super(pd).execute(stream::default_stream(), 
++      param.pd.second.execute(stream::default_stream(),
+                         {{DNNL_ARG_SRC, expected_src},
+                          {DNNL_ARG_WEIGHTS, expected_weights},
+                          {DNNL_ARG_DST, dst},
+@@ -992,7 +996,7 @@ private:
+                                 const tensor &weights,
+                                 const tensor &bias,
+                                 tensor &dst) {
+-    auto &pd = param.pd;
++    auto &pd = param.pd.first;
+     auto &scratchpad = param.scratchpad;
+     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
+     // make sure other has same format with dst.
+@@ -1104,7 +1108,7 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
+ 
+     auto pd = primitive_desc(
+         {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
+-         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
++         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints.first);
+ 
+     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
+     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
+@@ -1156,7 +1160,7 @@ struct convolution_backward_data : public dnnl::convolution_backward_data {
+ 
+     auto pd = primitive_desc(
+         {aalgorithm, diff_src_desc, weights_desc, diff_dst_desc, strides,
+-         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints);
++         dilates_, padding_l, padding_r}, op_attr, aengine, forward_hints.first);
+ 
+     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
+     auto expected_weights = weights_.reorder_if_differ_in(pd.weights_desc());
+@@ -1324,10 +1328,10 @@ struct convolution_backward_weights
+     auto pd = with_diff_bias
+         ? primitive_desc({aalgorithm, src_desc, diff_weights_desc,
+                           diff_bias_desc, diff_dst_desc, strides, dilates_,
+-                          padding_l, padding_r}, op_attr, aengine, forward_hints)
++                          padding_l, padding_r}, op_attr, aengine, forward_hints.first)
+         : primitive_desc({aalgorithm, src_desc, diff_weights_desc,
+                           diff_dst_desc, strides, dilates_,
+-                          padding_l, padding_r}, op_attr, aengine, forward_hints);
++                          padding_l, padding_r}, op_attr, aengine, forward_hints.first);
+ 
+     auto expected_diff_dst = diff_dst.reorder_if_differ_in(pd.diff_dst_desc());
+     auto expected_src = src.reorder_if_differ_in(pd.src_desc());
+diff --git a/include/ideep/operators/matmul.hpp b/include/ideep/operators/matmul.hpp
+index fc94d1a..e1b6a7c 100644
+--- a/include/ideep/operators/matmul.hpp
++++ b/include/ideep/operators/matmul.hpp
+@@ -515,7 +515,7 @@ enum task_type {
+          std::vector<int64_t>({dst_dims[1], 1});
+      tensor::desc dst_desc = is_dynamic ?
+          tensor::desc(dst_dims, dst_data_type, dst_strides) :
+-         tensor::desc(dst_dims, dst_data_type, tag::any);
++         tensor::desc(dst_dims, dst_data_type);
+      auto key = utils::create_key(
+          src_desc,
+          weights_desc,

--- a/docker/pytorch-aarch64/patches/onednn_acl_depthwise_convolution.patch
+++ b/docker/pytorch-aarch64/patches/onednn_acl_depthwise_convolution.patch
@@ -1,0 +1,362 @@
+ *******************************************************************************
+ Copyright 2022 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
+index fc93d2aa9..6ebac0d17 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.cpp
++++ b/src/cpu/aarch64/acl_convolution_utils.cpp
+@@ -54,10 +54,12 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     const int ndims = src_d.ndims();
+     const bool is_1d = ndims == 3;
+     const bool is_3d = ndims == 5;
++    const bool is_depthwise = wei_d.ndims() == 5 && wei_d.dims()[1] == 1 && wei_d.dims()[2] == 1;
++
+     bool is_nspc;
+ 
+     // Compute Library unsupported shape scenarios
+-    if (one_of(true, is_3d, is_1d, with_groups)) {
++    if (one_of(true, is_3d, is_1d, (with_groups && !is_depthwise))) {
+         return status::unimplemented;
+     }
+ 
+@@ -135,11 +137,11 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         is_nspc = utils::one_of(src_tag, nhwc);
+ 
+         memory_desc_t want_wei_md = weights_md;
+-        auto wei_tag = is_nspc ? ohwi : oihw;
++        auto wei_tag = is_depthwise ? hwigo : (is_nspc ? ohwi : oihw);
+         CHECK(memory_desc_init_by_tag(want_wei_md, wei_tag));
+ 
+         // Compute Library does not support mismatching layouts
+-        if ((src_tag != wei_tag) || (src_tag != dst_tag))
++        if (!is_depthwise && ((src_tag != wei_tag) || (src_tag != dst_tag)))
+             return status::unimplemented;
+ 
+         if (weights_md.format_kind == format_kind::any) {
+@@ -187,6 +189,12 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+             acl_wei_data_t,
+             acl_layout);
+ 
++    if(is_depthwise) {
++        // We need to set that values are not constant so that we
++        // we can update them in-place in ACL
++        acp.wei_info.set_are_values_constant(false);
++    }
++
+     acp.dst_info = arm_compute::TensorInfo(
+             is_nspc ? arm_compute::TensorShape(oc, ow, oh, mb) :
+             arm_compute::TensorShape(ow, oh, oc, mb),
+@@ -212,6 +220,12 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+                 arm_compute::QuantizationInfo(1.0f / scales[0], 0));
+     }
+ 
++    if(is_depthwise) {
++        // There is no support for fixed format kernels for depthwise convolution
++        // in ACL so we are going to use weight format that we set up earlier
++        return status::success;
++    }
++
+     acp.weights_info = arm_compute::WeightsInfo(
+         false,
+         kw,
+@@ -302,6 +316,10 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         const primitive_attr_t &attr) {
+     acp.is_indirect = false;
+ 
++    if(weights_md.ndims != 4) {
++        return status::unimplemented;
++    }
++
+     // General Compute Library checks, memory tags are also set there
+     CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
+ 
+@@ -330,7 +348,8 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     auto math_mode = get_fpmath_mode();
+     // Indirect convolution results in slowdown for low thread count or 1x1
+     // kernels, so fall back to GEMM-based convolution in these cases
+-    if (one_of(true, weights_md.dims[2] == 1, // kh
++    if (one_of(true, weights_md.ndims != 4,
++                weights_md.dims[2] == 1, // kh
+                 weights_md.dims[3] == 1, // kw
+                 (!math_mode && dnnl_get_max_threads() < 28))) {
+         return status::unimplemented;
+@@ -355,6 +374,27 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     return status::success;
+ }
+ 
++status_t init_conf_depthwise(acl_conv_conf_t &acp, memory_desc_t &src_md,
++        memory_desc_t &weights_md, memory_desc_t &dst_md,
++        memory_desc_t &bias_md, const convolution_desc_t &cd,
++        const primitive_attr_t &attr) {
++    acp.is_indirect = false;
++    // We need to make sure that number of dimensions for weights is either 5 or 3
++    if(weights_md.ndims != 5)
++        return status::unimplemented;
++
++    CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
++
++    ACL_CHECK_VALID(arm_compute::NEDepthwiseConvolutionLayer::validate(
++        &acp.src_info,
++        &acp.wei_info,
++        acp.with_bias ? &acp.bia_info : nullptr,
++        &acp.dst_info,
++        acp.padstride_info));
++
++    return status::success;
++}
++
+ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &weights_md, memory_desc_t &dst_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+@@ -364,7 +404,8 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     // Under these conditions, fallback to faster GEMM-based convolution
+     // unless the user explicitly specifies Winograd algorithm
+     // clang-format off
+-    if (one_of(true, src_md.dims[2] > 112, // ih
++    if (one_of(true, weights_md.ndims != 4,
++                src_md.dims[2] > 112, // ih
+                 src_md.dims[3] > 112, // iw
+                 src_md.dims[1] < 64, // ic
+                 dst_md.dims[1] < 64, // oc
+diff --git a/src/cpu/aarch64/acl_convolution_utils.hpp b/src/cpu/aarch64/acl_convolution_utils.hpp
+index 44dc8eecb..7eae5cbb1 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.hpp
++++ b/src/cpu/aarch64/acl_convolution_utils.hpp
+@@ -67,6 +67,11 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+         const primitive_attr_t &attr);
+ 
++status_t init_conf_depthwise(acl_conv_conf_t &acp, memory_desc_t &src_md,
++        memory_desc_t &weights_md, memory_desc_t &dst_md,
++        memory_desc_t &bias_md, const convolution_desc_t &cd,
++        const primitive_attr_t &attr);
++
+ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &weights_md, memory_desc_t &dst_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+diff --git a/src/cpu/cpu_convolution_list.cpp b/src/cpu/cpu_convolution_list.cpp
+index 4142dbc7e..1800aaf58 100644
+--- a/src/cpu/cpu_convolution_list.cpp
++++ b/src/cpu/cpu_convolution_list.cpp
+@@ -65,6 +65,7 @@ using namespace dnnl::impl::cpu::x64;
+ #if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
+ #include "cpu/aarch64/acl_gemm_convolution.hpp"
+ #include "cpu/aarch64/acl_indirect_gemm_convolution.hpp"
++#include "cpu/aarch64/acl_depthwise_convolution.hpp"
+ #include "cpu/aarch64/acl_winograd_convolution.hpp"
+ #endif
+ using namespace dnnl::impl::cpu::aarch64;
+@@ -104,6 +105,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
+             CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_fwd_t)
+             CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
+             CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
++            CPU_INSTANCE_AARCH64_ACL(acl_depthwise_convolution_fwd_t)
+             CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
+             CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f32>)
+             CPU_INSTANCE(gemm_convolution_fwd_t)
+diff --git a/src/cpu/aarch64/acl_depthwise_convolution.cpp b/src/cpu/aarch64/acl_depthwise_convolution.cpp
+new file mode 100644
+index 000000000..1beb8b8af
+--- /dev/null
++++ b/src/cpu/aarch64/acl_depthwise_convolution.cpp
+@@ -0,0 +1,41 @@
++/*******************************************************************************
++* Copyright 2022 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_depthwise_convolution.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++status_t acl_depthwise_convolution_fwd_t::execute_forward(
++    const exec_ctx_t &ctx) const {
++        std::lock_guard<std::mutex> _lock {this->mtx};
++
++        auto *acl_resource
++                = ctx.get_resource_mapper()->get<acl_depthwise_convolution_resource_t>(
++                    this);
++        acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer> &acl_depthwise_obj
++                = acl_resource->get_acl_obj();
++
++        return execute_forward_conv_acl<acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer>, pd_t,
++                data_t>(ctx, acl_depthwise_obj, pd());
++    }
++
++}
++}
++}
++}
+diff --git a/src/cpu/aarch64/acl_depthwise_convolution.hpp b/src/cpu/aarch64/acl_depthwise_convolution.hpp
+new file mode 100644
+index 000000000..d84fc4fb5
+--- /dev/null
++++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
+@@ -0,0 +1,139 @@
++/*******************************************************************************
++* Copyright 2022 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#ifndef CPU_AARCH64_ACL_DEPTHWISE_CONVOLUTION_HPP
++#define CPU_AARCH64_ACL_DEPTHWISE_CONVOLUTION_HPP
++
++#include "cpu/cpu_convolution_pd.hpp"
++#include "cpu/aarch64/acl_convolution_utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_depthwise_convolution_resource_t : public resource_t {
++    acl_depthwise_convolution_resource_t()
++        : acl_obj_(utils::make_unique<acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer>>()) {}
++
++    status_t configure(const acl_conv_conf_t &acp) {
++        if(!acl_obj_) return status::out_of_memory;
++
++        acl_obj_->src_tensor.allocator()->init(acp.src_info);
++        acl_obj_->wei_tensor.allocator()->init(acp.wei_info);
++        acl_obj_->dst_tensor.allocator()->init(acp.dst_info);
++        acl_obj_->bia_tensor.allocator()->init(acp.bia_info);
++
++        // clang-format off
++        acl_obj_->conv.configure(
++            &acl_obj_->src_tensor,
++            &acl_obj_->wei_tensor,
++            acp.with_bias ? &acl_obj_->bia_tensor : nullptr,
++            &acl_obj_->dst_tensor,
++            acp.padstride_info,
++            1, // depth multiplier default value
++            acp.act_info);
++
++        // clang-format on
++        return status::success;
++    }
++
++    acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer> &get_acl_obj() const {
++        return *acl_obj_;
++    }
++
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_depthwise_convolution_resource_t);
++
++private:
++    std::unique_ptr<acl_obj_t<arm_compute::NEDepthwiseConvolutionLayer>> acl_obj_;
++
++};
++
++struct acl_depthwise_convolution_fwd_t : public primitive_t {
++
++    struct pd_t : public cpu_convolution_fwd_pd_t {
++        pd_t(const convolution_desc_t* adesc, const primitive_attr_t *attr,
++                const typename pd_t::base_class *hint_fwd_pd)
++            : cpu_convolution_fwd_pd_t(adesc, attr, hint_fwd_pd), acp_() {}
++
++        DECLARE_COMMON_PD_T("depthwise_convolution:acl",
++                acl_depthwise_convolution_fwd_t, USE_GLOBAL_SCRATCHPAD);
++
++        status_t init(engine_t *engine) {
++            using namespace data_type;
++            using smask_t = primitive_attr_t::skip_mask_t;
++
++            bool ok = is_fwd()
++                    && set_default_alg_kind(alg_kind::convolution_direct)
++                    && expect_data_types(data_type::f32, data_type::f32,
++                            data_type::f32, data_type::f32, undef)
++                    && !has_zero_dim_memory()
++                    && attr()->has_default_values(
++                            smask_t::post_ops, data_type::f32);
++            if(!ok) return status::unimplemented;
++
++            CHECK(acl_convolution_utils::init_conf_depthwise(acp_, src_md_,
++                    weights_md_, dst_md_, bias_md_, *desc(), *attr()));
++
++            CHECK(post_ops.init(
++                    engine, attr_.post_ops_, dst_md_, acp_.act_info));
++            acp_.use_dst_acc = post_ops.has_sum();
++
++            return status::success;
++        }
++
++        acl_conv_conf_t acp_;
++
++        acl_post_ops_t post_ops;
++    };
++
++    acl_depthwise_convolution_fwd_t(const pd_t *apd) : primitive_t(apd) {}
++
++    status_t create_resource(
++        engine_t *engine, resource_mapper_t &mapper) const override {
++            if(mapper.has_resource(this)) return status::success;
++
++            auto r = utils::make_unique<acl_depthwise_convolution_resource_t>();
++            if(!r) return status::out_of_memory;
++
++            CHECK(r->configure(pd()->acp_));
++            mapper.add(this, std::move(r));
++
++            CHECK(pd()->post_ops.create_resource(engine, mapper));
++
++            return status::success;
++        }
++
++        typedef typename prec_traits<data_type::f32>::type data_t;
++
++        status_t execute(const exec_ctx_t &ctx) const override {
++            return execute_forward(ctx);
++        }
++
++private:
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++
++};
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_DEPTHWISE_CONVOLUTION_HPP

--- a/docker/pytorch-aarch64/patches/onednn_acl_fixed_format_kernels.patch
+++ b/docker/pytorch-aarch64/patches/onednn_acl_fixed_format_kernels.patch
@@ -1,0 +1,536 @@
+ *******************************************************************************
+ Copyright 2022 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
+index c46d69757..fc93d2aa9 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.cpp
++++ b/src/cpu/aarch64/acl_convolution_utils.cpp
+@@ -212,6 +212,87 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+                 arm_compute::QuantizationInfo(1.0f / scales[0], 0));
+     }
+ 
++    acp.weights_info = arm_compute::WeightsInfo(
++        false,
++        kw,
++        kh,
++        oc,
++        false,
++        arm_compute::WeightFormat::ANY);
++    arm_compute::WeightFormat expected_weight_format;
++    auto acl_st = arm_compute::NEGEMMConvolutionLayer::has_opt_impl(
++        expected_weight_format,
++        &acp.src_info,
++        &acp.wei_info,
++        acp.with_bias ? &acp.bia_info : nullptr,
++        &acp.dst_info,
++        acp.padstride_info,
++        acp.weights_info,
++        acp.dilation_info,
++        acp.act_info,
++        acp.fast_math);
++    if(acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        return status::unimplemented;
++    }
++    acp.weights_info.set_weight_format(expected_weight_format);
++
++    int interleaved_by = arm_compute::interleave_by(expected_weight_format);
++    int block_by = arm_compute::block_by(expected_weight_format);
++
++    bool is_fast_math_kernel = arm_compute::is_fixed_format_fast_math(expected_weight_format);
++    if(!is_fast_math_kernel) {
++        // FP32 kernel is faster then BF16
++        acp.fast_math = false;
++    }
++
++    memory_desc_t want_wei_md = weights_md;
++
++    int ic_multiply = ic;
++    if(ic % block_by != 0) {
++        ic_multiply = utils::div_up(ic, block_by) * block_by;
++        // Also we need to set padded dimensions as well
++        want_wei_md.padded_dims[1] = ic_multiply;
++    } else {
++        // If we do not need to pad input channels for fast math mode
++        // then it would be faster to run convolution with im2row
++        // instead of using indirect buffer
++        if(acp.fast_math && acp.is_indirect) {
++            return status::unimplemented;
++        }
++    }
++    if(oc % interleaved_by != 0) {
++        int padded_dim = utils::div_up(oc, interleaved_by) * interleaved_by;
++        want_wei_md.padded_dims[0] = padded_dim;
++    }
++
++    // Set strides based on blocking information
++    want_wei_md.format_desc.blocking.strides[0] = interleaved_by*ic_multiply*kw*kh;
++    want_wei_md.format_desc.blocking.strides[1] = interleaved_by*block_by;
++    want_wei_md.format_desc.blocking.strides[2] = interleaved_by*ic_multiply*kw;
++    want_wei_md.format_desc.blocking.strides[3] = interleaved_by*ic_multiply;
++
++    acl_utils::update_strides_y_and_z(
++        acp.wei_info,
++        want_wei_md.format_desc.blocking.strides[0] * wei_d.data_type_size(),
++        acp.wei_info.strides_in_bytes().z());
++
++    // Set blocking
++    want_wei_md.format_desc.blocking.inner_nblks = (block_by > 1) + 1;
++    want_wei_md.format_desc.blocking.inner_idxs[0] = 0; // second to last dimension in abcd format
++    want_wei_md.format_desc.blocking.inner_blks[0] = interleaved_by;
++
++    if(block_by > 1) {
++        want_wei_md.format_desc.blocking.inner_idxs[1] = 1; // second to last dimension in abcd format
++        want_wei_md.format_desc.blocking.inner_blks[1] = block_by;
++    }
++
++    if(is_fast_math_kernel) {
++        // If it is fast math mode we need weights in BFloat16
++        want_wei_md.data_type = dnnl_bf16;
++    }
++
++    weights_md = want_wei_md;
++
+     return status::success;
+ }
+ 
+@@ -219,6 +300,7 @@ status_t init_conf_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &weights_md, memory_desc_t &dst_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+         const primitive_attr_t &attr) {
++    acp.is_indirect = false;
+ 
+     // General Compute Library checks, memory tags are also set there
+     CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
+@@ -244,11 +326,13 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &weights_md, memory_desc_t &dst_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+         const primitive_attr_t &attr) {
++    acp.is_indirect = true;
++    auto math_mode = get_fpmath_mode();
+     // Indirect convolution results in slowdown for low thread count or 1x1
+     // kernels, so fall back to GEMM-based convolution in these cases
+     if (one_of(true, weights_md.dims[2] == 1, // kh
+                 weights_md.dims[3] == 1, // kw
+-                dnnl_get_max_threads() < 28)) {
++                (!math_mode && dnnl_get_max_threads() < 28))) {
+         return status::unimplemented;
+     }
+ 
+@@ -275,6 +359,7 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         memory_desc_t &weights_md, memory_desc_t &dst_md,
+         memory_desc_t &bias_md, const convolution_desc_t &cd,
+         const primitive_attr_t &attr) {
++    acp.is_indirect = false;
+ 
+     // Under these conditions, fallback to faster GEMM-based convolution
+     // unless the user explicitly specifies Winograd algorithm
+diff --git a/src/cpu/aarch64/acl_convolution_utils.hpp b/src/cpu/aarch64/acl_convolution_utils.hpp
+index 3e56245fa..44dc8eecb 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.hpp
++++ b/src/cpu/aarch64/acl_convolution_utils.hpp
+@@ -43,6 +43,7 @@ struct acl_conv_conf_t {
+     // If this is true, the result of the convolution goes into a temporarily
+     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
+     bool use_dst_acc;
++    bool is_indirect;
+     arm_compute::TensorInfo src_info;
+     arm_compute::TensorInfo wei_info;
+     arm_compute::TensorInfo bia_info;
+diff --git a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+index bcf031a77..4ddc8cf91 100644
+--- a/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
++++ b/src/cpu/aarch64/acl_indirect_gemm_convolution.hpp
+@@ -41,6 +41,7 @@ struct acl_indirect_gemm_resource_t : public resource_t {
+         acl_obj_->bia_tensor.allocator()->init(acp.bia_info);
+ 
+         // clang-format off
++        arm_compute::experimental::PostOpList<arm_compute::ITensorInfo *> empty_post_ops = arm_compute::experimental::PostOpList<arm_compute::ITensorInfo *> {};
+         acl_obj_->conv.configure(
+             &acl_obj_->src_tensor,
+             &acl_obj_->wei_tensor,
+@@ -50,7 +51,9 @@ struct acl_indirect_gemm_resource_t : public resource_t {
+                                     acp.dilation_info,
+                                     acp.act_info,
+                                     acp.fast_math,
+-                                    1));
++                                    1,
++                                    empty_post_ops,
++                                    acp.weights_info));
+         // clang-format on
+ 
+         return status::success;
+diff --git a/src/cpu/aarch64/acl_inner_product.hpp b/src/cpu/aarch64/acl_inner_product.hpp
+index c5e507085..163ff066e 100644
+--- a/src/cpu/aarch64/acl_inner_product.hpp
++++ b/src/cpu/aarch64/acl_inner_product.hpp
+@@ -45,6 +45,7 @@ struct acl_ip_conf_t {
+     arm_compute::TensorInfo bia_info;
+     arm_compute::TensorInfo dst_info;
+     arm_compute::FullyConnectedLayerInfo fc_info;
++    arm_compute::WeightsInfo weights_info;
+ };
+ struct acl_ip_resource_t : public resource_t {
+     acl_ip_resource_t() : acl_ip_obj_(utils::make_unique<acl_ip_obj_t>()) {}
+@@ -64,7 +65,8 @@ struct acl_ip_resource_t : public resource_t {
+             &acl_ip_obj_->wei_tensor,
+             aip.with_bias ? &acl_ip_obj_->bia_tensor : nullptr,
+             &acl_ip_obj_->dst_tensor,
+-            aip.fc_info);
++            aip.fc_info,
++            aip.weights_info);
+         // clang-format on
+ 
+         return status::success;
+@@ -156,8 +158,8 @@ struct acl_inner_product_fwd_t : public primitive_t {
+                 src_shape = (src_tag == nc) ? arm_compute::TensorShape(ic, n)
+                                             : arm_compute::TensorShape(n, ic);
+ 
+-                wei_shape = (wei_tag == io) ? arm_compute::TensorShape(oc, ic)
+-                                            : arm_compute::TensorShape(ic, oc);
++                // For fixed format kernels weight shape is always io
++                wei_shape = arm_compute::TensorShape(oc, ic);
+             }
+             if (is_4d) {
+                 src_shape = (src_tag == nhwc)
+@@ -166,7 +168,8 @@ struct acl_inner_product_fwd_t : public primitive_t {
+ 
+                 // ACL requires the weights to be in 2D flattened shape
+                 const int flattened_ic = is_4d ? ic * kh * kw : ic;
+-                wei_shape = arm_compute::TensorShape(flattened_ic, oc);
++                // For fixed format kernels weights shape is always io
++                wei_shape = arm_compute::TensorShape(oc, flattened_ic);
+             }
+ 
+             arm_compute::DataLayout src_layout = (src_tag == nhwc)
+@@ -183,6 +186,9 @@ struct acl_inner_product_fwd_t : public primitive_t {
+             aip.wei_info = arm_compute::TensorInfo(
+                     wei_shape, 1, arm_compute::DataType::F32, wei_layout);
+ 
++            aip.weights_info = arm_compute::WeightsInfo(
++                    false, 1, 1, is_4d ? ic * kh *kw : ic, false, arm_compute::WeightFormat::ANY);
++
+             aip.dst_info
+                     = arm_compute::TensorInfo(arm_compute::TensorShape(oc, n),
+                             1, arm_compute::DataType::F32);
+@@ -194,15 +200,7 @@ struct acl_inner_product_fwd_t : public primitive_t {
+                     1, arm_compute::DataType::F32);
+ 
+             aip.fc_info.weights_trained_layout = wei_layout;
+-            if (is_2d && wei_tag != src_tag) {
+-                // weights are already transposed
+-                aip.fc_info.transpose_weights = false;
+-
+-                if (desc()->prop_kind == dnnl_forward_training) {
+-                    aip.wei_info.set_are_values_constant(false);
+-                    aip.fc_info.are_weights_reshaped = true;
+-                }
+-            }
++            aip.fc_info.transpose_weights = false;
+ 
+             // Fast math mode
+             auto math_mode = get_fpmath_mode();
+@@ -214,6 +212,80 @@ struct acl_inner_product_fwd_t : public primitive_t {
+                     aip.fc_info.activation_info));
+             aip.use_dst_acc = post_ops.has_sum();
+ 
++            arm_compute::WeightFormat expected_weight_format;
++            auto acl_st = arm_compute::NEFullyConnectedLayer::has_opt_impl(
++                expected_weight_format,
++                &aip.src_info,
++                &aip.wei_info,
++                aip.with_bias ? &aip.bia_info : nullptr,
++                &aip.dst_info,
++                aip.fc_info,
++                aip.weights_info);
++            if(acl_st.error_code() != arm_compute::ErrorCode::OK) {
++                return status::unimplemented;
++            }
++
++            aip.weights_info.set_weight_format(expected_weight_format);
++
++            int interleaved_by = arm_compute::interleave_by(expected_weight_format);
++            int block_by = arm_compute::block_by(expected_weight_format);
++            bool is_fast_math_kernel = arm_compute::is_fixed_format_fast_math(expected_weight_format);
++
++            if(!is_fast_math_kernel) {
++                // FP32 kernel might be faster for some cases then BF16
++                aip.fc_info.enable_fast_math = false;
++            }
++
++            memory_desc_t want_wei_md = weights_md_;
++
++            int ic_multiply = ic;
++            if(is_4d) {
++                ic_multiply = ic * kh * kw;
++
++                // Since we are flattening dimensions the memory descriptor
++                // should also be for 2D
++                want_wei_md.ndims = 2;
++
++                want_wei_md.dims[1] = ic_multiply;
++                want_wei_md.padded_dims[1] = ic_multiply;
++                want_wei_md.format_desc.blocking.strides[1] = 1;
++
++                want_wei_md.dims[0] = oc;
++                want_wei_md.padded_dims[0] = want_wei_md.padded_dims[1];
++                want_wei_md.padded_dims[0] = oc;
++            }
++
++            want_wei_md.format_desc.blocking.strides[1] = interleaved_by * block_by;
++            if(want_wei_md.dims[1] % block_by != 0) {
++                want_wei_md.padded_dims[1] = utils::div_up(want_wei_md.dims[1], block_by) * block_by;
++            }
++            want_wei_md.format_desc.blocking.strides[0] = interleaved_by * want_wei_md.padded_dims[1];
++
++            if(oc % interleaved_by != 0) {
++                int padded_dim = utils::div_up(oc, interleaved_by) * interleaved_by;
++                want_wei_md.padded_dims[0] = padded_dim;
++            }
++
++            int data_type_size = memory_desc_wrapper(want_wei_md).data_type_size();
++            acl_utils::update_strides_y_and_z(
++                aip.wei_info,
++                want_wei_md.format_desc.blocking.strides[0] * data_type_size,
++                want_wei_md.format_desc.blocking.strides[1] * data_type_size);
++
++            want_wei_md.format_desc.blocking.inner_nblks = (block_by > 1) + 1;
++            want_wei_md.format_desc.blocking.inner_idxs[0] = 0;
++            want_wei_md.format_desc.blocking.inner_blks[0] = interleaved_by;
++            if(block_by > 1) {
++                want_wei_md.format_desc.blocking.inner_idxs[1] = 1;
++                want_wei_md.format_desc.blocking.inner_blks[1] = block_by;
++	        }
++
++            if(is_fast_math_kernel) {
++                want_wei_md.data_type = dnnl_bf16;
++            }
++
++            weights_md_ = want_wei_md;
++
+             // clang-format off
+             // Validate fully connected layer manually to check for return status
+             ACL_CHECK_VALID(arm_compute::NEFullyConnectedLayer::validate(
+diff --git a/src/cpu/aarch64/acl_utils.cpp b/src/cpu/aarch64/acl_utils.cpp
+index 79ea775d6..7ee4c7398 100644
+--- a/src/cpu/aarch64/acl_utils.cpp
++++ b/src/cpu/aarch64/acl_utils.cpp
+@@ -157,6 +157,28 @@ status_t tensor_info(
+     return status::success;
+ }
+ 
++status_t update_strides_y_and_z(
++    arm_compute::TensorInfo &info, const int y, const int z) {
++
++    arm_compute::TensorShape shape = info.tensor_shape();
++    arm_compute::Strides old_strides_in_bytes = info.strides_in_bytes();
++
++    arm_compute::Strides new_strides_in_bytes;
++    for(size_t i = 0; i < shape.num_dimensions(); ++i) {
++        new_strides_in_bytes.set(i, old_strides_in_bytes[i]);
++    }
++
++    // set y
++    new_strides_in_bytes.set(1, y);
++    // set z
++    new_strides_in_bytes.set(2, z);
++
++    info.init(info.tensor_shape(), info.num_channels(), info.data_type(),
++            new_strides_in_bytes, info.offset_first_element_in_bytes(), info.total_size());
++
++    return status::success;
++}
++
+ status_t insert_singleton_dimension(arm_compute::TensorInfo &ti, size_t dim_i) {
+ 
+     // Max 6 dims in ACL, so we can't insert another
+diff --git a/src/cpu/aarch64/acl_utils.hpp b/src/cpu/aarch64/acl_utils.hpp
+index 28693bb16..c7c9e1278 100644
+--- a/src/cpu/aarch64/acl_utils.hpp
++++ b/src/cpu/aarch64/acl_utils.hpp
+@@ -62,6 +62,9 @@ status_t tensor_info(arm_compute::TensorInfo &info, const memory_desc_t &md);
+ status_t tensor_info(
+         arm_compute::TensorInfo &info, const memory_desc_wrapper &md);
+ 
++// Update y and z strides in arm_compute::TensorInfo
++status_t update_strides_y_and_z(arm_compute::TensorInfo &info, const int y, const int z);
++
+ // Insert a dimension of size 1 at the index dim_i of TensorInfo
+ status_t insert_singleton_dimension(arm_compute::TensorInfo &ti, size_t dim_i);
+ 
+diff --git a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+index 679baec3a..853277e37 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
++++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+@@ -66,15 +66,12 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+ 
+     // Transpose A (src) or B (wei)
+     amp.is_transA = helper.transA() == 'T';
+-    amp.is_transB = helper.transB() == 'T';
++    amp.is_transB = false;
++
+     if (amp.is_transA)
+         amp.src_acc_info = arm_compute::TensorInfo(
+                 arm_compute::TensorShape(M, K, 1, src_batch), 1,
+                 arm_compute::DataType::F32);
+-    if (amp.is_transB)
+-        amp.wei_acc_info = arm_compute::TensorInfo(
+-                arm_compute::TensorShape(K, N, wei_batch), 1,
+-                arm_compute::DataType::F32);
+ 
+     amp.src_info = arm_compute::TensorInfo(
+             arm_compute::TensorShape(K, M, 1, src_batch), 1,
+@@ -103,6 +100,140 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+         ACL_CHECK_VALID(arm_compute::NETranspose::validate(
+                 &amp.wei_acc_info, &amp.wei_info));
+ 
++    arm_compute::WeightFormat expected_weight_format;
++
++    amp.gemm_info.set_fixed_format(true);
++    amp.gemm_info.set_weight_format(arm_compute::WeightFormat::ANY);
++
++    auto acl_st = arm_compute::NEGEMM::has_opt_impl(
++        expected_weight_format,
++        &amp.src_info,
++        &amp.wei_info,
++        nullptr,
++        &amp.dst_info,
++        amp.alpha,
++        0.0f,
++        amp.gemm_info);
++
++    if(acl_st.error_code() != arm_compute::ErrorCode::OK) {
++        return status::unimplemented;
++    }
++
++    amp.gemm_info.set_weight_format(expected_weight_format);
++
++    memory_desc_t want_wei_md = wei_md;
++
++    // We need to transpose second to last dimension and use blocking
++    // as returned by interleave by from expecting strides
++    int interleaved_by = arm_compute::interleave_by(expected_weight_format);
++    int block_by = arm_compute::block_by(expected_weight_format);
++    bool is_fast_math_kernel = arm_compute::is_fixed_format_fast_math(expected_weight_format);
++    if(!is_fast_math_kernel) {
++        amp.gemm_info.set_fast_math(false);
++    }
++
++    int blocked_first_dimension = -1;
++    int blocked_second_dimension = -1;
++
++    // Assume that interleaved by is X and blocked by is Y
++    switch(want_wei_md.ndims) {
++        case 2: {
++           // For 2D case the format that we need to pass is BaXb and
++           // when doing fast mode BAXbYa
++           want_wei_md.format_desc.blocking.strides[0] = interleaved_by * block_by;
++            // check to see whether we need to pad
++            if(want_wei_md.dims[0] % block_by != 0) {
++                want_wei_md.padded_dims[0] = utils::div_up(want_wei_md.dims[0], block_by) * block_by;
++            }
++            want_wei_md.format_desc.blocking.strides[1] = interleaved_by * want_wei_md.padded_dims[0];
++            if(want_wei_md.dims[1] % interleaved_by != 0) {
++                want_wei_md.padded_dims[1] = utils::div_up(want_wei_md.dims[1], interleaved_by) * interleaved_by;
++            }
++
++            acl_utils::update_strides_y_and_z(
++                amp.wei_info,
++                want_wei_md.format_desc.blocking.strides[1] * wei_d.data_type_size(),
++                want_wei_md.format_desc.blocking.strides[0] * wei_d.data_type_size());
++
++            blocked_first_dimension = 1;
++            blocked_second_dimension = 0;
++
++            break;
++        }
++
++        case 3: {
++           // For 3D case the format we need to pass is aCbXc and
++           // when doing fast mode is aCBXcYb
++           want_wei_md.format_desc.blocking.strides[1] = interleaved_by*block_by;
++           if(want_wei_md.dims[1] % block_by != 0) {
++               want_wei_md.padded_dims[1] = utils::div_up(want_wei_md.dims[1], block_by) * block_by;
++           }
++           want_wei_md.format_desc.blocking.strides[2] = interleaved_by * want_wei_md.padded_dims[1];
++           if(want_wei_md.dims[2] % interleaved_by != 0) {
++                want_wei_md.padded_dims[2] = utils::div_up(want_wei_md.dims[2], interleaved_by) * interleaved_by;
++           }
++           want_wei_md.format_desc.blocking.strides[0] = want_wei_md.padded_dims[2] * want_wei_md.padded_dims[1];
++
++           acl_utils::update_strides_y_and_z(
++                amp.wei_info,
++                want_wei_md.format_desc.blocking.strides[2] * wei_d.data_type_size(),
++                want_wei_md.format_desc.blocking.strides[0] * wei_d.data_type_size());
++
++           blocked_first_dimension = 2;
++           blocked_second_dimension = 1;
++
++           break;
++        }
++
++        case 4: {
++            // For 4D case the format we need to pass is abDcXd and
++            // when doing fast mode is abDCxdYc
++            int D_padded = want_wei_md.dims[3];
++            if(D_padded % interleaved_by != 0) {
++                D_padded = utils::div_up(D_padded, interleaved_by) * interleaved_by;
++                want_wei_md.padded_dims[3] = D_padded;
++            }
++
++            int C_padded = want_wei_md.dims[2];
++            if(C_padded % block_by != 0) {
++                C_padded = utils::div_up(C_padded, block_by) * block_by;
++                want_wei_md.padded_dims[2] = C_padded;
++            }
++
++            want_wei_md.format_desc.blocking.strides[0] = want_wei_md.dims[1]*D_padded*C_padded;
++            want_wei_md.format_desc.blocking.strides[1] = D_padded*C_padded;
++            want_wei_md.format_desc.blocking.strides[2] = interleaved_by*block_by;
++            want_wei_md.format_desc.blocking.strides[3] = interleaved_by*C_padded;
++
++            acl_utils::update_strides_y_and_z(
++                amp.wei_info,
++                want_wei_md.format_desc.blocking.strides[3] * wei_d.data_type_size(),
++                want_wei_md.format_desc.blocking.strides[1] * wei_d.data_type_size());
++
++            blocked_first_dimension = 3;
++            blocked_second_dimension = 2;
++
++            break;
++        }
++
++        default:
++            return status::unimplemented;
++    }
++
++    want_wei_md.format_desc.blocking.inner_nblks = (block_by > 1) + 1;
++    want_wei_md.format_desc.blocking.inner_idxs[0] = blocked_first_dimension;
++    want_wei_md.format_desc.blocking.inner_blks[0] = interleaved_by;
++    if(block_by > 1) {
++        want_wei_md.format_desc.blocking.inner_idxs[1] = blocked_second_dimension;
++        want_wei_md.format_desc.blocking.inner_blks[1] = block_by;
++    }
++
++    if(is_fast_math_kernel) {
++        want_wei_md.data_type = dnnl_bf16;
++    }
++
++    wei_md = want_wei_md;
++
+     return status::success;
+ }
+ 

--- a/docker/pytorch-aarch64/patches/onednn_reorder_padded.patch
+++ b/docker/pytorch-aarch64/patches/onednn_reorder_padded.patch
@@ -1,0 +1,858 @@
+ *******************************************************************************
+ Copyright 2022 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/jit_uni_reorder.cpp b/src/cpu/aarch64/jit_uni_reorder.cpp
+index 24d6220cf..a6cefaa20 100644
+--- a/src/cpu/aarch64/jit_uni_reorder.cpp
++++ b/src/cpu/aarch64/jit_uni_reorder.cpp
+@@ -1,6 +1,7 @@
+ /*******************************************************************************
+ * Copyright 2018-2021 Intel Corporation
+ * Copyright 2020-2021 FUJITSU LIMITED
++* Copyright 2022 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -54,6 +55,35 @@ namespace aarch64 {
+ 
+ namespace tr {
+ 
++static bool prb_has_small_strides(const prb_t &prb) {
++    constexpr ptrdiff_t max_stride = (1LL << 31) - 1;
++    for (int d = 0; d < prb.ndims; ++d) {
++        const ptrdiff_t cms = max_stride / prb.nodes[d].n;
++        const bool small_strides = true
++                && prb.nodes[d].is < cms / (int)data_type_size(prb.itype)
++                && prb.nodes[d].os < cms / (int)data_type_size(prb.otype);
++        if (!small_strides) return false;
++    }
++    return true;
++}
++
++static bool prb_tail_friendly(const prb_t &prb) {
++    /* find optimal ndims to makes it easier to
++     * identify the blk_chunk in the loop*/
++    int ndims = prb.full_ndims - prb.ndims;
++
++    int n = prb.nodes[0].is;
++    for (int d = 1; d < prb.ndims; ++d) {
++        if (d != prb.blk_chunk_idx) n *= prb.nodes[d].n;
++    }
++    if (prb.ip_tail > 0
++            && ((ndims == 0 && n != 1)
++                    || (ndims > 0 && prb.ndims > prb.blk_chunk_idx)))
++        return false;
++
++    return true;
++}
++
+ /** Minimal reasonable/desirable kernel size.
+  * The constant might be used to determine how a problem should be split
+  * between kernel and threading driver. */
+@@ -121,18 +151,10 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+                 && utils::one_of(p.otype, f32, s32, data_type::s8, u8)
+                 && utils::everyone_is(0, p.ioff, p.ooff) /* do we need this? */
+                 && utils::one_of(p.beta, 0.f, 1.f) /* anything else? */
+-                && simple_impl_desc_init(p, nullptr);
++                && simple_impl_desc_init(p, nullptr) && prb_has_small_strides(p)
++                && prb_tail_friendly(p);
+         if (!ok) return false;
+ 
+-        const ptrdiff_t max_stride = (1LL << 31) - 1;
+-        for (int d = 0; d < p.ndims; ++d) {
+-            const ptrdiff_t cms = max_stride / p.nodes[d].n;
+-            bool strides_ok = true
+-                    && p.nodes[d].is < cms / (int)data_type_size(p.itype)
+-                    && p.nodes[d].os < cms / (int)data_type_size(p.otype);
+-            if (!strides_ok) return false;
+-        }
+-
+         return true;
+     }
+ 
+@@ -153,6 +175,13 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         return (int)prb_.nodes[d].ss;
+     }
+ 
++    int blk_cnt() {
++        assert(prb_.blk_chunk_idx < prb_.full_ndims);
++        return (int)prb_.nodes[prb_.blk_chunk_idx].n - 1;
++    }
++    int op_padding() { return prb_.op_tail ? prb_.iblock - prb_.op_tail : 0; }
++    int ip_padding() { return prb_.ip_tail ? prb_.oblock - prb_.ip_tail : 0; }
++
+     void step(int off, int prev_i_off, int prev_o_off, int prev_s_off,
+             int &i_off, int &o_off, int &s_off, int step_size = 1) {
+         i_off = prev_i_off;
+@@ -385,6 +414,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+                                 prb_.otype, u8, data_type::s8, s32, f32)))
+                 && utils::everyone_is(8, n(0), n(1))
+                 && utils::everyone_is(1, os(0), is(1))
++                && utils::everyone_is(0, prb_.ip_tail, prb_.op_tail)
+                 && prb_.scale_type == scale_type_t::NONE && prb_.beta == 0.f;
+     }
+ 
+@@ -405,17 +435,14 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+     bool process_direct_copy(int len) {
+         using namespace data_type;
+ 
+-        const int simd_w = cpu_isa_traits<isa>::vlen == 16
+-                ? cpu_isa_traits<isa>::vlen / itype_sz /* use 128-bit VReg */
+-                : cpu_isa_traits<isa>::vlen / itype_sz
+-                        / 2; /* use lower half of 512-bit ZReg */
+-
++        const int simd_w = cpu_isa_traits<isa>::vlen / itype_sz;
+         bool can_do = true && mayiuse(isa)
+                 && utils::everyone_is(1, os(0), is(0))
+                 && (false || prb_.itype == prb_.otype
+                         || (prb_.itype == s32 && prb_.otype == f32)
+                         || (prb_.itype == f32 && prb_.otype == s32))
+                 && len % simd_w == 0 && n(0) % len == 0
++                && prb_.ip_tail % simd_w == 0 && prb_.op_tail % simd_w == 0
+                 && prb_.scale_type == scale_type_t::NONE && prb_.beta == 0.f;
+         if (!can_do) return false;
+ 
+@@ -511,7 +538,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+     }
+ 
+     void process_unroll_generic_step(int reg_unroll, const int *i_off,
+-            const int *o_off, const int *s_off) {
++            const int *o_off, const int *s_off, const int *ip_padding,
++            const bool h_padded) {
+         using namespace data_type;
+ 
+         auto cvt2ps
+@@ -571,6 +599,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         for (int ur = 1; ur < reg_unroll; ++ur)
+             if (o_off[ur] != o_off[ur - 1] + 1) can_store_xmm = false;
+         const int ur_step = can_store_xmm ? 4 : 1;
++        const int load_tail_step
++                = !can_load_xmm && can_store_xmm ? ur_step : load_step;
+ 
+         const bool interim_f32 = false
+                 || utils::one_of(f32, prb_.itype, prb_.otype)
+@@ -579,55 +609,85 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         const bool need_saturation
+                 = (utils::one_of(prb_.otype, u8, data_type::s8, s32)
+                         && interim_f32);
+-
+-        if (!can_load_xmm && can_store_xmm) {
+-            assert(ur_step == 4);
+-            /* load with stride */
+-            for (int ur = 0; ur < reg_unroll; ur += ur_step) {
+-
++        if (h_padded) {
++            for (int ur = 0; ur < reg_unroll; ur += load_tail_step) {
++                if (itype_sz == 4)
++                    movi(VReg4S(ur), 0);
++                else if (itype_sz == 2)
++                    movi(VReg8H(ur), 0);
++                else
++                    movi(VReg16B(ur), 0);
+                 /* x_tmp_vec = X_TMP_0 - X_TMP_4
+                  Do not use X_TMP_? as the last arg. */
+-                for (int r = 0; r < ur_step; ++r) {
+-                    add_imm(x_tmp_vec[r], x_ptr_in_off,
+-                            i_off[ur + r] * itype_sz, X_DEFAULT_ADDR);
++                for (int r = 0; r < load_tail_step; ++r) {
++                    if (ip_padding[ur + r] == 0) {
++                        add_imm(x_tmp_vec[r], x_ptr_in_off,
++                                i_off[ur + r] * itype_sz, X_DEFAULT_ADDR);
++                    }
+                 }
+ 
+-                for (int r = 0; r < ur_step; ++r) {
+-                    if (itype_sz == 4)
+-                        ld1(VReg4S(ur)[r], ptr(x_tmp_vec[r]));
+-                    else if (itype_sz == 2)
+-                        ld1(VReg8H(ur)[r], ptr(x_tmp_vec[r]));
+-                    else
+-                        ld1(VReg16B(ur)[r], ptr(x_tmp_vec[r]));
++                for (int r = 0; r < load_tail_step; ++r) {
++                    if (ip_padding[ur + r] == 0) {
++                        if (itype_sz == 4)
++                            ld1(VReg4S(ur)[r], ptr(x_tmp_vec[r]));
++                        else if (itype_sz == 2)
++                            ld1(VReg8H(ur)[r], ptr(x_tmp_vec[r]));
++                        else
++                            ld1(VReg16B(ur)[r], ptr(x_tmp_vec[r]));
++                    }
+                 }
+             }
+         } else {
+-            int ur = 0;
+-            int tmp_ur = 0;
+-            while (ur < reg_unroll) {
+-                int count = 0;
++            if (!can_load_xmm && can_store_xmm) {
++                assert(ur_step == 4);
++                /* load with stride */
++                for (int ur = 0; ur < reg_unroll; ur += ur_step) {
+ 
+-                do {
+-                    add_imm(x_tmp_vec[count++], x_ptr_in_off,
+-                            i_off[ur] * itype_sz, X_DEFAULT_ADDR);
+-                    ur += load_step;
+-                } while (ur < reg_unroll && count < x_tmp_vec_size);
++                    /* x_tmp_vec = X_TMP_0 - X_TMP_4
++                 Do not use X_TMP_? as the last arg. */
++                    for (int r = 0; r < ur_step; ++r) {
++                        add_imm(x_tmp_vec[r], x_ptr_in_off,
++                                i_off[ur + r] * itype_sz, X_DEFAULT_ADDR);
++                    }
+ 
+-                for (int i = 0; i < count; i++) {
++                    for (int r = 0; r < ur_step; ++r) {
++                        if (itype_sz == 4)
++                            ld1(VReg4S(ur)[r], ptr(x_tmp_vec[r]));
++                        else if (itype_sz == 2)
++                            ld1(VReg8H(ur)[r], ptr(x_tmp_vec[r]));
++                        else
++                            ld1(VReg16B(ur)[r], ptr(x_tmp_vec[r]));
++                    }
++                }
++            } else {
++                int ur = 0;
++                int tmp_ur = 0;
++                while (ur < reg_unroll) {
++                    int count = 0;
++
++                    do {
++                        add_imm(x_tmp_vec[count++], x_ptr_in_off,
++                                i_off[ur] * itype_sz, X_DEFAULT_ADDR);
++                        ur += load_step;
++                    } while (ur < reg_unroll && count < x_tmp_vec_size);
++
++                    for (int i = 0; i < count; i++) {
+ 
+-                    switch (load_step * itype_sz) {
+-                        case 16: ldr(QReg(tmp_ur), ptr(x_tmp_vec[i])); break;
+-                        case 8: ldr(DReg(tmp_ur), ptr(x_tmp_vec[i])); break;
+-                        case 4: ldr(SReg(tmp_ur), ptr(x_tmp_vec[i])); break;
+-                        case 2: ldr(HReg(tmp_ur), ptr(x_tmp_vec[i])); break;
+-                        case 1: ldr(BReg(tmp_ur), ptr(x_tmp_vec[i])); break;
+-                        default: assert(!"unreachable");
++                        switch (load_step * itype_sz) {
++                            case 16:
++                                ldr(QReg(tmp_ur), ptr(x_tmp_vec[i]));
++                                break;
++                            case 8: ldr(DReg(tmp_ur), ptr(x_tmp_vec[i])); break;
++                            case 4: ldr(SReg(tmp_ur), ptr(x_tmp_vec[i])); break;
++                            case 2: ldr(HReg(tmp_ur), ptr(x_tmp_vec[i])); break;
++                            case 1: ldr(BReg(tmp_ur), ptr(x_tmp_vec[i])); break;
++                            default: assert(!"unreachable");
++                        }
++                        tmp_ur += load_step;
+                     }
+-                    tmp_ur += load_step;
+                 }
+             }
+         }
+-
+         /* xmm[:] <-- (f32)xmm[:] */
+         if (interim_f32) {
+             const int cvt_step = nstl::max(load_step, ur_step);
+@@ -708,7 +768,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+                         if (s_off[r] != s_off[r - 1] + 0)
+                             scale_load_type = scale_load_type_t::load;
+ 
+-                    if (scale_load_type == scale_load_type_t::bcast) {
++                    if (scale_load_type == scale_load_type_t::bcast
++                            && !h_padded) {
+                         VReg4S v(xmm_scale.getIdx());
+                         VReg4S v_dst(ur);
+                         add_imm(X_TMP_0, x_ptr_scale_off, s_off[ur] * stype_sz,
+@@ -724,7 +785,8 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+                         if (s_off[r] != s_off[r - 1] + 1)
+                             scale_load_type = scale_load_type_t::gather;
+ 
+-                    if (scale_load_type == scale_load_type_t::load) {
++                    if (scale_load_type == scale_load_type_t::load
++                            && !h_padded) {
+                         uint32_t idx = xmm_scale.getIdx();
+                         VReg4S v_dst(ur);
+                         add_imm(X_TMP_0, x_ptr_scale_off, s_off[ur] * stype_sz,
+@@ -739,14 +801,18 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+                     // so gather the scale factors one by one
+                     /*ur_step is 1 or 4. */
+                     for (int r = ur; r < ur + ur_step; ++r) {
+-                        /* x_tmp_vec = X_TMP_0 - X_TMP_4
++                        if (ip_padding[r] == 0 || !h_padded) {
++                            /* x_tmp_vec = X_TMP_0 - X_TMP_4
+                          Do not use X_TMP_? as the last arg. */
+-                        add_imm(x_tmp_vec[r - ur], x_ptr_scale_off,
+-                                s_off[r] * stype_sz, X_DEFAULT_ADDR);
++                            add_imm(x_tmp_vec[r - ur], x_ptr_scale_off,
++                                    s_off[r] * stype_sz, X_DEFAULT_ADDR);
++                        }
+                     }
+                     for (int r = ur; r < ur + ur_step; ++r) {
+-                        VReg4S v(xmm_scale.getIdx());
+-                        ld1(v[r - ur], ptr(x_tmp_vec[r - ur]));
++                        if (ip_padding[r] == 0 || !h_padded) {
++                            VReg4S v(xmm_scale.getIdx());
++                            ld1(v[r - ur], ptr(x_tmp_vec[r - ur]));
++                        }
+                     }
+                     fmul(VReg4S(ur), VReg4S(ur), xmm_scale);
+                 }
+@@ -925,7 +991,15 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         }
+     }
+ 
+-    void process_unroll_generic(int len) {
++    void comp_padding_flag(int ndims, int off, int len, int &i_tail) {
++        const int ip_without_padding
++                = ndims == 0 ? len - ip_padding() : prb_.ip_tail;
++        if ((ndims == 0 && off >= ip_without_padding)
++                || (ndims > 0 && (off % prb_.oblock) >= ip_without_padding))
++            i_tail = 1;
++    }
++
++    void process_unroll_generic(const int ndims, int len, const bool h_padded) {
+         const int blk = 8;
+ 
+         int i_off[2 * blk] = {0};
+@@ -936,22 +1010,37 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+ 
+         for (int off = 0; off < len; off += blk) {
+             const int reg_unroll = nstl::min(off + blk, len) - off;
++            int ip_padding[blk] = {0};
+ 
+-            /* compute offsets */
++            /* compute offsets and tail*/
+             for (int ur = off != 0 ? 0 : 1; ur < reg_unroll; ++ur) {
+                 const int ur_c = curr * blk + ur;
+                 const int ur_p = (ur_c - 1 + 2 * blk) % (2 * blk); // prev ur
+                 step(off + ur, i_off[ur_p], o_off[ur_p], s_off[ur_p],
+                         i_off[ur_c], o_off[ur_c], s_off[ur_c]);
++                if (h_padded)
++                    comp_padding_flag(ndims, off + ur, len, ip_padding[ur]);
+             }
+-
+             process_unroll_generic_step(reg_unroll, i_off + curr * blk,
+-                    o_off + curr * blk, s_off + curr * blk);
++                    o_off + curr * blk, s_off + curr * blk, ip_padding,
++                    h_padded);
+ 
+             curr = 1 - curr;
+         }
+     }
+ 
++    void compute_ker(
++            const int ndims, const int len_unroll, const bool h_padded) {
++        bool optimized = false;
++        optimized = optimized
++                || (process_direct_copy<sve_256>(len_unroll) && !h_padded);
++        optimized = optimized
++                || (process_direct_copy<asimd>(len_unroll) && !h_padded);
++        optimized
++                = optimized || (process_unroll_tr8x8(len_unroll) && !h_padded);
++        if (!optimized) process_unroll_generic(ndims, len_unroll, h_padded);
++    }
++
+     void loop_begin(Label &l, XReg reg_cnt, int len) {
+         mov(reg_cnt, len);
+         L(l);
+@@ -985,6 +1074,28 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         }
+     }
+ 
++    void compute_blk_ker(const int len_unroll) {
++        int omp_ndims = prb_.full_ndims - prb_.ndims;
++        Label no_last_blk, end_label;
++
++        if (prb_.ip_tail > 0 && prb_.op_tail == 0) {
++            if (omp_ndims == 0) {
++                cmp(reg_last_loop_cnt, 1);
++                bne(no_last_blk);
++                compute_ker(omp_ndims, len_unroll, true);
++            } else {
++                cmp(reg_blk_chunks, blk_cnt());
++                bne(no_last_blk);
++                compute_ker(omp_ndims, len_unroll, true);
++            }
++            b(end_label);
++        }
++
++        L(no_last_blk);
++        compute_ker(omp_ndims, len_unroll, false);
++        L(end_label);
++    }
++
+     bool simple_impl() {
+         simple_impl_desc_t d;
+         if (!simple_impl_desc_init(prb_, &d)) return false;
+@@ -1013,11 +1124,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         if (n_jit_loops > 0)
+             loop_begin(l_loop[0], reg_cnt[0], n(nfu + 0) / ldu);
+ 
+-        bool optimized = false;
+-        optimized = optimized || process_direct_copy<sve_512>(d.len_unroll);
+-        optimized = optimized || process_direct_copy<asimd>(d.len_unroll);
+-        optimized = optimized || process_unroll_tr8x8(d.len_unroll);
+-        if (!optimized) process_unroll_generic(d.len_unroll);
++        compute_blk_ker(d.len_unroll);
+ 
+         if (n_jit_loops > 0)
+             loop_end(l_loop[0], reg_cnt[0], n(nfu + 0) / ldu, is(nfu + 0) * ldu,
+@@ -1236,9 +1343,13 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         }
+         add_imm(X_TMP_0, abi_param1, PARAM(in), X_TMP_2);
+         add_imm(X_TMP_1, abi_param1, PARAM(out), X_TMP_2);
++        add_imm(reg_blk, abi_param1, PARAM(blk_chunks), reg_blk);
+         ldr(reg_ptr_in, ptr(X_TMP_0));
+         ldr(reg_ptr_out, ptr(X_TMP_1));
++        ldr(reg_blk_chunks, ptr(reg_blk));
++
+ #undef PARAM
++        mov_imm(reg_last_loop_cnt, 1);
+ 
+         mov(x_ptr_in_off, XReg(reg_ptr_in.getIdx()));
+         mov(x_ptr_out_off, XReg(reg_ptr_out.getIdx()));
+@@ -1282,6 +1393,10 @@ private:
+     XReg reg_off_out = x9;
+     XReg reg_off_scale = x10;
+ 
++    XReg reg_blk = x11;
++    XReg reg_blk_chunks = x12;
++    XReg reg_last_loop_cnt = x11;
++
+     XReg reg_tmp = x0;
+ 
+     VReg4S xmm_scale = v15.s;
+@@ -1416,10 +1531,16 @@ static void prb_thread_kernel_balance(
+     for (int d = 0; d < prb.ndims; ++d)
+         sz_total *= prb.nodes[d].n;
+ 
++    /* The general expression for sz_drv_thr can be written as
++     * sz_drv_min = C0 + FC * (nthr > 1 ? 1 : 0) + VC * (nthr - 1)
++     * where FC and VC are fixed and variable costs respectively.
++     * Though for now, the below heuristic seems to be good enough */
++    const size_t sz_drv_thr = (nthr > 1) ? 16 * nthr : 1;
++
+     /* sz_drv_min is the minimal size for the parallel
+      * driver required for good parallelization */
+     const size_t sz_drv_min
+-            = nstl::min<size_t>(16 * nthr, utils::div_up(sz_total, 1024));
++            = nstl::min<size_t>(sz_drv_thr, utils::div_up(sz_total, 1024));
+ 
+     /* kdims -- # of dimensions processed by a kernel
+      * sz_ker_cur -- product of the dimension processed by a kernel
+@@ -1440,7 +1561,8 @@ static void prb_thread_kernel_balance(
+      * (less than tr::ker_prb_size_min). In that case try to split the
+      * innermost driver dimension into two, to increase sz_ker_cur. */
+     bool want_borrow_ker_from_drv = true && kdims < prb.ndims
+-            && sz_ker_cur < tr::ker_prb_size_min && sz_drv_cur > sz_drv_min;
++            && sz_ker_cur < tr::ker_prb_size_min && sz_drv_cur > sz_drv_min
++            && kdims != prb.blk_chunk_idx;
+     if (want_borrow_ker_from_drv) {
+         /* sz_want_borrow is the minimal sz, so that:
+          *  o) sz_ker_cur * sz_want_borrow >= tr::ker_prb_size_min
+@@ -1464,7 +1586,7 @@ static void prb_thread_kernel_balance(
+      * try to split the outermost kernel dimension into two, to increase
+      * sz_drv_cur. */
+     bool want_borrow_drv_from_ker = true && sz_ker_cur > tr::ker_prb_size_min
+-            && sz_drv_cur < sz_drv_min;
++            && sz_drv_cur < sz_drv_min && kdims != prb.blk_chunk_idx;
+     if (want_borrow_drv_from_ker) {
+         size_t sz_want_borrow = utils::div_up(sz_drv_min, sz_drv_cur);
+         for (; prb.nodes[kdims - 1].n % sz_want_borrow; ++sz_want_borrow)
+@@ -1518,6 +1640,8 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
+         prb_dump(prb);
+     });
+ 
++    CHECK(prb_check_blk(prb, *dst_md));
++
+     int ndims_ker_max;
+     int nthr = dnnl_get_max_threads();
+     prb_thread_kernel_balance(prb, ndims_ker_max, nthr);
+@@ -1552,7 +1676,7 @@ status_t jit_uni_reorder_t::pd_t::create(reorder_pd_t **reorder_pd,
+ 
+ void jit_uni_reorder_t::omp_driver_0d(
+         int off, const char *in, char *out, const float *scale) const {
+-    tr::call_param_t c {in, out, scale};
++    tr::call_param_t c {in, out, scale, 0};
+     (*kernel_)(&c);
+ }
+ 
+@@ -1564,6 +1688,7 @@ void jit_uni_reorder_t::omp_driver_1d(int ithr, int nthr, int off,
+         c.in = in + d0 * ns[0].is * data_type_size(pd()->prb_.itype);
+         c.out = out + d0 * ns[0].os * data_type_size(pd()->prb_.otype);
+         c.scale = scale + d0 * ns[0].ss;
++        c.blk_chunks = d0;
+         (*kernel_)(&c);
+     });
+ }
+@@ -1571,6 +1696,7 @@ void jit_uni_reorder_t::omp_driver_1d(int ithr, int nthr, int off,
+ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
+         const char *in, char *out, const float *scale) const {
+     const tr::node_t *ns = pd()->prb_.nodes + off;
++    const int blk_idx_off = pd()->prb_.blk_chunk_idx - off;
+     for_nd(ithr, nthr, (ptrdiff_t)ns[1].n, (ptrdiff_t)ns[0].n,
+             [&](ptrdiff_t d1, ptrdiff_t d0) {
+                 auto c = tr::call_param_t();
+@@ -1581,6 +1707,7 @@ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
+                         + (d0 * ns[0].os + d1 * ns[1].os)
+                                 * data_type_size(pd()->prb_.otype);
+                 c.scale = scale + d0 * ns[0].ss + d1 * ns[1].ss;
++                c.blk_chunks = utils::pick(blk_idx_off, d0, d1);
+                 (*kernel_)(&c);
+             });
+ }
+@@ -1588,6 +1715,7 @@ void jit_uni_reorder_t::omp_driver_2d(int ithr, int nthr, int off,
+ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
+         const char *in, char *out, const float *scale) const {
+     const tr::node_t *ns = pd()->prb_.nodes + off;
++    const int blk_idx_off = pd()->prb_.blk_chunk_idx - off;
+     for_nd(ithr, nthr, (ptrdiff_t)ns[2].n, (ptrdiff_t)ns[1].n,
+             (ptrdiff_t)ns[0].n, [&](ptrdiff_t d2, ptrdiff_t d1, ptrdiff_t d0) {
+                 auto c = tr::call_param_t();
+@@ -1598,6 +1726,7 @@ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
+                         + (d0 * ns[0].os + d1 * ns[1].os + d2 * ns[2].os)
+                                 * data_type_size(pd()->prb_.otype);
+                 c.scale = scale + d0 * ns[0].ss + d1 * ns[1].ss + d2 * ns[2].ss;
++                c.blk_chunks = utils::pick(blk_idx_off, d0, d1, d2);
+                 (*kernel_)(&c);
+             });
+ }
+@@ -1605,6 +1734,7 @@ void jit_uni_reorder_t::omp_driver_3d(int ithr, int nthr, int off,
+ void jit_uni_reorder_t::omp_driver_4d(int ithr, int nthr, int off,
+         const char *in, char *out, const float *scale) const {
+     const tr::node_t *ns = pd()->prb_.nodes + off;
++    const int blk_idx_off = pd()->prb_.blk_chunk_idx - off;
+     for_nd(ithr, nthr, (ptrdiff_t)ns[3].n, (ptrdiff_t)ns[2].n,
+             (ptrdiff_t)ns[1].n, (ptrdiff_t)ns[0].n,
+             [&](ptrdiff_t d3, ptrdiff_t d2, ptrdiff_t d1, ptrdiff_t d0) {
+@@ -1619,6 +1749,7 @@ void jit_uni_reorder_t::omp_driver_4d(int ithr, int nthr, int off,
+                                 * data_type_size(pd()->prb_.otype);
+                 c.scale = scale + d0 * ns[0].ss + d1 * ns[1].ss + d2 * ns[2].ss
+                         + d3 * ns[3].ss;
++                c.blk_chunks = utils::pick(blk_idx_off, d0, d1, d2, d3);
+                 (*kernel_)(&c);
+             });
+ }
+diff --git a/src/cpu/aarch64/jit_uni_reorder.hpp b/src/cpu/aarch64/jit_uni_reorder.hpp
+index 88762756c..2fb6f0f89 100644
+--- a/src/cpu/aarch64/jit_uni_reorder.hpp
++++ b/src/cpu/aarch64/jit_uni_reorder.hpp
+@@ -1,6 +1,7 @@
+ /*******************************************************************************
+ * Copyright 2018-2020 Intel Corporation
+ * Copyright 2020 FUJITSU LIMITED
++* Copyright 2022 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -52,11 +53,19 @@ struct prb_t {
+     ptrdiff_t ooff;
+     scale_type_t scale_type;
+     float beta;
++    int full_ndims;
++    int ip_tail;
++    int op_tail;
++    int iblock;
++    int oblock;
++    int blk_chunk_idx;
+ };
+ 
+ status_t prb_init(prb_t &prb, const memory_desc_t &imd,
+         const memory_desc_t &omd, const primitive_attr_t *attr);
+ 
++status_t prb_check_blk(prb_t &prb, const memory_desc_t &imd);
++
+ /** sorts the problem nodes so that output strides come in ascending order */
+ void prb_normalize(prb_t &p);
+ 
+@@ -82,6 +91,7 @@ struct call_param_t {
+     const void *in;
+     void *out;
+     const float *scale;
++    size_t blk_chunks;
+ };
+ 
+ struct kernel_t {
+diff --git a/src/cpu/aarch64/jit_uni_reorder_utils.cpp b/src/cpu/aarch64/jit_uni_reorder_utils.cpp
+index 3d6e424e3..7123811f8 100644
+--- a/src/cpu/aarch64/jit_uni_reorder_utils.cpp
++++ b/src/cpu/aarch64/jit_uni_reorder_utils.cpp
+@@ -1,6 +1,7 @@
+ /*******************************************************************************
+ * Copyright 2018-2021 Intel Corporation
+ * Copyright 2020 FUJITSU LIMITED
++* Copyright 2022 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -15,7 +16,8 @@
+ * limitations under the License.
+ *******************************************************************************/
+ 
+-#include <assert.h>
++#include <cassert>
++#include <set>
+ 
+ #include "common/c_types_map.hpp"
+ #include "common/dnnl_thread.hpp"
+@@ -46,8 +48,65 @@ struct layout_desc_t {
+     strides_t strides;
+ };
+ 
+-status_t cvt_mem_desc_to_layout_desc(
+-        const memory_desc_t &md_, layout_desc_t &ld, const dims_t &blocks) {
++static status_t compute_blk_and_tail(
++        const memory_desc_t &md_, const int idx, int &blk, int &tail) {
++    const auto md = memory_desc_wrapper(md_);
++    const auto &bd = md.blocking_desc();
++    if (tail == 0) return status::success;
++
++    const std::set<dim_t> unique_inner_idxs(
++            bd.inner_idxs, bd.inner_idxs + bd.inner_nblks);
++    std::set<dim_t> dims_with_multiple_blks;
++    for (dim_t dim : unique_inner_idxs) {
++        if (std::count(bd.inner_idxs, bd.inner_idxs + bd.inner_nblks, dim) > 1)
++            dims_with_multiple_blks.insert(dim);
++    }
++
++    // Dims that have a tail and have multiple blocks are not supported by the jit kernel yet.
++    // For example:
++    // src_tag = abcd
++    // dst_tag = ABcd16b16a4b
++    // 16x15x3x3
++    // In this case, 'b' dim has two blocks and has a tail. It is not a supported case.
++    if (dims_with_multiple_blks.find(idx) != dims_with_multiple_blks.end())
++        return status::unimplemented;
++
++    // Only supports inconsistent padding in single and double blocks
++    // and the total block size <= 256
++    for (int iblk = bd.inner_nblks - 1; iblk > 0; --iblk) {
++        if (bd.inner_idxs[iblk] == idx) break;
++        blk *= bd.inner_blks[iblk];
++        tail *= bd.inner_blks[iblk];
++    }
++    if (unique_inner_idxs.size() > 2 || blk > 256) return status::unimplemented;
++
++    return status::success;
++}
++
++static status_t compute_chunk_idx(const prb_t &p, const memory_desc_t &imd_,
++        const memory_desc_t &omd_, const int blk_idx, int &chunk_idx) {
++    const auto imd = memory_desc_wrapper(imd_);
++    const auto omd = memory_desc_wrapper(omd_);
++    const auto &ibd = imd.blocking_desc();
++    const auto &obd = omd.blocking_desc();
++    if (p.ip_tail == 0 && p.op_tail == 0) return status::success;
++
++    const ptrdiff_t is
++            = ibd.strides[blk_idx] * obd.inner_blks[obd.inner_idxs[blk_idx]];
++    const ptrdiff_t os = obd.strides[blk_idx];
++
++    for (int i = blk_idx; i < omd.ndims(); ++i) {
++        if (p.nodes[i].os == os && p.nodes[i].is == is) {
++            chunk_idx = i;
++            return status::success;
++        }
++    }
++
++    return status::invalid_arguments;
++}
++
++status_t cvt_mem_desc_to_layout_desc(const memory_desc_t &md_,
++        layout_desc_t &ld, const dims_t &blocks, const dims_t &ext_padding) {
+     const auto md = memory_desc_wrapper(md_);
+ 
+     bool ok = true && md.is_blocking_desc() && md.extra().flags == 0;
+@@ -75,7 +134,7 @@ status_t cvt_mem_desc_to_layout_desc(
+                 stride *= bd.inner_blks[iblk];
+             }
+         }
+-        P(d, md.padded_dims()[d] / blocks[d], bd.strides[d]);
++        P(d, (md.padded_dims()[d] + ext_padding[d]) / blocks[d], bd.strides[d]);
+ 
+         // TODO: NOW: revisit, do we need a reverse?
+         // TODO: NOW: consider using strides instead of block sizes in md
+@@ -98,7 +157,8 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
+ 
+     auto check_post_ops = [](const primitive_attr_t *attr) {
+         const auto &po = attr->post_ops_;
+-        return po.len() == 0 || (po.len() == 1 && po.entry_[0].is_sum(false));
++        return po.len() == 0
++                || (po.len() == 1 && po.contain(primitive_kind::sum, 0));
+     };
+ 
+     bool ok = im_d.is_blocking_desc() && om_d.is_blocking_desc()
+@@ -110,26 +170,58 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
+             && check_post_ops(attr);
+     if (!ok) return unimplemented;
+ 
+-    dims_t iblocks, oblocks;
++    dims_t iblocks, oblocks, ip_padding, op_padding;
+     im_d.compute_blocks(iblocks);
+     om_d.compute_blocks(oblocks);
++    utils::array_set(ip_padding, 0, im_d.ndims());
++    utils::array_set(op_padding, 0, om_d.ndims());
++
++    /* padding_dim consistency check
++     * only supports inconsitent padding for src
++     * TODO: Add inconsistent padding support for dst */
++    int ip_tail = 0;
++    int op_tail = 0;
++    int iblk_w_tail = 1;
++    int oblk_w_tail = 1;
++    int blk_idx = 0;
+ 
+-    /* padding_dim consistency check */
+     for (int d = 0; d < im_d.ndims(); ++d) {
+-        const auto pdim = im_d.padded_dims()[d];
+-        bool ok = true && pdim == om_d.padded_dims()[d]
+-                && pdim % iblocks[d] == 0 && pdim % oblocks[d] == 0;
+-        if (!ok) return unimplemented;
++        const int ip_tmp_dim = im_d.padded_dims()[d];
++        const int op_tmp_dim = om_d.padded_dims()[d];
++        const int ip_tmp_tail = ip_tmp_dim % oblocks[d];
++        const int op_tmp_tail = op_tmp_dim % iblocks[d];
++
++        const bool pdim_consistent = ip_tmp_dim == op_tmp_dim
++                && ip_tmp_tail == 0 && op_tmp_tail == 0;
++        const bool pdim_tail = ip_tmp_tail > 0
++                && (ip_tmp_dim + oblocks[d] - ip_tmp_tail) == op_tmp_dim
++                && op_tmp_tail == 0 && ip_tail == 0;
++        if (!pdim_consistent && !pdim_tail) return status::unimplemented;
++        if (pdim_tail) {
++            blk_idx = d;
++            ip_tail = ip_tmp_tail;
++            op_tail = op_tmp_tail;
++            iblk_w_tail = iblocks[d];
++            oblk_w_tail = oblocks[d];
++            ip_padding[d] = oblocks[d] - ip_tmp_tail;
++            op_padding[d] = iblocks[d] - op_tmp_tail;
++        }
+     }
++    CHECK(compute_blk_and_tail(omd, blk_idx, oblk_w_tail, ip_tail));
+ 
+     layout_desc_t ild, old;
+-    status_t status = cvt_mem_desc_to_layout_desc(imd, ild, iblocks);
++    status_t status
++            = cvt_mem_desc_to_layout_desc(imd, ild, iblocks, ip_padding);
+     if (status != success) return status;
+-    status = cvt_mem_desc_to_layout_desc(omd, old, oblocks);
++    status = cvt_mem_desc_to_layout_desc(omd, old, oblocks, op_padding);
+     if (status != success) return status;
+ 
+     p.itype = ild.dt;
+     p.otype = old.dt;
++    p.ip_tail = ip_tail;
++    p.op_tail = op_tail;
++    p.iblock = iblk_w_tail;
++    p.oblock = oblk_w_tail;
+ 
+     p.scale_type = attr->output_scales_.has_default_values()
+             ? scale_type_t::NONE
+@@ -156,7 +248,6 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
+ 
+     while (i_pos < ild.ndims && o_pos < old.ndims) {
+         assert(ild.id[i_pos] == old.id[o_pos]);
+-        if (ild.id[i_pos] != old.id[o_pos]) return runtime_error;
+ 
+         assert(ndims < max_ndims);
+         if (ndims == max_ndims) return runtime_error;
+@@ -191,7 +282,12 @@ status_t prb_init(prb_t &p, const memory_desc_t &imd, const memory_desc_t &omd,
+             ild.dims[i_pos] = factor;
+         }
+     }
++    int blk_chunk_idx = ndims;
++    CHECK(compute_chunk_idx(p, imd, omd, blk_idx, blk_chunk_idx));
++
+     p.ndims = ndims;
++    p.full_ndims = ndims;
++    p.blk_chunk_idx = blk_chunk_idx;
+ 
+     p.ioff = memory_desc_wrapper(imd).offset0();
+     p.ooff = memory_desc_wrapper(omd).offset0();
+@@ -211,8 +307,28 @@ void prb_normalize(prb_t &p) {
+                             && p.nodes[j].n < p.nodes[min_pos].n);
+             if (new_min) min_pos = j;
+         }
+-        if (min_pos != d) nstl::swap(p.nodes[d], p.nodes[min_pos]);
++        if (min_pos != d) {
++            nstl::swap(p.nodes[d], p.nodes[min_pos]);
++            if (p.blk_chunk_idx == min_pos || p.blk_chunk_idx == d)
++                p.blk_chunk_idx = p.blk_chunk_idx == min_pos ? d : min_pos;
++        }
++    }
++}
++
++status_t prb_check_blk(prb_t &p, const memory_desc_t &md_) {
++    const auto md = memory_desc_wrapper(md_);
++    const auto &bd = md.blocking_desc();
++    if (p.ip_tail == 0) return status::success;
++
++    // Check if the inner blocks and p.nodes[blk].n in the firsti nblks
++    // is equivalent in reverse order when has tail in block layout.
++    const int nblk = bd.inner_nblks;
++    for (int iblk = 0; iblk < nblk; ++iblk) {
++        if (bd.inner_blks[nblk - iblk - 1]
++                != static_cast<ptrdiff_t>(p.nodes[iblk].n))
++            return status::unimplemented;
+     }
++    return status::success;
+ }
+ 
+ void prb_simplify(prb_t &p) {
+@@ -225,18 +341,29 @@ void prb_simplify(prb_t &p) {
+     for (int d = 0; d < p.ndims - 1; ++d) {
+         auto &this_node = p.nodes[d + 0];
+         auto &next_node = p.nodes[d + 1];
++        const bool skip_blk_idx = (p.ip_tail > 0 || p.op_tail > 0)
++                && (p.blk_chunk_idx == d || p.blk_chunk_idx == d + 1);
+         const bool fold = false
+-                || next_node.n == (size_t)1 // trivial case, just drop next node
++                || (next_node.n == static_cast<size_t>(1)
++                        && !skip_blk_idx) // trivial case, just drop next node
+                 || (true // or real folding if possible
+-                        && next_node.is == (ptrdiff_t)this_node.n * this_node.is
+-                        && next_node.os == (ptrdiff_t)this_node.n * this_node.os
++                        && !skip_blk_idx
++                        && next_node.is
++                                == static_cast<ptrdiff_t>(
++                                        this_node.n * this_node.is)
++                        && next_node.os
++                                == static_cast<ptrdiff_t>(
++                                        this_node.n * this_node.os)
+                         && next_node.ss
+-                                == (ptrdiff_t)this_node.n * this_node.ss);
++                                == static_cast<ptrdiff_t>(
++                                        this_node.n * this_node.ss));
+         if (fold) {
+             this_node.n *= next_node.n;
+             for (int j = d + 2; j < p.ndims; ++j)
+                 p.nodes[j - 1] = p.nodes[j];
++            if (d < p.blk_chunk_idx) --p.blk_chunk_idx;
+             --p.ndims;
++            --p.full_ndims;
+             --d; // make another try
+         }
+     }
+@@ -251,6 +378,8 @@ void prb_node_split(prb_t &p, int dim, size_t n1) {
+     assert(p.nodes[dim].n % n1 == 0);
+ 
+     p.ndims += 1;
++    p.full_ndims += 1;
++    if (dim < p.blk_chunk_idx) p.blk_chunk_idx += 1;
+ 
+     for (int d = p.ndims; d > dim + 1; --d)
+         p.nodes[d] = p.nodes[d - 1];

--- a/docker/pytorch-aarch64/patches/onednn_reorder_to_bf16.patch
+++ b/docker/pytorch-aarch64/patches/onednn_reorder_to_bf16.patch
@@ -1,0 +1,107 @@
+ *******************************************************************************
+ Copyright 2022 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/jit_uni_reorder.cpp b/src/cpu/aarch64/jit_uni_reorder.cpp
+index a708da808..0522ac8a0 100644
+--- a/src/cpu/aarch64/jit_uni_reorder.cpp
++++ b/src/cpu/aarch64/jit_uni_reorder.cpp
+@@ -160,7 +160,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+ 
+         bool ok = true && p.ndims > 0
+                 && utils::one_of(p.itype, f32, s32, data_type::s8, u8)
+-                && utils::one_of(p.otype, f32, s32, data_type::s8, u8)
++                && utils::one_of(p.otype, f32, bf16, s32, data_type::s8, u8)
+                 && utils::everyone_is(0, p.ioff, p.ooff) /* do we need this? */
+                 && utils::one_of(p.beta, 0.f, 1.f) /* anything else? */
+                 && simple_impl_desc_init(p, nullptr)
+@@ -623,6 +623,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+                         cvt_v_s32_u8(startIdx, regNum);
+                     if (idt == data_type::s8) cvt_v_s8_u8(startIdx, regNum);
+                     break;
++                case bf16:
++                    if(idt == f32) cvt_v_f32_bf16(startIdx, regNum);
++                    break;
+                 default: assert(!"unreachable");
+             }
+         };
+@@ -719,7 +722,6 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+                     } while (ur < reg_unroll && count < x_tmp_vec_size);
+ 
+                     for (int i = 0; i < count; i++) {
+-
+                         switch (load_step * itype_sz_) {
+                             case 16:
+                                 ldr(QReg(tmp_ur), ptr(x_tmp_vec[i]));
+@@ -1134,7 +1136,7 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+             }
+         }
+ 
+-        for (int ur = 0; ur < reg_unroll; ur += ur_step) {
++        for (int ur = 0, count = 0; ur < reg_unroll; ur += ur_step, count += 1) {
+             if (prb_.req_src_zp || prb_.req_dst_zp) {
+                 const bool use_store_masks = !store_masks.empty();
+                 if (use_store_masks) {
+@@ -1193,7 +1195,24 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+             if (prb_.otype != f32)
+                 cvt2odt(ur, 1, prb_.otype, interim_f32 ? f32 : prb_.itype);
+ 
+-            store(o_addr(o_off[ur]), VReg(ur), ur_step * otype_sz_);
++            if(prb_.otype == bf16) {
++                if((count + 1) % 2 == 0) {
++                    // this is the second conversion so we are going to
++                    // store the result now
++                    uzp1(VReg8H(ur-ur_step), VReg8H(ur-ur_step), VReg8H(ur));
++                    store(o_addr(o_off[ur-ur_step]), VReg(ur-ur_step), ur_step * (otype_sz_ + otype_sz_));
++                } else {
++                    // this was the first conversion
++                    continue;
++                }
++            } else {
++                store(o_addr(o_off[ur]), VReg(ur), ur_step * otype_sz_);
++            }
++        }
++
++        // this is edge case when we have only one conversion
++        if (prb_.otype == bf16 && reg_unroll == ur_step) {
++            st1h(ZRegS(0), p_lsb_128, ptr(o_addr(o_off[0])));
+         }
+     }
+ 
+@@ -1594,6 +1613,10 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         UNROLL_INST(fcvtzs, VReg4S, tmp, tmp);
+     }
+ 
++    void cvt_v_f32_bf16(const size_t startIdx, const size_t regNum) {
++        UNROLL_INST2(bfcvt, ZRegH(i), p_lsb_128 / T_m, ZRegS(i));
++    }
++
+     void cvt_z_s8_s32(const size_t startIdx, const size_t regNum) {
+         cvt_z_b_s(startIdx, regNum);
+         UNROLL_INST(sxtb, ZRegS, tmp, P_ALL_ONE / T_m, tmp);
+diff --git a/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp b/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp
+index ba5499ba9..975ddc1f3 100644
+--- a/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp
++++ b/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp
+@@ -34,6 +34,8 @@ const impl_list_map_t &regular_f32_bf16_impl_list_map() {
+             DNNL_NON_X64_ONLY(REG_SR_BIDIR(f32, any, bf16, nChw16c))
+             DNNL_NON_X64_ONLY(REG_SR_BIDIR(f32, any, bf16, nCdhw16c))
+ 
++            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
++
+             DNNL_NON_X64_ONLY(REG_SR(f32, oihw, bf16, OIhw8i16o2i, fmt_order::keep))
+             DNNL_NON_X64_ONLY(REG_SR(f32, goihw, bf16, gOIhw8i16o2i, fmt_order::keep))
+             DNNL_NON_X64_ONLY(REG_SR(f32, oihw, bf16, OIhw8o16i2o, fmt_order::keep))

--- a/docker/pytorch-aarch64/scripts/build-acl.sh
+++ b/docker/pytorch-aarch64/scripts/build-acl.sh
@@ -34,6 +34,7 @@ cd ${src_repo}
 git checkout $version
 
 # Patches for ACL build
+patch -p1 < ../acl_fixed_format_kernels_striding.patch
 patch -p1 < ../acl_openmp_fix.patch
 
 # Default to v8a if $acl_arch is unset.
@@ -47,6 +48,7 @@ multi_isa=0
 # Build with scons
 scons -j16  Werror=0 debug=0 neon=1 opencl=0 embed_kernels=0 \
   os=linux arch=$arch build=native multi_isa=$multi_isa \
+  experimental_fixed_format_kernels=1 openmp=1 cppthreads=0 \
   build_dir=$install_dir/build
 
 cp -r arm_compute $install_dir


### PR DESCRIPTION
 - Using fixed format kernels in oneDNN and ACL.
 - Convolution caching at PyTorch level.
 - Call oneDNN matrix multiplication for BLAS operation when LHS is transposed, but not RHS.
 - Jitted reorder when destination tensor is BF16.