### PR TITLE
Cortex-M35: Increase masterclock frequency to 25MHz

### DIFF
--- a/fast-models-examples/cortex-m35/software/RTE/CMSIS/RTX_Config.h
+++ b/fast-models-examples/cortex-m35/software/RTE/CMSIS/RTX_Config.h
@@ -50,8 +50,10 @@
 //   <o>Kernel Tick Frequency [Hz] <1-1000000>
 //   <i> Defines base time unit for delays and timeouts.
 //   <i> Default: 1000 (1ms tick)
+//   Adjust the Kernel Tick Frequency [Hz] for fast model to match
+//   delay similar to FPGA. The value 20 is the closest match.
 #ifndef OS_TICK_FREQ
-#define OS_TICK_FREQ                1000
+#define OS_TICK_FREQ                20
 #endif
 
 //   <e>Round-Robin Thread switching

--- a/fast-models-examples/cortex-m35/system/m35.lisa
+++ b/fast-models-examples/cortex-m35/system/m35.lisa
@@ -9,17 +9,17 @@ component m35
 		pvbus2ambapv : PVBus2AMBAPV();
 		ramdevice : RAMDevice("size"=0x1000000000);
 		pvbusdecoder : PVBusDecoder();
-		clockdivider : ClockDivider("mul"=50);
+		clock25MHz : ClockDivider("mul"=25000000);
 		masterclock : MasterClock();
     }
     connection
     {
-	masterclock.clk_out => clockdivider.clk_in;
+	masterclock.clk_out => clock25MHz.clk_in;
 	pvbus2ambapv.amba_pv_m => self.m_port_to_external_counter;
 	pvbusdecoder.pvbus_m_range[0x21000000..0x21000fff] => pvbus2ambapv.pvbus_s;
 	pvbusdecoder.pvbus_m_range[0x0..0x20ffffff] => ramdevice.pvbus;
 	self.slave_counter_irq_in => ambapvsignal2sgsignal.amba_pv_signal_s;
-	clockdivider.clk_out => armcortexm35pct.clk_in;
+	clock25MHz.clk_out => armcortexm35pct.clk_in;
 	ambapvsignal2sgsignal.sg_signal_m => armcortexm35pct.irq[30];
 	armcortexm35pct.pvbus_m => pvbusdecoder.pvbus_s;
     }

--- a/fast-models-examples/cortex-m35/system/m35.sgcanvas
+++ b/fast-models-examples/cortex-m35/system/m35.sgcanvas
@@ -2,7 +2,7 @@
 #//////////////////////////////////////////////////////////////////////////
 #//
 #//  File:    m35.sgcanvas
-#//  Created: Tue Dec 13 12:20:53 2022
+#//  Created: Tue Jan 24 22:03:46 2023
 #//  By: Fast Models  System Canvas 11.19.14  (Sep  8 2022)
 #//
 # *  Do NOT modify this file. It is for internal use by System Canvas only.
@@ -10240,13 +10240,13 @@ editor
                 )
             )
         )
-        instance "clockdivider"
+        instance "clock25MHz"
         (
             x = -810;
-            y = -370;
+            y = -450;
             width = 171;
-            height = 99;
-            sheight = 61;
+            height = 79;
+            sheight = 41;
             show_title = true;
             show_name = true;
             show_type = false;
@@ -10290,8 +10290,8 @@ editor
         )
         instance "masterclock"
         (
-            x = -810;
-            y = -480;
+            x = -1050;
+            y = -470;
             width = 171;
             height = 81;
             sheight = 61;
@@ -10449,35 +10449,23 @@ editor
         define "armcortexm35pct.pvbus_m=>pvbusdecoder.pvbus_s"
         (
         )
-        define "clockdivider.clk_out=>armcortexm35pct.clk_in"
-        (
-        )
-        define "masterclock.clk_out=>clockdivider.clk_in"
+        define "clock25MHz.clk_out=>armcortexm35pct.clk_in"
         (
             point
             (
-                x = -630;
-                y = -410;
+                x = -590;
+                y = -400;
                 automatic = true;
             )
             point
             (
-                x = -630;
-                y = -380;
-                automatic = true;
-            )
-            point
-            (
-                x = -820;
-                y = -380;
-                automatic = true;
-            )
-            point
-            (
-                x = -820;
+                x = -590;
                 y = -300;
                 automatic = true;
             )
+        )
+        define "masterclock.clk_out=>clock25MHz.clk_in"
+        (
         )
         define "pvbusdecoder.pvbus_m_range=>pvbus2ambapv.pvbus_s"
         (


### PR DESCRIPTION
The masterclock frequency was set to 50Hz which was causing the simulated time to hit the max value approximately around 35 seconds user time. Once the simulated time hit the max value, SysTick_Hanlder was not triggered at all.

Increase the masterclock frequency to 25MHz to mitigate this.