### PR TITLE
Use indirect convolution only for Tensorflow

### DIFF
--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -9,6 +9,8 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Added
 
+ - oneDNN patch to use indirect convolution only.
+
 ### Changed
 
 ### Removed

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -288,6 +288,7 @@ COPY patches/onednn_acl_thread_local_scheduler.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_threadcap.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_reorder.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_fp32_bf16_reorder.patch $PACKAGE_DIR/.
+COPY patches/onednn_acl_use_indirect_conv.patch $PACKAGE_DIR/.
 COPY patches/acl_fp32_bf16_reorder.patch $PACKAGE_DIR/.
 COPY scripts/build-tensorflow.sh $PACKAGE_DIR/.
 RUN $PACKAGE_DIR/build-tensorflow.sh

--- a/docker/tensorflow-aarch64/patches/onednn_acl_use_indirect_conv.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_use_indirect_conv.patch
@@ -1,0 +1,43 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
+index 53b1e2c82..c9dec4a4c 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.cpp
++++ b/src/cpu/aarch64/acl_convolution_utils.cpp
+@@ -307,22 +307,8 @@ status_t init_conf_indirect_gemm(acl_conv_conf_t &acp, memory_desc_t &src_md,
+         const primitive_attr_t &attr) {
+     if (weights_md.ndims != 4) return status::unimplemented;
+ 
+-    // Indirect is slower for small convolution kernels
+-    if (weights_md.dims[2] == 1 && weights_md.dims[3] == 1)
+-        return status::unimplemented;
+-
+     CHECK(acl_init_conf(acp, src_md, weights_md, dst_md, bias_md, cd, attr));
+
+-    // Indirect is slower than gemm for low thread counts, except for fast math
+-    if (dnnl_get_max_threads() < 28 && !acp.fast_math)
+-        return status::unimplemented;
+-
+-    // If we do not need to pad input channels for fast math mode then it would
+-    // be faster to run convolution with im2row instead of using indirect kernel
+-    int block_by = arm_compute::block_by(acp.weights_info.weight_format());
+-    int ic = src_md.dims[1];
+-    if (acp.fast_math && ic % block_by == 0) return status::unimplemented;
+-
+     // clang-format off
+     // NOTE: indirect convolution method supports only nhwc layout.
+     ACL_CHECK_VALID(arm_compute::NEGEMMConv2d::validate(

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -28,10 +28,10 @@ index c89fb8c5461..f44262f3b75 100644
          "@org_tensorflow//tensorflow/tsl:windows": ["-DENABLE_ONEDNN_V3"],
          "//conditions:default": [],
 diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
-index 7e9faa558a4..759041daf67 100644
+index 7e9faa558a4..cb5093e18ed 100644
 --- a/tensorflow/workspace2.bzl
 +++ b/tensorflow/workspace2.bzl
-@@ -204,24 +204,20 @@ def _tf_repositories():
+@@ -204,24 +204,21 @@ def _tf_repositories():
          build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
          patch_file = [
              "//third_party/mkl_dnn:onednn_acl_threadcap.patch",
@@ -44,6 +44,7 @@ index 7e9faa558a4..759041daf67 100644
              "//third_party/mkl_dnn:onednn_acl_reorder.patch",
 +            "//third_party/mkl_dnn:onednn_acl_fp32_bf16_reorder.patch",
              "//third_party/mkl_dnn:onednn_acl_thread_local_scheduler.patch",
++            "//third_party/mkl_dnn:onednn_acl_use_indirect_conv.patch",
          ],
 -        sha256 = "a50993aa6265b799b040fe745e0010502f9f7103cc53a9525d59646aef006633",
 -        strip_prefix = "oneDNN-2.7.3",
@@ -62,7 +63,7 @@ index 7e9faa558a4..759041daf67 100644
          ],
          sha256 = "c4ca329a78da380163b2d86e91ba728349b6f0ee97d66e260a694ef37f0b0d93",
 diff --git a/third_party/mkl_dnn/mkldnn_acl.BUILD b/third_party/mkl_dnn/mkldnn_acl.BUILD
-index a1085427ec0..daff639aee7 100644
+index a1085427ec0..2023a134d0a 100644
 --- a/third_party/mkl_dnn/mkldnn_acl.BUILD
 +++ b/third_party/mkl_dnn/mkldnn_acl.BUILD
 @@ -61,6 +61,13 @@ _DNNL_RUNTIME_THREADPOOL = {

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -91,6 +91,7 @@ if [[ $ONEDNN_BUILD ]]; then
         mv ../onednn_acl_fp32_bf16_reorder.patch ./third_party/mkl_dnn/.
         mv ../onednn_acl_thread_local_scheduler.patch ./third_party/mkl_dnn/.
         mv ../onednn_acl_threadcap.patch ./third_party/mkl_dnn/.
+        mv ../onednn_acl_use_indirect_conv.patch ./third_party/mkl_dnn/.
 
         ## Compute Library
         # Adds ACL f32 to bf16 reorder


### PR DESCRIPTION
This addresses an issue where direct convolution causes large memory growth due to allocating memory for im2col.