### PR TITLE
Set threadcap for Eigen ThreadPool in TF

### DIFF
--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -9,6 +9,7 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Added
  - oneDNN patch to enable JITed BF16 reorders.
+ - Tensorflow patch to limit Eigen ThreadPool threads.
 
 ### Changed
  - oneDNN updated to v3.2.1

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -283,6 +283,7 @@ ENV PATH="$PACKAGE_DIR/bazel:$PATH"
 
 # Build TensorFlow
 COPY patches/tf_acl.patch $PACKAGE_DIR/.
+COPY patches/tf_threadpool_threadcap.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_reorder.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_thread_local_scheduler.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_threadcap.patch $PACKAGE_DIR/.

--- a/docker/tensorflow-aarch64/patches/tf_threadpool_threadcap.patch
+++ b/docker/tensorflow-aarch64/patches/tf_threadpool_threadcap.patch
@@ -1,0 +1,39 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/tensorflow/tsl/platform/threadpool.cc b/tensorflow/tsl/platform/threadpool.cc
+index 271aa58c804..b4abf97a1f1 100644
+--- a/tensorflow/tsl/platform/threadpool.cc
++++ b/tensorflow/tsl/platform/threadpool.cc
+@@ -27,6 +27,7 @@ limitations under the License.
+ #include "tensorflow/tsl/platform/numa.h"
+ #include "tensorflow/tsl/platform/setround.h"
+ #include "tensorflow/tsl/platform/tracing.h"
++#include <thread>
+
+ #ifdef TENSORFLOW_THREADSCALING_EXPERIMENTAL
+ ABSL_FLAG(float, tensorflow_num_threads_scale_factor, 1.0,
+@@ -107,6 +108,10 @@ ThreadPool::ThreadPool(Env* env, const ThreadOptions& thread_options,
+                        bool low_latency_hint, Eigen::Allocator* allocator) {
+   CHECK_GE(num_threads, 1);
+
++if(num_threads == std::thread::hardware_concurrency() && num_threads > 1){
++  num_threads = num_threads - 1;
++}
++
+ #ifdef TENSORFLOW_THREADSCALING_EXPERIMENTAL
+   CHECK_GT(absl::GetFlag(FLAGS_tensorflow_num_threads_scale_factor), 0);
+   num_threads *= absl::GetFlag(FLAGS_tensorflow_num_threads_scale_factor);

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -86,6 +86,7 @@ if [[ $ONEDNN_BUILD ]]; then
         fi
 
         patch -p1 < ../tf_acl.patch
+        patch -p1 < ../tf_threadpool_threadcap.patch
         mv ../onednn_acl_reorder.patch ./third_party/mkl_dnn/.
         mv ../onednn_acl_thread_local_scheduler.patch ./third_party/mkl_dnn/.
         mv ../onednn_acl_threadcap.patch ./third_party/mkl_dnn/.


### PR DESCRIPTION
Sets numbers of threads in threadpool to threads - 1 if using as many threads as cores on the system. This solves issue with increased runtime when running with as many intra threads as there are available cores on the system.
