### PR TITLE
add tensor dilation parameter configuration for acl depthwise conv

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -9,6 +9,7 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Added
 - Back-ports support for dilated conv. kernels in ACL.
+- Adds tensor dilation parameter configuration for acl depthwise convolution
 
 ### Changed
 
@@ -20,7 +21,6 @@ where `YY` is the year, and `MM` the month of the increment.
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r23.05/docker/pytorch-aarch64
 
 ### Added
-- Adds tensor dilation parameter configuration for acl depthwise convolution
 
 ### Changed
 - Increments PyTorch version from 1.13 to 2.0.

--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -20,6 +20,7 @@ where `YY` is the year, and `MM` the month of the increment.
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r23.05/docker/pytorch-aarch64
 
 ### Added
+- Adds tensor dilation parameter configuration for acl depthwise convolution
 
 ### Changed
 - Increments PyTorch version from 1.13 to 2.0.

--- a/docker/pytorch-aarch64/patches/onednn_acl_depthwise_convolution.patch
+++ b/docker/pytorch-aarch64/patches/onednn_acl_depthwise_convolution.patch
@@ -1,5 +1,6 @@
  *******************************************************************************
  Copyright 2022 Arm Limited and affiliates.
+ Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,7 +17,7 @@
  *******************************************************************************
 
 diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
-index fc93d2aa9..6ebac0d17 100644
+index fc93d2aa9..406f3d033 100644
 --- a/src/cpu/aarch64/acl_convolution_utils.cpp
 +++ b/src/cpu/aarch64/acl_convolution_utils.cpp
 @@ -54,10 +54,12 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
@@ -94,7 +95,7 @@ index fc93d2aa9..6ebac0d17 100644
                  weights_md.dims[3] == 1, // kw
                  (!math_mode && dnnl_get_max_threads() < 28))) {
          return status::unimplemented;
-@@ -355,6 +374,27 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -355,6 +374,30 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
      return status::success;
  }
  
@@ -114,7 +115,10 @@ index fc93d2aa9..6ebac0d17 100644
 +        &acp.wei_info,
 +        acp.with_bias ? &acp.bia_info : nullptr,
 +        &acp.dst_info,
-+        acp.padstride_info));
++        acp.padstride_info,
++        1, // depth mutliplier default value
++        acp.act_info,
++        acp.dilation_info));
 +
 +    return status::success;
 +}
@@ -122,7 +126,7 @@ index fc93d2aa9..6ebac0d17 100644
  status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
          memory_desc_t &weights_md, memory_desc_t &dst_md,
          memory_desc_t &bias_md, const convolution_desc_t &cd,
-@@ -364,7 +404,8 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
+@@ -364,7 +407,8 @@ status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
      // Under these conditions, fallback to faster GEMM-based convolution
      // unless the user explicitly specifies Winograd algorithm
      // clang-format off
@@ -148,26 +152,6 @@ index 44dc8eecb..7eae5cbb1 100644
  status_t init_conf_wino(acl_conv_conf_t &acp, memory_desc_t &src_md,
          memory_desc_t &weights_md, memory_desc_t &dst_md,
          memory_desc_t &bias_md, const convolution_desc_t &cd,
-diff --git a/src/cpu/cpu_convolution_list.cpp b/src/cpu/cpu_convolution_list.cpp
-index 4142dbc7e..1800aaf58 100644
---- a/src/cpu/cpu_convolution_list.cpp
-+++ b/src/cpu/cpu_convolution_list.cpp
-@@ -65,6 +65,7 @@ using namespace dnnl::impl::cpu::x64;
- #if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
- #include "cpu/aarch64/acl_gemm_convolution.hpp"
- #include "cpu/aarch64/acl_indirect_gemm_convolution.hpp"
-+#include "cpu/aarch64/acl_depthwise_convolution.hpp"
- #include "cpu/aarch64/acl_winograd_convolution.hpp"
- #endif
- using namespace dnnl::impl::cpu::aarch64;
-@@ -104,6 +105,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
-             CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_fwd_t)
-             CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
-             CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
-+            CPU_INSTANCE_AARCH64_ACL(acl_depthwise_convolution_fwd_t)
-             CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
-             CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f32>)
-             CPU_INSTANCE(gemm_convolution_fwd_t)
 diff --git a/src/cpu/aarch64/acl_depthwise_convolution.cpp b/src/cpu/aarch64/acl_depthwise_convolution.cpp
 new file mode 100644
 index 000000000..1beb8b8af
