### PR TITLE
Update oneDNN to v3.2

### DIFF
--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -239,6 +239,10 @@ RUN pip install --no-cache-dir transformers pandas
 # Install OpenCV into our venv (needed for MLCommons benchmarks)
 RUN pip install --no-cache-dir opencv-python-headless==4.8.0.74
 
+# Pin to 0.2.0 due to incompatibility of newer
+# versions with TF 2.14-RC
+RUN pip install --no-cache-dir ml_dtypes==0.2.0
+
 # Remove dependency on HDF5 save support in Keras as this does not
 # work with TensorFlow 2.11 and Transformers 4.24
 COPY scripts/remove-keras-hdf-save-dependency.sh $PACKAGE_DIR/.
@@ -298,6 +302,11 @@ RUN chmod a+x $PACKAGE_DIR/bazel/bazel
 ENV PATH="$PACKAGE_DIR/bazel:$PATH"
 
 # Build TensorFlow
+COPY patches/tf_acl.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_reorder.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_thread_local_scheduler.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_threadcap.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_fp32_bf16_reorder.patch $PACKAGE_DIR/.
 COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh
 COPY scripts/build-tensorflow-addons.sh $PACKAGE_DIR/.

--- a/docker/tensorflow-aarch64/patches/onednn_acl_fp32_bf16_reorder.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_fp32_bf16_reorder.patch
@@ -1,0 +1,111 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/src/cpu/aarch64/cpu_isa_traits.hpp b/src/cpu/aarch64/cpu_isa_traits.hpp
+index 4a43b24c5..1a5cfe590 100644
+--- a/src/cpu/aarch64/cpu_isa_traits.hpp
++++ b/src/cpu/aarch64/cpu_isa_traits.hpp
+@@ -1,6 +1,7 @@
+ /*******************************************************************************
+ * Copyright 2018-2023 Intel Corporation
+ * Copyright 2020-2023 FUJITSU LIMITED
++* Copyright 2023 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -211,10 +212,10 @@ static inline bool mayiuse_atomic() {
+     return cpu().isAtomicSupported();
+ }
+ 
+-inline bool isa_has_bf16(cpu_isa_t isa) {
+-    return false;
++static inline bool mayiuse_bf16() {
++    using namespace Xbyak_aarch64::util;
++    return cpu().isBf16Supported();
+ }
+-
+ } // namespace
+ 
+ /* whatever is required to generate string literals... */
+diff --git a/src/cpu/aarch64/jit_uni_reorder.cpp b/src/cpu/aarch64/jit_uni_reorder.cpp
+index 6bd259ec2..5541bb702 100644
+--- a/src/cpu/aarch64/jit_uni_reorder.cpp
++++ b/src/cpu/aarch64/jit_uni_reorder.cpp
+@@ -1,7 +1,7 @@
+ /*******************************************************************************
+ * Copyright 2018-2023 Intel Corporation
+ * Copyright 2020-2023 FUJITSU LIMITED
+-* Copyright 2022 Arm Ltd. and affiliates
++* Copyright 2022-2023 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -163,11 +163,11 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+ 
+         bool ok = true && p.ndims > 0
+                 && utils::one_of(p.itype, f32, s32, data_type::s8, u8)
+-                && utils::one_of(p.otype, f32, s32, data_type::s8, u8)
++                && utils::one_of(p.otype, f32, bf16, s32, data_type::s8, u8)
+                 && utils::everyone_is(0, p.ioff, p.ooff) /* do we need this? */
+                 && utils::one_of(p.beta, 0.f, 1.f) /* anything else? */
+-                && simple_impl_desc_init(p, nullptr)
+-                && prb_has_small_strides(p);
++                && simple_impl_desc_init(p, nullptr) && prb_has_small_strides(p)
++                && ((p.otype != bf16) || (p.itype == f32 && mayiuse_bf16()));
+ 
+         return ok;
+     }
+@@ -648,6 +648,9 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+                         cvt_v_s32_u8(startIdx, regNum);
+                     if (idt == data_type::s8) cvt_v_s8_u8(startIdx, regNum);
+                     break;
++                case bf16:
++                    if (idt == f32) cvt_v_f32_bf16(startIdx, regNum);
++                    break;
+                 default: assert(!"unreachable");
+             }
+         };
+@@ -1677,6 +1680,10 @@ struct jit_uni_reorder_kernel_f32_t : public kernel_t, public jit_generator {
+         UNROLL_INST(fcvtzs, VReg4S, tmp, tmp);
+     }
+ 
++    void cvt_v_f32_bf16(const size_t startIdx, const size_t regNum) {
++        UNROLL_INST2(bfcvtn, VReg4H(i), VReg4S(i));
++    }
++
+     void cvt_z_s8_s32(const size_t startIdx, const size_t regNum) {
+         cvt_z_b_s(startIdx, regNum);
+         UNROLL_INST(sxtb, ZRegS, tmp, P_ALL_ONE / T_m, tmp);
+diff --git a/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp b/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp
+index ba5499ba9..d4e21d316 100644
+--- a/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp
++++ b/src/cpu/reorder/cpu_reorder_regular_f32_bf16.cpp
+@@ -1,5 +1,6 @@
+ /*******************************************************************************
+ * Copyright 2020-2022 Intel Corporation
++* Copyright 2023 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -34,6 +35,8 @@ const impl_list_map_t &regular_f32_bf16_impl_list_map() {
+             DNNL_NON_X64_ONLY(REG_SR_BIDIR(f32, any, bf16, nChw16c))
+             DNNL_NON_X64_ONLY(REG_SR_BIDIR(f32, any, bf16, nCdhw16c))
+ 
++            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::jit_uni_reorder_t))
++
+             DNNL_NON_X64_ONLY(REG_SR(f32, oihw, bf16, OIhw8i16o2i, fmt_order::keep))
+             DNNL_NON_X64_ONLY(REG_SR(f32, goihw, bf16, gOIhw8i16o2i, fmt_order::keep))
+             DNNL_NON_X64_ONLY(REG_SR(f32, oihw, bf16, OIhw8o16i2o, fmt_order::keep))

--- a/docker/tensorflow-aarch64/patches/onednn_acl_reorder.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_reorder.patch
@@ -1,0 +1,371 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/src/cpu/aarch64/acl_reorder.cpp b/src/cpu/aarch64/acl_reorder.cpp
+new file mode 100644
+index 000000000..061751b55
+--- /dev/null
++++ b/src/cpu/aarch64/acl_reorder.cpp
+@@ -0,0 +1,52 @@
++/*******************************************************************************
++* Copyright 2023 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++
++#include "cpu/aarch64/acl_reorder.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++status_t acl_reorder_fwd_t::execute_forward(const exec_ctx_t &ctx) const {
++    // Lock here is needed because resource_mapper does not support
++    // concurrent multithreaded access.
++    std::lock_guard<std::mutex> _lock {this->mtx};
++
++    auto src = CTX_IN_MEM(const void *, DNNL_ARG_FROM);
++    auto dst = CTX_OUT_MEM(void *, DNNL_ARG_TO);
++
++    // Retrieve primitive resource and configured Compute Library objects
++    auto *acl_resource
++            = ctx.get_resource_mapper()->get<acl_reorder_resource_t>(this);
++
++    acl_reorder_obj_t &acl_obj = acl_resource->get_acl_obj();
++
++    acl_obj.src_tensor.allocator()->import_memory(const_cast<void *>(src));
++    acl_obj.dst_tensor.allocator()->import_memory(dst);
++
++    acl_obj.reorder.run();
++
++    acl_obj.src_tensor.allocator()->free();
++    acl_obj.dst_tensor.allocator()->free();
++
++    return status::success;
++}
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
+diff --git a/src/cpu/aarch64/acl_reorder.hpp b/src/cpu/aarch64/acl_reorder.hpp
+new file mode 100644
+index 0000000000..edbc38914d
+--- /dev/null
++++ b/src/cpu/aarch64/acl_reorder.hpp
+@@ -0,0 +1,262 @@
++/*******************************************************************************
++* Copyright 2023 Arm Ltd. and affiliates
++*
++* Licensed under the Apache License, Version 2.0 (the "License");
++* you may not use this file except in compliance with the License.
++* You may obtain a copy of the License at
++*
++*     http://www.apache.org/licenses/LICENSE-2.0
++*
++* Unless required by applicable law or agreed to in writing, software
++* distributed under the License is distributed on an "AS IS" BASIS,
++* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++* See the License for the specific language governing permissions and
++* limitations under the License.
++*******************************************************************************/
++#ifndef CPU_AARCH64_ACL_REORDER_HPP
++#define CPU_AARCH64_ACL_REORDER_HPP
++
++#include "cpu/aarch64/acl_utils.hpp"
++#include "cpu/reorder/cpu_reorder_pd.hpp"
++#include "arm_compute/core/Types.h"
++#include "common/utils.hpp"
++
++namespace dnnl {
++namespace impl {
++namespace cpu {
++namespace aarch64 {
++
++struct acl_reorder_obj_t {
++    arm_compute::NEReorderLayer reorder;
++    arm_compute::Tensor src_tensor;
++    arm_compute::Tensor dst_tensor;
++    arm_compute::WeightFormat src_wf;
++    arm_compute::WeightFormat dst_wf;
++};
++
++struct acl_reorder_conf_t {
++    arm_compute::TensorInfo src_info;
++    arm_compute::TensorInfo dst_info;
++    arm_compute::WeightFormat src_wf;
++    arm_compute::WeightFormat dst_wf;
++};
++
++struct acl_reorder_resource_t : public resource_t {
++    acl_reorder_resource_t() : acl_obj_(utils::make_unique<acl_reorder_obj_t>()) {}
++
++    status_t configure(const acl_reorder_conf_t &app) {
++        if (!acl_obj_) return status::out_of_memory;
++
++        // Init Compute Library tensors based on info from descriptor
++        acl_obj_->src_tensor.allocator()->init(app.src_info);
++        acl_obj_->dst_tensor.allocator()->init(app.dst_info);
++
++        // clang-format off
++        acl_obj_->reorder.configure(
++            &acl_obj_->src_tensor,
++            &acl_obj_->dst_tensor,
++            app.src_wf,
++            app.dst_wf
++            );
++        // clang-format on
++
++        return status::success;
++    }
++
++    acl_reorder_obj_t &get_acl_obj() const { return *acl_obj_; }
++    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_reorder_resource_t);
++
++private:
++    std::unique_ptr<acl_reorder_obj_t> acl_obj_;
++}; // acl_reorder_resource_t
++
++struct acl_reorder_fwd_t : public primitive_t {
++    using primitive_t::primitive_t;
++    struct pd_t : public cpu_reorder_pd_t {
++
++        using cpu_reorder_pd_t::cpu_reorder_pd_t;
++
++        DECLARE_COMMON_PD_T("acl", acl_reorder_fwd_t);
++
++        static status_t create(reorder_pd_t **reorder_pd, engine_t *engine,
++                const primitive_attr_t *attr, engine_t *src_engine,
++                const memory_desc_t *src_md, engine_t *dst_engine,
++                const memory_desc_t *dst_md) {
++
++            using namespace acl_utils;
++            // using skip_mask_t = dnnl_primitive_attr::skip_mask_t;
++
++            bool ok = src_md->data_type
++                            == dst_md->data_type // ACL only supports matching src/dst data types
++                    && utils::one_of(src_md->data_type,
++                            data_type::f32) // Only supports f32 for now
++                    && attr->has_default_values();
++            if (!ok) return status::unimplemented;
++
++            int mask = -1;
++            bool is_set = false;
++            // CHECK(attr->scales_.get(DNNL_ARG_DST, &mask, &is_set));
++            const memory_desc_wrapper input_d(src_md);
++            if (input_d.has_runtime_dims_or_strides() && is_set && mask > 0)
++                return status::unimplemented;
++
++            // Create and check primitive descriptor
++            auto _pd = new pd_t(attr, src_engine->kind(), src_md,
++                    dst_engine->kind(), dst_md);
++            if (_pd == nullptr) return status::out_of_memory;
++            if (_pd->init(engine, src_engine, dst_engine) != status::success) {
++                delete _pd;
++                return status::unimplemented;
++            }
++
++            const memory_desc_wrapper src_d(*src_md);
++            const memory_desc_wrapper dst_d(*dst_md);
++
++            const int ndims = src_d.ndims();
++
++            auto src_tag = memory_desc_matches_one_of_tag(
++                            *src_md, format_tag::ba, format_tag::cdba);
++            ACL_CHECK_SUPPORT(
++                            utils::one_of(format_tag::undef, src_tag),
++                            "");
++
++            arm_compute::TensorShape acl_tensor_shape_in;
++            arm_compute::TensorShape acl_tensor_shape_out;
++            // Need even amount of dims in dim 0 for ACL kernel (eg mulitple of 8 rows when blocking by 8)
++            int dim_0_rounded_up;
++
++            // Switch for 2 or 4 dim tensors
++            switch(ndims)
++            {
++                // Currently for Ab4a and Ab8a
++                // No format_tag for these, have to deduce from stride
++                case 2:
++                    {
++                        if(dst_md->dims[0] == 1 || dst_md->dims[1] == 1){
++                            return status::unimplemented;
++                        }
++                        int dst_dim_1 = dst_md->dims[1];
++                        int dst_dim_0_stride = dst_md->format_desc.blocking.strides[0];
++                        int dst_dim_1_stride = dst_md->format_desc.blocking.strides[1];
++                        // Interleave of 4 or 8 that stride for dim 1
++                        if (dst_dim_1_stride != 4 && dst_dim_1_stride != 8){
++                            return status::unimplemented;
++                        }
++                        // Check to ensure it's a blocking transpose
++                        if (dst_dim_1 * dst_dim_1_stride != dst_dim_0_stride){
++                            return status::unimplemented;
++                        }
++                        if(dst_dim_1_stride == 4){
++                            // Set Dest WeightFormat
++                            _pd->app_.dst_wf = arm_compute::WeightFormat::OHWIo4;
++                            dim_0_rounded_up
++                                    = utils::rnd_up(src_md->dims[0], 4);
++                        } else {
++                            // Set Dest WeightFormat
++                            _pd->app_.dst_wf = arm_compute::WeightFormat::OHWIo8;
++                            dim_0_rounded_up
++                                    = utils::rnd_up(src_md->dims[0], 8);
++                        }
++                        acl_tensor_shape_in = arm_compute::TensorShape(src_md->dims[1], src_md->dims[0]);
++                        acl_tensor_shape_out = arm_compute::TensorShape(src_md->dims[1], dim_0_rounded_up);
++
++                        break;
++                    }
++                // Currently for Acdb4a and Acdb8a
++                case 4:
++                    { 
++
++                        auto dst_tag = memory_desc_matches_one_of_tag(
++                            *dst_md, format_tag::Acdb4a, format_tag::Acdb8a);
++                        ACL_CHECK_SUPPORT(
++                            utils::one_of(format_tag::undef, dst_tag),
++                            "");
++                        if(dst_tag == format_tag::Acdb4a){
++                            // Set Dest WeightFormat
++                            _pd->app_.dst_wf = arm_compute::WeightFormat::OHWIo4;
++                            dim_0_rounded_up
++                                    = utils::rnd_up(src_md->dims[0], 4);
++                        }
++                        else{
++                            // Set Dest WeightFormat
++                            _pd->app_.dst_wf = arm_compute::WeightFormat::OHWIo8;
++                            dim_0_rounded_up
++                                    = utils::rnd_up(src_md->dims[0], 8);
++                        }
++                        // Currently only supporting AxBx1x1 cases
++                        if(dst_md->dims[2] != 1 || dst_md->dims[3] != 1){
++                            return status::unimplemented;
++                        }
++                        if(dst_md->dims[0] == 1 || dst_md->dims[1] == 1){
++                            return status::unimplemented;
++                        }
++                        acl_tensor_shape_in = arm_compute::TensorShape(src_md->dims[3], src_md->dims[2], src_md->dims[1], src_md->dims[0]);
++                        acl_tensor_shape_out = arm_compute::TensorShape(src_md->dims[3], src_md->dims[2], src_md->dims[1], dim_0_rounded_up);
++                        break;
++                    }
++                default:
++                    return status::unimplemented;
++            }
++
++            // Choose the data layout
++            // bool is_nspc = utils::one_of(src_tag, format_tag::nhwc);
++            const auto acl_layout = arm_compute::DataLayout::NCHW;
++
++            // Set Source WeightFormat
++            _pd->app_.src_wf = arm_compute::WeightFormat::OHWI;
++
++            // Create ACL tensor infos
++            const data_type_t data_type = src_d.data_type();
++            const arm_compute::DataType acl_data_t
++                    = acl_utils::get_acl_data_t(data_type);
++            _pd->app_.src_info = arm_compute::TensorInfo(
++                        acl_tensor_shape_in, 1, acl_data_t, acl_layout);
++            _pd->app_.dst_info = arm_compute::TensorInfo(
++                        acl_tensor_shape_out, 1, acl_data_t, acl_layout);
++
++            // Init scratch memory, not used so 0 in this implementation
++            _pd->init_scratchpad_md();
++
++            return safe_ptr_assign(*reorder_pd, _pd);
++        } // create 
++
++        friend dnnl::impl::impl_list_item_t;
++        acl_reorder_conf_t app_;
++
++    }; // pd_t
++
++    acl_reorder_fwd_t(const pd_t *apd) : primitive_t(apd) {}
++
++    status_t create_resource(
++            engine_t *engine, resource_mapper_t &mapper) const override {
++        if (mapper.has_resource(this)) return status::success;
++
++        auto r = utils::make_unique<acl_reorder_resource_t>();
++        if (!r) return status::out_of_memory;
++
++        // Configure the resource based on information from primitive descriptor
++        CHECK(r->configure(pd()->app_));
++
++        mapper.add(this, std::move(r));
++        return status::success;
++    }
++
++    status_t execute(const exec_ctx_t &ctx) const override {
++        return execute_forward(ctx);
++    }
++
++private:
++    // To guard the const execute_forward, the mutex must be 'mutable'
++    mutable std::mutex mtx;
++    status_t execute_forward(const exec_ctx_t &ctx) const;
++    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++
++
++}; // acl_reorder_fwd_t
++
++} // namespace aarch64
++} // namespace cpu
++} // namespace impl
++} // namespace dnnl
++
++#endif // CPU_AARCH64_ACL_REORDER_HPP
+diff --git a/src/cpu/reorder/cpu_reorder_regular_f32_f32.cpp b/src/cpu/reorder/cpu_reorder_regular_f32_f32.cpp
+index a4150b619..f4d6b4de3 100644
+--- a/src/cpu/reorder/cpu_reorder_regular_f32_f32.cpp
++++ b/src/cpu/reorder/cpu_reorder_regular_f32_f32.cpp
+@@ -16,6 +16,7 @@
+ *******************************************************************************/
+ 
+ #include "cpu/reorder/cpu_reorder.hpp"
++#include "cpu/aarch64/acl_reorder.hpp"
+ 
+ namespace dnnl {
+ namespace impl {
+@@ -28,6 +29,7 @@ const impl_list_map_t &regular_f32_f32_impl_list_map() {
+         // f32 -> f32
+         {{f32, f32, 0}, {
+             REG_FAST_DIRECT_COPY_F32_F32
++            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::acl_reorder_fwd_t))
+ 
+             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::brgemm_matmul_matrix_B_reorder_t))
+             DNNL_X64_ONLY(CPU_REORDER_INSTANCE(x64::jit_blk_reorder_t))
+@@ -69,6 +71,8 @@ const impl_list_map_t &regular_f32_f32_impl_list_map() {
+             nullptr,
+         }},
+         {{f32, f32, 4}, {
++
++            DNNL_AARCH64_ONLY(CPU_REORDER_INSTANCE(aarch64::acl_reorder_fwd_t))
+             CPU_REORDER_INSTANCE(rnn_weights_reorder_t<f32, f32>)
+ 
+             REG_FAST_DIRECT_COPY_F32_F32

--- a/docker/tensorflow-aarch64/patches/onednn_acl_thread_local_scheduler.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_thread_local_scheduler.patch
@@ -1,0 +1,97 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/src/cpu/aarch64/acl_thread.cpp b/src/cpu/aarch64/acl_thread.cpp
+index fd2c76d01..bd7bed837 100644
+--- a/src/cpu/aarch64/acl_thread.cpp
++++ b/src/cpu/aarch64/acl_thread.cpp
+@@ -55,14 +55,17 @@ void acl_set_benchmark_scheduler_default() {
+ #endif
+ 
+ #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+-void acl_set_tp_scheduler() {
+-    static std::once_flag flag_once;
+-    // Create threadpool scheduler
+-    std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
+-            = std::make_unique<ThreadpoolScheduler>();
++void acl_set_tp_scheduler(int intra_threads = 0) {
++    static thread_local std::once_flag flag_once;
+     // set CUSTOM scheduler in ACL
+     std::call_once(flag_once,
+-            [&]() { arm_compute::Scheduler::set(threadpool_scheduler); });
++            [&]() {
++                    // Create threadpool scheduler
++                    std::shared_ptr<arm_compute::IScheduler> threadpool_scheduler
++                        = std::make_unique<ThreadpoolScheduler>();
++                    threadpool_scheduler->set_num_threads(intra_threads);
++
++                    arm_compute::Scheduler::set(threadpool_scheduler); });
+ }
+ 
+ void acl_set_threadpool_num_threads() {
+@@ -102,14 +105,6 @@ void set_acl_threading() {
+         acl_set_benchmark_scheduler_default();
+     }
+ #endif
+-#if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+-    if (verbose_has_profile_externals()) {
+-        acl_set_tp_benchmark_scheduler();
+-    } else {
+-        acl_set_tp_scheduler();
+-    }
+-
+-#endif
+ }
+ 
+ } // namespace acl_thread_utils
+diff --git a/src/cpu/aarch64/acl_thread.hpp b/src/cpu/aarch64/acl_thread.hpp
+index f073376e6..654a2aa5d 100644
+--- a/src/cpu/aarch64/acl_thread.hpp
++++ b/src/cpu/aarch64/acl_thread.hpp
+@@ -40,7 +40,7 @@ void acl_set_benchmark_scheduler_default();
+ 
+ #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+ // Retrieve threadpool size during primitive execution and set ThreadpoolScheduler num_threads
+-void acl_set_tp_scheduler();
++void acl_set_tp_scheduler(int intra_threads);
+ void acl_set_threadpool_num_threads();
+ // Swap BenchmarkScheduler for custom scheduler builds (i.e. ThreadPoolScheduler) for DNNL_VERBOSE=profile,profile_externals
+ void acl_set_tp_benchmark_scheduler();
+diff --git a/src/cpu/aarch64/acl_threadpool_scheduler.cpp b/src/cpu/aarch64/acl_threadpool_scheduler.cpp
+index 439ca862e..6656c37a5 100644
+--- a/src/cpu/aarch64/acl_threadpool_scheduler.cpp
++++ b/src/cpu/aarch64/acl_threadpool_scheduler.cpp
+@@ -102,8 +102,6 @@ void ThreadpoolScheduler::schedule_op(ICPPKernel *kernel, const Hints &hints,
+ void ThreadpoolScheduler::run_workloads(
+         std::vector<arm_compute::IScheduler::Workload> &workloads) {
+ 
+-    arm_compute::lock_guard<std::mutex> lock(this->_run_workloads_mutex);
+-
+     const unsigned int num_threads
+             = std::min(static_cast<unsigned int>(_num_threads),
+                     static_cast<unsigned int>(workloads.size()));
+diff --git a/src/cpu/cpu_engine.cpp b/src/cpu/cpu_engine.cpp
+index 0bfec3871..7207b2b60 100644
+--- a/src/cpu/cpu_engine.cpp
++++ b/src/cpu/cpu_engine.cpp
+@@ -47,6 +47,7 @@ status_t cpu_engine_t::create_stream(stream_t **stream, unsigned flags) {
+ #if DNNL_CPU_RUNTIME == DNNL_RUNTIME_THREADPOOL
+ status_t cpu_engine_t::create_stream(stream_t **stream,
+         dnnl::threadpool_interop::threadpool_iface *threadpool) {
++    dnnl::impl::cpu::aarch64::acl_thread_utils::acl_set_tp_scheduler(threadpool->get_num_threads());
+     return safe_ptr_assign<stream_t>(
+             *stream, new cpu_stream_t(this, threadpool));
+ }

--- a/docker/tensorflow-aarch64/patches/onednn_acl_threadcap.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_threadcap.patch
@@ -1,0 +1,43 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/src/cpu/aarch64/acl_thread.cpp b/src/cpu/aarch64/acl_thread.cpp
+index fd2c76d01..2d7c76d48 100644
+--- a/src/cpu/aarch64/acl_thread.cpp
++++ b/src/cpu/aarch64/acl_thread.cpp
+@@ -17,6 +17,8 @@
+ #include "cpu/aarch64/acl_thread.hpp"
+ #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_THREADPOOL
+ #include "cpu/aarch64/acl_threadpool_scheduler.hpp"
++#elif DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
++#include <thread>
+ #endif
+ #include "cpu/aarch64/acl_benchmark_scheduler.hpp"
+ 
+@@ -30,9 +32,10 @@ namespace acl_thread_utils {
+ #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
+ void acl_thread_bind() {
+     static std::once_flag flag_once;
+-    // The threads in Compute Library are bound for the cores 0..max_threads-1
+-    // dnnl_get_max_threads() returns OMP_NUM_THREADS
+-    const int max_threads = dnnl_get_max_threads();
++    // Cap the number of threads to 90% of the total core count
++    // to ensure Compute Library doesn't use too much resource
++    int capped_threads = (int)std::floor(0.9*std::thread::hardware_concurrency());
++    const int max_threads = std::min(capped_threads, dnnl_get_max_threads());
+     // arm_compute::Scheduler does not support concurrent access thus a
+     // workaround here restricts it to only one call
+     std::call_once(flag_once, [&]() {

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -1,0 +1,97 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/tensorflow/tsl/mkl/build_defs.bzl b/tensorflow/tsl/mkl/build_defs.bzl
+index c89fb8c5461..f44262f3b75 100644
+--- a/tensorflow/tsl/mkl/build_defs.bzl
++++ b/tensorflow/tsl/mkl/build_defs.bzl
+@@ -115,7 +115,7 @@ def onednn_v3_define():
+       An empty list of all other cases (include ARM builds).
+     """
+     return select({
+-        "@org_tensorflow//tensorflow/tsl/mkl:build_with_mkl_aarch64": [],
++        "@org_tensorflow//tensorflow/tsl/mkl:build_with_mkl_aarch64": ["-DENABLE_ONEDNN_V3"],
+         "@org_tensorflow//tensorflow/tsl:linux_x86_64": ["-DENABLE_ONEDNN_V3"],
+         "@org_tensorflow//tensorflow/tsl:windows": ["-DENABLE_ONEDNN_V3"],
+         "//conditions:default": [],
+diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
+index 7e9faa558a4..748d860c57a 100644
+--- a/tensorflow/workspace2.bzl
++++ b/tensorflow/workspace2.bzl
+@@ -204,18 +204,13 @@ def _tf_repositories():
+         build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
+         patch_file = [
+             "//third_party/mkl_dnn:onednn_acl_threadcap.patch",
+-            "//third_party/mkl_dnn:onednn_acl_remove_winograd.patch",
+-            "//third_party/mkl_dnn:onednn_acl_fixed_format_kernels.patch",
+-            "//third_party/mkl_dnn:onednn_acl_depthwise_convolution.patch",
+-            "//third_party/mkl_dnn:onednn_acl_threadpool_scheduler.patch",
+-            "//third_party/mkl_dnn:onednn_acl_reorder_padded.patch",
+-            "//third_party/mkl_dnn:onednn_acl_reorder_update.patch",
+             "//third_party/mkl_dnn:onednn_acl_reorder.patch",
+             "//third_party/mkl_dnn:onednn_acl_thread_local_scheduler.patch",
++            "//third_party/mkl_dnn:onednn_acl_fp32_bf16_reorder.patch",
+         ],
+-        sha256 = "a50993aa6265b799b040fe745e0010502f9f7103cc53a9525d59646aef006633",
+-        strip_prefix = "oneDNN-2.7.3",
+-        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.7.3.tar.gz"),
++        sha256 = "8b1db9cc5799ae39c2a567eb836962de0346d79fbc3d8e6f7090a3d9f8729129",
++        strip_prefix = "oneDNN-3.2",
++        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/v3.2.tar.gz"),
+     )
+ 
+     tf_http_archive(
+diff --git a/third_party/mkl_dnn/mkldnn_acl.BUILD b/third_party/mkl_dnn/mkldnn_acl.BUILD
+index a1085427ec0..f9c4d89d92d 100644
+--- a/third_party/mkl_dnn/mkldnn_acl.BUILD
++++ b/third_party/mkl_dnn/mkldnn_acl.BUILD
+@@ -61,6 +61,7 @@ _DNNL_RUNTIME_THREADPOOL = {
+     "#cmakedefine01 BUILD_XEHPG": "#define BUILD_XEHPG 0",
+     "#cmakedefine01 BUILD_XEHPC": "#define BUILD_XEHPC 0",
+     "#cmakedefine01 BUILD_XEHP": "#define BUILD_XEHP 0",
++    "#cmakedefine ONEDNN_BUILD_GRAPH": "#undef ONEDNN_BUILD_GRAPH",
+ }
+ 
+ _DNNL_RUNTIME_OMP = {
+@@ -108,6 +109,7 @@ _DNNL_RUNTIME_OMP = {
+     "#cmakedefine01 BUILD_XEHPG": "#define BUILD_XEHPG 0",
+     "#cmakedefine01 BUILD_XEHPC": "#define BUILD_XEHPC 0",
+     "#cmakedefine01 BUILD_XEHP": "#define BUILD_XEHP 0",
++    "#cmakedefine ONEDNN_BUILD_GRAPH": "#undef ONEDNN_BUILD_GRAPH",
+ }
+ 
+ expand_template(
+@@ -124,9 +126,9 @@ expand_template(
+     name = "dnnl_version_h",
+     out = "include/oneapi/dnnl/dnnl_version.h",
+     substitutions = {
+-        "@DNNL_VERSION_MAJOR@": "2",
+-        "@DNNL_VERSION_MINOR@": "7",
+-        "@DNNL_VERSION_PATCH@": "3",
++        "@DNNL_VERSION_MAJOR@": "3",
++        "@DNNL_VERSION_MINOR@": "2",
++        "@DNNL_VERSION_PATCH@": "0",
+         "@DNNL_VERSION_HASH@": "N/A",
+     },
+     template = "include/oneapi/dnnl/dnnl_version.h.in",
+@@ -142,6 +144,7 @@ cc_library(
+         ],
+         exclude = [
+             "src/cpu/x64/**",
++            "src/cpu/rv64/**",
+         ],
+     ),
+     copts = select({

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -84,6 +84,14 @@ if [[ $ONEDNN_BUILD ]]; then
         else
             tf_backend_desc="oneDNN + Compute Library (OpenMP runtime)."
         fi
+
+        patch -p1 < ../tf_acl.patch
+        mv ../onednn_acl_reorder.patch ./third_party/mkl_dnn/.
+        mv ../onednn_acl_thread_local_scheduler.patch ./third_party/mkl_dnn/.
+        mv ../onednn_acl_threadcap.patch ./third_party/mkl_dnn/.
+        mv ../onednn_acl_fp32_bf16_reorder.patch ./third_party/mkl_dnn/.
+
+
     fi
 else
     tf_backend_desc="Eigen."


### PR DESCRIPTION
This PR:
  - updates oneDNN to v3.2
  - adds a patch to oneDNN to support FP32-BF16 Jit reorders
  - pins ml_dtypes to 0.2.0 to fix incompatibility with TF 2.14-RC