@@ -217,10 +201,10 @@ index 000000000..1beb8b8af
 +}
 diff --git a/src/cpu/aarch64/acl_depthwise_convolution.hpp b/src/cpu/aarch64/acl_depthwise_convolution.hpp
 new file mode 100644
-index 000000000..d84fc4fb5
+index 000000000..832aab96e
 --- /dev/null
 +++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
-@@ -0,0 +1,139 @@
+@@ -0,0 +1,140 @@
 +/*******************************************************************************
 +* Copyright 2022 Arm Ltd. and affiliates
 +*
@@ -268,7 +252,8 @@ index 000000000..d84fc4fb5
 +            &acl_obj_->dst_tensor,
 +            acp.padstride_info,
 +            1, // depth multiplier default value
-+            acp.act_info);
++            acp.act_info,
++            acp.dilation_info);
 +
 +        // clang-format on
 +        return status::success;
@@ -360,3 +345,26 @@ index 000000000..d84fc4fb5
 +} // namespace dnnl
 +
 +#endif // CPU_AARCH64_ACL_DEPTHWISE_CONVOLUTION_HPP
+diff --git a/src/cpu/cpu_convolution_list.cpp b/src/cpu/cpu_convolution_list.cpp
+index 4142dbc7e..1800aaf58 100644
+--- a/src/cpu/cpu_convolution_list.cpp
++++ b/src/cpu/cpu_convolution_list.cpp
+@@ -65,6 +65,7 @@ using namespace dnnl::impl::cpu::x64;
+ #if DNNL_AARCH64 && DNNL_AARCH64_USE_ACL
+ #include "cpu/aarch64/acl_gemm_convolution.hpp"
+ #include "cpu/aarch64/acl_indirect_gemm_convolution.hpp"
++#include "cpu/aarch64/acl_depthwise_convolution.hpp"
+ #include "cpu/aarch64/acl_winograd_convolution.hpp"
+ #endif
+ using namespace dnnl::impl::cpu::aarch64;
+@@ -104,6 +105,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
+             CPU_INSTANCE_AARCH64(jit_sve_512_dw_convolution_fwd_t)
+             CPU_INSTANCE_AARCH64(jit_sve_512_1x1_convolution_fwd_f32_t)
+             CPU_INSTANCE_AARCH64(jit_sve_512_convolution_fwd_t<f32>)
++            CPU_INSTANCE_AARCH64_ACL(acl_depthwise_convolution_fwd_t)
+             CPU_INSTANCE_AARCH64_ACL(acl_indirect_gemm_convolution_fwd_t)
+             CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<f32>)
+             CPU_INSTANCE(gemm_convolution_fwd_t)
+-- 
+2.25.1
+

--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -20,6 +20,7 @@ where `YY` is the year, and `MM` the month of the increment.
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r23.05/docker/tensorflow-aarch64
 
 ### Added
+- Adds tensor dilation parameter configuration for acl depthwise convolution
 
 ### Changed
 - Updates TensorFlow to v2.12.

--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -9,6 +9,7 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Added
 - Back-ports support for dilated conv. kernels in ACL.
+- Adds tensor dilation parameter configuration for acl depthwise convolution
 
 ### Changed
 
@@ -20,7 +21,6 @@ where `YY` is the year, and `MM` the month of the increment.
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r23.05/docker/tensorflow-aarch64
 
 ### Added
-- Adds tensor dilation parameter configuration for acl depthwise convolution
 
 ### Changed
 - Updates TensorFlow to v2.12.

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -302,6 +302,7 @@ COPY patches/tf_recursive_scheduler.patch $PACKAGE_DIR/.
 COPY patches/tf_dispatch_with_heuristics.patch $PACKAGE_DIR/.
 COPY patches/tf_use_acl_instead_of_gemm_api.patch $PACKAGE_DIR/.
 COPY patches/onednn_reorder_padded.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_depthwise_convolution_dilation.patch $PACKAGE_DIR/.
 COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh
 COPY scripts/build-tensorflow-addons.sh $PACKAGE_DIR/.

--- a/docker/tensorflow-aarch64/patches/onednn_acl_depthwise_convolution_dilation.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_depthwise_convolution_dilation.patch
@@ -1,0 +1,50 @@
+ *******************************************************************************
+ Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
+index 6ebac0d17..e2d482085 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.cpp
++++ b/src/cpu/aarch64/acl_convolution_utils.cpp
+@@ -390,7 +390,10 @@ status_t init_conf_depthwise(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         &acp.wei_info,
+         acp.with_bias ? &acp.bia_info : nullptr,
+         &acp.dst_info,
+-        acp.padstride_info));
++        acp.padstride_info,
++        1, // depth multiplier default value
++        acp.act_info,
++        acp.dilation_info));
+ 
+     return status::success;
+ }
+diff --git a/src/cpu/aarch64/acl_depthwise_convolution.hpp b/src/cpu/aarch64/acl_depthwise_convolution.hpp
+index d84fc4fb5..832aab96e 100644
+--- a/src/cpu/aarch64/acl_depthwise_convolution.hpp
++++ b/src/cpu/aarch64/acl_depthwise_convolution.hpp
+@@ -45,7 +45,8 @@ struct acl_depthwise_convolution_resource_t : public resource_t {
+             &acl_obj_->dst_tensor,
+             acp.padstride_info,
+             1, // depth multiplier default value
+-            acp.act_info);
++            acp.act_info,
++            acp.dilation_info);
+ 
+         // clang-format on
+         return status::success;
+-- 
+2.25.1
+

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -1,5 +1,6 @@
  *******************************************************************************
  Copyright 2022-2023 Arm Limited and affiliates.
+ Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,23 +16,21 @@
  limitations under the License.
  *******************************************************************************
 diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
-index 1261273bc92..15107eeb925 100644
+index 1261273bc92..f10f4fb946b 100644
 --- a/tensorflow/workspace2.bzl
 +++ b/tensorflow/workspace2.bzl
-@@ -200,6 +200,8 @@ def _tf_repositories():
+@@ -200,7 +200,10 @@ def _tf_repositories():
              "//third_party/mkl_dnn:onednn_acl_threadcap.patch",
              "//third_party/mkl_dnn:onednn_acl_fixed_format_kernels.patch",
              "//third_party/mkl_dnn:onednn_acl_depthwise_convolution.patch",
 +            "//third_party/mkl_dnn:onednn_reorder_padded.patch",
 +            "//third_party/mkl_dnn:onednn_reorder_update.patch",
              "//third_party/mkl_dnn:onednn_acl_threadpool_scheduler.patch",
++            "//third_party/mkl_dnn:onednn_acl_depthwise_convolution_dilation.patch",
          ],
          sha256 = "a50993aa6265b799b040fe745e0010502f9f7103cc53a9525d59646aef006633",
-diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
-index 15107eeb925..347fbe86216 100644
---- a/tensorflow/workspace2.bzl
-+++ b/tensorflow/workspace2.bzl
-@@ -214,7 +214,7 @@ def _tf_repositories():
+         strip_prefix = "oneDNN-2.7.3",
+@@ -212,7 +215,7 @@ def _tf_repositories():
          sha256 = "e20a060d3c4f803889d96c2f0b865004ba3ef4e228299a44339ea1c1ba827c85",
          strip_prefix = "ComputeLibrary-22.11",
          build_file = "//third_party/compute_library:BUILD",
@@ -39,3 +38,7 @@ index 15107eeb925..347fbe86216 100644
 +        patch_file = ["//third_party/compute_library:compute_library.patch", "//third_party/compute_library:acl_fixed_format_kernels_striding.patch", "//third_party/compute_library:acl_openmp_fix.patch", "//third_party/compute_library:acl_conv_dilation_support.patch"],
          urls = tf_mirror_urls("https://github.com/ARM-software/ComputeLibrary/archive/v22.11.tar.gz"),
      )
+ 
+-- 
+2.25.1
+

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -103,6 +103,7 @@ if [[ $ONEDNN_BUILD ]]; then
         wget https://github.com/oneapi-src/oneDNN/commit/b84c533dad4db495a92fc6d390a7db5ebd938a88.patch -O ../onednn_reorder_update.patch
         mv ../onednn_reorder_update.patch ./third_party/mkl_dnn/.
         mv ../onednn_reorder_padded.patch ./third_party/mkl_dnn/.
+        mv ../onednn_acl_depthwise_convolution_dilation.patch ./third_party/mkl_dnn/.
 
         ## Compute Library
         # Back-port dilation support


### PR DESCRIPTION
updated the existing onednn acl depthwise conv patch in pytorch docker to add tensor dilation parameter configuration.