### PR TITLE
r24.01 Updates

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -16,6 +16,7 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Fixed
 
 ## [r24.01] 2024-01-23
+https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r24.01/docker/pytorch-aarch64
 
 ### Added
 - ACL and oneDNN patches for in place sum

--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -15,6 +15,20 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Fixed
 
+## [r24.01] 2024-01-23
+
+### Added
+- ACL and oneDNN patches for in place sum
+
+### Changed
+- Updated oneDNN version to v3.3.4
+- Updated pytorch version to v2.2.0-rc8
+- Updated ideep to Git Hash: 087f41a
+
+### Removed
+
+### Fixed
+
 ## [r23.12] 2023-12-15
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r23.12/docker/pytorch-aarch64
 

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2020-2023 Arm Limited and affiliates.
+# Copyright 2020-2024 Arm Limited and affiliates.
 # Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -169,6 +169,8 @@ ENV LD_LIBRARY_PATH=$OPENBLAS_DIR/lib:$LD_LIBRARY_PATH
 COPY scripts/build-acl.sh $PACKAGE_DIR/.
 COPY patches/acl_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/acl_fp32_bf16_reorder.patch $PACKAGE_DIR/.
+COPY patches/acl_in_place_sum.patch $PACKAGE_DIR/.
+
 RUN $PACKAGE_DIR/build-acl.sh
 ENV ACL_ROOT_DIR=$PROD_DIR/ComputeLibrary
 
@@ -262,8 +264,8 @@ ENV ONEDNN_BUILD="${onednn_opt}" \
 
 # Key version numbers
 ENV PY_VERSION="${default_py_version}" \
-    ONEDNN_VERSION="v3.3" \
-    TORCH_VERSION=2.1.0 \
+    ONEDNN_VERSION="v3.3.4" \
+    TORCH_VERSION=2.2.0-rc8 \
     TORCHXLA_VERSION=2.1.0 \
     TORCHVISION_VERSION=0.16.0 \
     TORCHDATA_VERSION=0.7.0 \
@@ -292,6 +294,7 @@ COPY patches/onednn_fp32_bf16_reorder.patch $PACKAGE_DIR/.
 COPY patches/onednn_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/ideep_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
+COPY patches/onednn_in_place_sum.patch $PACKAGE_DIR/.
 
 COPY scripts/build-torchvision.sh $PACKAGE_DIR/.
 COPY scripts/build-torchtext.sh $PACKAGE_DIR/.
@@ -309,10 +312,13 @@ RUN $PACKAGE_DIR/build-pytorch.sh
 ENV VENV_PACKAGE_DIR=$VENV_DIR/lib/python$PY_VERSION/site-packages
 # Build torchvision from source to workaround the undefined C++ symbols issues
 RUN $PACKAGE_DIR/build-torchvision.sh
+
+# Build torchdata from source because there is no wheel for v0.4.0
+# torchtext depends on torchdata, so we first build torchdata and then torchtext
+RUN $PACKAGE_DIR/build-torchdata.sh
+
 # Build torchtext from source to workaround the undefined symbol issue with the wheel
 RUN $PACKAGE_DIR/build-torchtext.sh
-# Build torchdata from source because there is no wheel for v0.4.0
-RUN $PACKAGE_DIR/build-torchdata.sh
 
 CMD ["bash", "-l"]
 

--- a/docker/pytorch-aarch64/patches/acl_in_place_sum.patch
+++ b/docker/pytorch-aarch64/patches/acl_in_place_sum.patch
@@ -1,0 +1,333 @@
+ *******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/arm_compute/function_info/GEMMInfo.h b/arm_compute/function_info/GEMMInfo.h
+index daaf86243a..41a7057a18 100644
+--- a/arm_compute/function_info/GEMMInfo.h
++++ b/arm_compute/function_info/GEMMInfo.h
+@@ -81,7 +81,8 @@ public:
+           _activation_info(),
+           _post_ops(),
+           _fixed_format(false),
+-          _weight_format(arm_compute::WeightFormat::UNSPECIFIED)
++          _weight_format(arm_compute::WeightFormat::UNSPECIFIED),
++          _accumulate(false)
+     {
+     }
+     /** Constructor
+@@ -106,7 +107,7 @@ public:
+     GEMMInfo(bool is_a_reshaped, bool is_b_reshaped, bool reshape_b_only_on_first_run, int depth_output_gemm3d = 0, bool reinterpret_input_as_3d = false, bool retain_internal_weights = false,
+              GEMMLowpOutputStageInfo gemmlowp_output_stage = GEMMLowpOutputStageInfo(), bool fp_mixed_precision = false, bool fast_math = false, bool broadcast_bias = false,
+              const ActivationLayerInfo &activation_info = ActivationLayerInfo(), const experimental::PostOpList<ITensorInfo *> &post_ops = experimental::PostOpList<ITensorInfo *>(),
+-             bool fixed_format = false, arm_compute::WeightFormat weight_format = arm_compute::WeightFormat::UNSPECIFIED) noexcept
++             bool fixed_format = false, arm_compute::WeightFormat weight_format = arm_compute::WeightFormat::UNSPECIFIED, bool accumulate = false) noexcept
+         : _is_a_reshaped(is_a_reshaped),
+           _is_b_reshaped(is_b_reshaped),
+           _reshape_b_only_on_first_run(reshape_b_only_on_first_run),
+@@ -122,7 +123,8 @@ public:
+           _activation_info(activation_info),
+           _post_ops(post_ops),
+           _fixed_format(fixed_format),
+-          _weight_format(weight_format)
++          _weight_format(weight_format),
++          _accumulate(accumulate)
+     {
+     }
+     /** Flag which specifies if the matrix A has been reshaped
+@@ -296,6 +298,11 @@ public:
+         return _fixed_format;
+     }
+ 
++    bool accumulate() const
++    {
++        return _accumulate;
++    }
++
+     /** Set fixed-format flag
+      *
+      * @param[in] fixed_format sets whether or not to use fixed-format kernels
+@@ -305,6 +312,10 @@ public:
+         _fixed_format = fixed_format;
+     }
+ 
++    void set_accumulate(bool accumulate) {
++        _accumulate = accumulate;
++    }
++
+     arm_compute::WeightFormat weight_format() const
+     {
+         return _weight_format;
+@@ -336,6 +347,7 @@ private:
+     experimental::PostOpList<ITensorInfo *> _post_ops;
+     bool                                    _fixed_format;
+     arm_compute::WeightFormat               _weight_format;
++    bool                                    _accumulate;
+ };
+ } //namespace arm_compute
+ #endif /* ACL_ARM_COMPUTE_FUNCTION_INFO_GEMMINFO */
+diff --git a/src/core/NEON/kernels/arm_gemm/gemm_fp32.cpp b/src/core/NEON/kernels/arm_gemm/gemm_fp32.cpp
+index 44a7bb894a..c6c9a15330 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemm_fp32.cpp
++++ b/src/core/NEON/kernels/arm_gemm/gemm_fp32.cpp
+@@ -292,14 +292,14 @@ GemmImplementation<float, float>::with_estimate(
+ {
+     GemmMethod::GEMM_HYBRID,
+     "a64_smallK_hybrid_fp32_mla_8x4",
+-    [](const GemmArgs &args) { return args._Ksize <= 8 && (args._Nsize % 4)==0 && !args._indirect_input; },
++    [](const GemmArgs &args) { return args._Ksize <= 8 && (args._Nsize % 4)==0 && !args._indirect_input && !args._accumulate; },
+     nullptr,
+     [](const GemmArgs &args) { return new GemmHybrid<cls_a64_smallK_hybrid_fp32_mla_8x4, float, float>(args); }
+ },
+ {
+     GemmMethod::GEMM_HYBRID,
+     "a64_smallK_hybrid_fp32_mla_6x4",
+-    [](const GemmArgs &args) { return (args._Ksize > 8 && args._Ksize <= 16) && (args._Nsize % 4)==0 && !args._indirect_input; },
++    [](const GemmArgs &args) { return (args._Ksize > 8 && args._Ksize <= 16) && (args._Nsize % 4)==0 && !args._indirect_input && !args._accumulate; },
+     nullptr,
+     [](const GemmArgs &args) { return new GemmHybrid<cls_a64_smallK_hybrid_fp32_mla_6x4, float, float>(args); }
+ },
+diff --git a/src/core/NEON/kernels/arm_gemm/gemm_hybrid_indirect.hpp b/src/core/NEON/kernels/arm_gemm/gemm_hybrid_indirect.hpp
+index 1780375c44..203c59888c 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemm_hybrid_indirect.hpp
++++ b/src/core/NEON/kernels/arm_gemm/gemm_hybrid_indirect.hpp
+@@ -530,7 +530,7 @@ public:
+                                  (m_end - m_start), (nmax - n0), kern_k, b_panel, this->_ldb, out_arg,
+                                  (this->_bias && first_pass) ? this->_bias + (multi * this->_bias_multi_stride) + n0 : nullptr,
+                                  last_pass ? _args._act : Activation(),
+-                                 !first_pass,
++                                 !first_pass || _args._accumulate,
+                                  // Quantization parameters
+                                  _os, _col_bias+(multi * _args._Nsize), n0);
+                 } else if (_convolver) {
+@@ -563,7 +563,7 @@ public:
+                                  (m_end - m_start), (nmax - n0), kern_k, b_panel, this->_ldb, out_arg,
+                                  (this->_bias && first_pass) ? this->_bias + (multi * this->_bias_multi_stride) + n0 : nullptr,
+                                  last_pass ? _args._act : Activation(),
+-                                 !first_pass,
++                                 !first_pass || _args._accumulate,
+                                  // Quantization parameters
+                                  _os, _col_bias+(multi * _args._Nsize), n0);
+                 } else {
+@@ -579,7 +579,7 @@ public:
+                                  (m_end - m_start), (nmax - n0), kern_k, b_panel, this->_ldb, out_arg,
+                                  (this->_bias && first_pass) ? this->_bias + (multi * this->_bias_multi_stride) + n0 : nullptr,
+                                  last_pass ? _args._act : Activation(),
+-                                 !first_pass,
++                                 !first_pass || _args._accumulate,
+                                  // Quantization parameters
+                                  _os, _col_bias+(multi * _args._Nsize), n0);
+                 }
+diff --git a/src/core/NEON/kernels/arm_gemm/gemm_int8.cpp b/src/core/NEON/kernels/arm_gemm/gemm_int8.cpp
+index fd20e53f60..02f093753a 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemm_int8.cpp
++++ b/src/core/NEON/kernels/arm_gemm/gemm_int8.cpp
+@@ -128,14 +128,14 @@ GemmImplementation<int8_t, int32_t>::with_estimate(
+ {
+     GemmMethod::GEMM_HYBRID,
+     "a64_smallK_hybrid_s8s32_dot_8x4",
+-    [](const GemmArgs &args) { return args._ci->has_dotprod() && (args._Nsize % 4 == 0) && (args._Ksize<=32) && !args._indirect_input; },
++    [](const GemmArgs &args) { return args._ci->has_dotprod() && (args._Nsize % 4 == 0) && (args._Ksize<=32) && !args._indirect_input && !args._accumulate; },
+     [](const GemmArgs &args) { return !(args._ci->has_svei8mm() || args._ci->has_i8mm()); },
+     [](const GemmArgs &args) { return new GemmHybrid<cls_a64_smallK_hybrid_s8s32_dot_8x4, int8_t, int32_t>(args); }
+ },
+ {
+     GemmMethod::GEMM_HYBRID,
+     "a64_smallK_hybrid_s8s32_dot_6x4",
+-    [](const GemmArgs &args) { return args._ci->has_dotprod() && (args._Nsize % 4 == 0) && (args._Ksize>32) && (args._Ksize<=64) && !args._indirect_input; },
++    [](const GemmArgs &args) { return args._ci->has_dotprod() && (args._Nsize % 4 == 0) && (args._Ksize>32) && (args._Ksize<=64) && !args._indirect_input && !args._accumulate; },
+     [](const GemmArgs &args) { return !(args._ci->has_svei8mm() || args._ci->has_i8mm()); },
+     [](const GemmArgs &args) { return new GemmHybrid<cls_a64_smallK_hybrid_s8s32_dot_6x4, int8_t, int32_t>(args); }
+ },
+diff --git a/src/core/NEON/kernels/arm_gemm/gemm_interleaved.hpp b/src/core/NEON/kernels/arm_gemm/gemm_interleaved.hpp
+index e3f3588f28..c094f2d1ce 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemm_interleaved.hpp
++++ b/src/core/NEON/kernels/arm_gemm/gemm_interleaved.hpp
+@@ -423,6 +423,7 @@ class GemmInterleaved : public GemmCommon<To, Tr> {
+     const bool _thread_columns;
+ 
+     const Activation _act;
++    const bool _accumulate;
+ 
+     const int _maxthreads;
+     int _nthreads;
+@@ -753,7 +754,7 @@ public:
+                       _Ksections(args._Ksections), _Ktotal(get_ktotal(args)),
+                       _rounded_Ksize(roundup(_Ksize, strategy::k_unroll())),
+                       _nbatches(args._nbatches), _nmulti(args._nmulti), _thread_columns(is_thread_columns(args)),
+-                      _act(args._act), _maxthreads(args._maxthreads), _nthreads(args._maxthreads),
++                      _act(args._act), _accumulate(args._accumulate), _maxthreads(args._maxthreads), _nthreads(args._maxthreads),
+                       _k_block(get_k_block_size(args)), _x_block(get_x_block_size(args)), _Mround(roundup(args._Msize, strategy::out_height())),
+                       _os(os) { }
+ 
+@@ -763,7 +764,7 @@ public:
+                       _Ksections(args._Ksections), _Ktotal(get_ktotal(args)),
+                       _rounded_Ksize(roundup(_Ksize, strategy::k_unroll())),
+                       _nbatches(args._nbatches), _nmulti(args._nmulti), _thread_columns(is_thread_columns(args)),
+-                      _act(args._act), _maxthreads(args._maxthreads), _nthreads(args._maxthreads),
++                      _act(args._act), _accumulate(args._accumulate),  _maxthreads(args._maxthreads), _nthreads(args._maxthreads),
+                       _k_block(get_k_block_size(args)), _x_block(get_x_block_size(args)), _Mround(roundup(args._Msize, strategy::out_height())),
+                       _os() { }
+ 
+@@ -889,7 +890,7 @@ public:
+                             // Only do bias on the first pass
+                             ((first_pass && this->_bias) ? this->_bias + (multi * this->_bias_multi_stride) : nullptr),
+                             // Only do activation on the last pass, and accumulation on any non-first pass.
+-                            (last_pass ? _act : Activation()), !first_pass,
++                            (last_pass ? _act : Activation()), (!first_pass || _accumulate),
+                             // Pass in quantization parameters for requantizing kernels (others will ignore)
+                             _os, col_bias + (multi * _Nsize),
+                             // Accumulation buffer
+@@ -1037,7 +1038,7 @@ public:
+                             // Only do bias on the first pass
+                             ((first_pass && this->_bias) ? this->_bias + (current.multi() * this->_bias_multi_stride) : nullptr),
+                             // Only do activation on the last pass, and accumulation on any non-first pass.
+-                            (last_pass ? _act : Activation()), !first_pass,
++                            (last_pass ? _act : Activation()), (!first_pass || _accumulate),
+                             // Pass in quantization parameters for requantizing kernels (others will ignore)
+                             _os, col_bias + (current.multi() * _Nsize),
+                             // Accumulation buffer
+diff --git a/src/core/NEON/kernels/arm_gemm/gemm_uint8.cpp b/src/core/NEON/kernels/arm_gemm/gemm_uint8.cpp
+index af5cfbbf2b..921a4cd688 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemm_uint8.cpp
++++ b/src/core/NEON/kernels/arm_gemm/gemm_uint8.cpp
+@@ -94,14 +94,14 @@ GemmImplementation<uint8_t, uint32_t>::with_estimate(
+ {
+     GemmMethod::GEMM_HYBRID,
+     "a64_smallK_hybrid_u8u32_dot_8x4",
+-    [](const GemmArgs &args) { return args._ci->has_dotprod() && (args._Nsize % 4 == 0) && (args._Ksize<=32) && !args._indirect_input; },
++    [](const GemmArgs &args) { return args._ci->has_dotprod() && (args._Nsize % 4 == 0) && (args._Ksize<=32) && !args._indirect_input && !args._accumulate; },
+     [](const GemmArgs &args) { return !(args._ci->has_svei8mm() || args._ci->has_i8mm()); },
+     [](const GemmArgs &args) { return new GemmHybrid<cls_a64_smallK_hybrid_u8u32_dot_8x4, uint8_t, uint32_t>(args); }
+ },
+ {
+     GemmMethod::GEMM_HYBRID,
+     "a64_smallK_hybrid_u8u32_dot_6x4",
+-    [](const GemmArgs &args) { return args._ci->has_dotprod() && (args._Nsize % 4 == 0) && (args._Ksize>32) && (args._Ksize<=64) && !args._indirect_input; },
++    [](const GemmArgs &args) { return args._ci->has_dotprod() && (args._Nsize % 4 == 0) && (args._Ksize>32) && (args._Ksize<=64) && !args._indirect_input && !args._accumulate; },
+     [](const GemmArgs &args) { return !(args._ci->has_svei8mm() || args._ci->has_i8mm()); },
+     [](const GemmArgs &args) { return new GemmHybrid<cls_a64_smallK_hybrid_u8u32_dot_6x4, uint8_t, uint32_t>(args); }
+ },
+diff --git a/src/core/NEON/kernels/arm_gemm/gemv_pretransposed.hpp b/src/core/NEON/kernels/arm_gemm/gemv_pretransposed.hpp
+index 86b33d081f..36f30425f4 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemv_pretransposed.hpp
++++ b/src/core/NEON/kernels/arm_gemm/gemv_pretransposed.hpp
+@@ -180,7 +180,7 @@ public:
+                                  this->_Cptr + (multi * this->_C_multi_stride) + n,
+                                  (nmax - n), (kmax-k0),
+                                  this->_bias ? this->_bias + (multi * this->_bias_multi_stride) + n : nullptr,
+-                                 _args._act, (k0 != 0),
++                                 _args._act, (k0 != 0) || _args._accumulate,
+                                  _os, col_bias, n + (_args._Nsize * multi));
+                 }
+             }
+diff --git a/src/cpu/kernels/assembly/arm_gemm.hpp b/src/cpu/kernels/assembly/arm_gemm.hpp
+index eba3f7a064..b703c13a92 100644
+--- a/src/cpu/kernels/assembly/arm_gemm.hpp
++++ b/src/cpu/kernels/assembly/arm_gemm.hpp
+@@ -154,14 +154,16 @@ public:
+     int               _maxthreads;
+     bool              _fixed_format;
+     bool              _fast_mode;
++    bool              _accumulate;
+     const GemmConfig *_cfg;
+ 
+     GemmArgs(const CPUInfo *ci, unsigned int M, unsigned int N,
+              unsigned int K, unsigned int Ksections, unsigned int nbatches,
+              unsigned int nmulti, bool indirect_input, Activation act, const int maxthreads,
+-             bool fixed_format = false, bool fast_mode = false, const GemmConfig *cfg = nullptr)
++             bool fixed_format = false, bool fast_mode = false, bool accumulate = false,
++             const GemmConfig *cfg = nullptr)
+         : _ci(ci), _Msize(M), _Nsize(N), _Ksize(K), _Ksections(Ksections), _nbatches(nbatches), _nmulti(nmulti), _indirect_input(indirect_input), _act(act), _maxthreads(maxthreads),
+-          _fixed_format(fixed_format), _fast_mode(fast_mode), _cfg(cfg)
++          _fixed_format(fixed_format), _fast_mode(fast_mode), _accumulate(accumulate), _cfg(cfg)
+     {
+     }
+ };
+diff --git a/src/cpu/operators/CpuGemm.cpp b/src/cpu/operators/CpuGemm.cpp
+index 34b845928d..164f55170a 100644
+--- a/src/cpu/operators/CpuGemm.cpp
++++ b/src/cpu/operators/CpuGemm.cpp
+@@ -52,6 +52,7 @@ cpu::AsmGemmInfo init_assembly_metadata(const GEMMInfo &info)
+     asm_info.fast_mode               = info.fast_math();
+     asm_info.fixed_format            = info.fixed_format();
+     asm_info.weight_format           = info.weight_format();
++    asm_info.accumulate              = info.accumulate();
+ 
+     return asm_info;
+ }
+@@ -138,7 +139,7 @@ void CpuGemm::configure(const ITensorInfo *a, const ITensorInfo *b, const ITenso
+     }
+ 
+     // Configure matrix addition kernel
+-    if(_run_addition)
++    if(_run_addition && !gemm_info.accumulate())
+     {
+         _ma_kernel = std::make_unique<cpu::kernels::CpuGemmMatrixAdditionKernel>();
+         _ma_kernel->configure(c, d, beta);
+diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+index e6e6311ab1..dafbb5dd08 100644
+--- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
++++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+@@ -633,7 +633,8 @@ void create_arm_gemm(std::unique_ptr<CpuGemmAssemblyDispatch::IFallback> &arm_ge
+ 
+     arm_gemm::GemmConfig cfg;
+     cfg.weight_format = assembly_utils::map_to_arm_gemm_weight_format(info.weight_format);
+-    arm_gemm::GemmArgs args(&ci, p.M, p.N, p.K, p.sections, p.batches, p.multis, p.indirect, activation, num_threads, info.fixed_format, info.fast_mode, &cfg);
++    arm_gemm::GemmArgs args(&ci, p.M, p.N, p.K, p.sections, p.batches, p.multis, p.indirect, activation, num_threads, info.fixed_format, info.fast_mode, false, &cfg);
++    args._accumulate = info.accumulate;
+ 
+     // Create arm_gemm fallback
+     auto fallback = std::make_unique<Fallback<TypeInput, TypeOutput>>();
+@@ -654,7 +655,7 @@ void create_arm_gemm_dequant(std::unique_ptr<CpuGemmAssemblyDispatch::IFallback>
+ 
+     arm_gemm::GemmConfig cfg;
+     cfg.weight_format = assembly_utils::map_to_arm_gemm_weight_format(info.weight_format);
+-    arm_gemm::GemmArgs args(&ci, p.M, p.N, p.K, p.sections, p.batches, p.multis, p.indirect, activation, num_threads, info.fixed_format, info.fast_mode, &cfg);
++    arm_gemm::GemmArgs args(&ci, p.M, p.N, p.K, p.sections, p.batches, p.multis, p.indirect, activation, num_threads, info.fixed_format, info.fast_mode, false, &cfg);
+ 
+     // Create arm_gemm fallback
+     auto fallback = std::make_unique<Fallback<TypeInput, TypeOutput, arm_gemm::DequantizeFloat>>();
+@@ -684,7 +685,7 @@ void create_arm_gemm_quant(std::unique_ptr<CpuGemmAssemblyDispatch::IFallback> &
+ 
+     arm_gemm::GemmConfig cfg;
+     cfg.weight_format = assembly_utils::map_to_arm_gemm_weight_format(info.weight_format);
+-    arm_gemm::GemmArgs args(&ci, p.M, p.N, p.K, p.sections, p.batches, p.multis, p.indirect, activation, num_threads, info.fixed_format, info.fast_mode, &cfg);
++    arm_gemm::GemmArgs args(&ci, p.M, p.N, p.K, p.sections, p.batches, p.multis, p.indirect, activation, num_threads, info.fixed_format, info.fast_mode, false, &cfg);
+ 
+     // Create arm_gemm fallback
+     auto fallback = std::make_unique<Fallback<TypeInput, TypeOutput, arm_gemm::Requantize32>>();
+@@ -737,7 +738,7 @@ Status CpuGemmAssemblyDispatch::has_opt_impl(arm_compute::WeightFormat &expected
+     arm_gemm::GemmConfig cfg;
+     cfg.weight_format                           = assembly_utils::map_to_arm_gemm_weight_format(info.weight_format);
+     arm_gemm::WeightFormat arm_gemm_expected_wf = assembly_utils::map_to_arm_gemm_weight_format(expected_weight_format);
+-    arm_gemm::GemmArgs     args(&ci, p.M, p.N, p.K, p.sections, p.batches, p.multis, p.indirect, act, num_threads, info.fixed_format, info.fast_mode, &cfg);
++    arm_gemm::GemmArgs     args(&ci, p.M, p.N, p.K, p.sections, p.batches, p.multis, p.indirect, act, num_threads, info.fixed_format, info.fast_mode, false, &cfg);
+     switch(a->data_type())
+     {
+         case DataType::F32:
+diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.h b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.h
+index ceb7a3f775..4d12df6df9 100644
+--- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.h
++++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.h
+@@ -56,6 +56,7 @@ struct AsmGemmInfo
+     bool                      fixed_format{ false };
+     arm_compute::WeightFormat weight_format{ arm_compute::WeightFormat::UNSPECIFIED };
+     bool                      reshape_b_only_on_first_run{ true };
++    bool                      accumulate{ true };
+ };
+ 
+ /** Assembly kernel glue */

--- a/docker/pytorch-aarch64/patches/onednn_acl_threadcap.patch
+++ b/docker/pytorch-aarch64/patches/onednn_acl_threadcap.patch
@@ -1,5 +1,5 @@
  *******************************************************************************
- Copyright 2023 Arm Limited and affiliates.
+ Copyright 2023-2024 Arm Limited and affiliates.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
  limitations under the License.
  *******************************************************************************
 diff --git a/src/cpu/aarch64/acl_thread.cpp b/src/cpu/aarch64/acl_thread.cpp
-index fd2c76d01..2d7c76d48 100644
+index 1b098629a..abd4b477d 100644
 --- a/src/cpu/aarch64/acl_thread.cpp
 +++ b/src/cpu/aarch64/acl_thread.cpp
 @@ -17,6 +17,8 @@
@@ -27,17 +27,20 @@ index fd2c76d01..2d7c76d48 100644
  #endif
  #include "cpu/aarch64/acl_benchmark_scheduler.hpp"
  
-@@ -30,9 +32,10 @@ namespace acl_thread_utils {
+@@ -30,12 +32,13 @@ namespace acl_thread_utils {
  #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
  void acl_thread_bind() {
      static std::once_flag flag_once;
 -    // The threads in Compute Library are bound for the cores 0..max_threads-1
 -    // dnnl_get_max_threads() returns OMP_NUM_THREADS
 -    const int max_threads = dnnl_get_max_threads();
-+    // Cap the number of threads to 90% of the total core count
-+    // to ensure Compute Library doesn't use too much resource
-+    int capped_threads = (int)std::floor(0.9*std::thread::hardware_concurrency());
-+    const int max_threads = std::min(capped_threads, dnnl_get_max_threads());
      // arm_compute::Scheduler does not support concurrent access thus a
      // workaround here restricts it to only one call
      std::call_once(flag_once, [&]() {
++        // Cap the number of threads to 90% of the total core count
++        // to ensure Compute Library doesn't use too much resource
++        int capped_threads = (int)std::floor(0.9*std::thread::hardware_concurrency());
++        const int max_threads = std::min(capped_threads, dnnl_get_max_threads());
+         arm_compute::Scheduler::get().set_num_threads(max_threads);
+     });
+ }

--- a/docker/pytorch-aarch64/patches/onednn_in_place_sum.patch
+++ b/docker/pytorch-aarch64/patches/onednn_in_place_sum.patch
@@ -1,0 +1,68 @@
+ *******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/matmul/acl_matmul.cpp b/src/cpu/aarch64/matmul/acl_matmul.cpp
+index ca1c7eb47..12c0aefd7 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
++++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
+@@ -31,7 +31,6 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
+     auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+ 
+     bool is_transA = pd()->amp_.is_transA;
+-    bool use_dst_acc = pd()->amp_.use_dst_acc;
+ 
+     std::lock_guard<std::mutex> _lock {this->mtx};
+     auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
+@@ -51,14 +50,8 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
+                 const_cast<data_t *>(wei_base));
+     }
+ 
+-    if (use_dst_acc) {
+-        // Put the result in a new tensor, it will be accumulated to the dst
+-        // during the post ops
+-        acl_obj.dst_tensor.allocator()->allocate();
+-    } else {
+-        auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+-        acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+-    }
++    auto dst_base = CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
++    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
+ 
+     acl_obj.gemm.run();
+ 
+diff --git a/src/cpu/aarch64/matmul/acl_matmul.hpp b/src/cpu/aarch64/matmul/acl_matmul.hpp
+index 6d848abe5..ed6eaca85 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
++++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
+@@ -90,9 +90,15 @@ struct acl_matmul_t : public primitive_t {
+                     amp_, src_md_, weights_md_, dst_md_, *desc(), *attr()));
+ 
+             arm_compute::ActivationLayerInfo act_info;
+-            CHECK(post_ops.init(engine, attr_.post_ops_, dst_md_, act_info));
++            // We are only going to create post ops if it doesn't have sum only
++            amp_.use_dst_acc = false;
++            if(!(attr_.post_ops_.len() == 1 && attr_.post_ops_.entry_[0].is_sum())) {
++                CHECK(post_ops.init(engine, attr_.post_ops_, dst_md_, act_info));
++            } else {
++                amp_.use_dst_acc = true;
++                amp_.gemm_info.set_accumulate(true);
++            }
+             amp_.gemm_info.set_activation_info(act_info);
+-            amp_.use_dst_acc = post_ops.has_sum();
+ 
+             // Validate ACL GEMM
+             ACL_CHECK_VALID(arm_compute::NEGEMM::validate(&amp_.src_tensor_info,

--- a/docker/pytorch-aarch64/scripts/build-acl.sh
+++ b/docker/pytorch-aarch64/scripts/build-acl.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020-2023 Arm Limited and affiliates.
+# Copyright 2020-2024 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -41,6 +41,8 @@ cat ../acl_fp32_bf16_reorder.patch tmp.patch > ../acl_fp32_bf16_reorder.patch
 patch -p1 < ../acl_fp32_bf16_reorder.patch
 
 patch -p1 < ../acl_dynamic_quantization.patch
+
+patch -p1 < ../acl_in_place_sum.patch
 
 # Default to v8a if $acl_arch is unset.
 arch=${ACL_ARCH:-"arm64-v8a"}

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020-2023 Arm Limited and affiliates.
+# Copyright 2020-2024 Arm Limited and affiliates.
 # Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -47,16 +47,11 @@ if [[ $ONEDNN_BUILD ]]; then
   esac
 fi
 
-
-# Fix mldnn_matmul error
-curl https://github.com/pytorch/pytorch/commit/cdc8d709cb458d656d170569b4da3d8193e4a6a2.patch -o /tmp/mldnn_matmul_fix.patch
-patch -p1 < /tmp/mldnn_matmul_fix.patch
-
 patch -p1 < $PACKAGE_DIR/pytorch_dynamic_quantization.patch
 
 cd third_party/ideep
-# Checkout a version of ideep compatible with oneDNN v3.3 and pytorch v2.1.0
-git checkout d0c2278a5d6830edecb2cad0f8d2598331f65554
+# Checkout a version of ideep compatible with oneDNN v3.3.4 and pytorch v2.2.0
+git checkout 087f41ae0d921e22c2d167e7d4723bb5beeda417
 
 patch -p1 < $PACKAGE_DIR/ideep_dynamic_quantization.patch
 
@@ -77,6 +72,8 @@ patch -p1 < $PACKAGE_DIR/onednn_fp32_bf16_reorder.patch
 patch -p1 < $PACKAGE_DIR/onednn_acl_threadcap.patch
 
 patch -p1 < $PACKAGE_DIR/onednn_acl_thread_local_scheduler.patch
+
+patch -p1 < $PACKAGE_DIR/onednn_in_place_sum.patch
 
 cd $PACKAGE_DIR/$src_repo
 

--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -9,9 +9,20 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Added
 
+### Changed
+
+### Removed
+
+### Fixed
+
+## [r24.01] 2034-01-23
+https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r24.01/docker/tensorflow-aarch64
+
+### Added
  - oneDNN patch to use indirect convolution only.
 
 ### Changed
+ - Updated tensorflow to v2.15.0
 
 ### Removed
 

--- a/docker/tensorflow-aarch64/build.sh
+++ b/docker/tensorflow-aarch64/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020-2023 Arm Limited and affiliates.
+# Copyright 2020-2024 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -230,7 +230,7 @@ if [[ $clean_build ]]; then
 fi
 
 # Set TensorFlow version
-tf_version="v2.14.0"
+tf_version="v2.15.0"
 
 # Add build-args to pass version numbers,
 extra_args="$extra_args \

--- a/docker/tensorflow-aarch64/patches/onednn_acl_threadcap.patch
+++ b/docker/tensorflow-aarch64/patches/onednn_acl_threadcap.patch
@@ -1,5 +1,5 @@
  *******************************************************************************
- Copyright 2023 Arm Limited and affiliates.
+ Copyright 2023-2024 Arm Limited and affiliates.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,7 +15,7 @@
  limitations under the License.
  *******************************************************************************
 diff --git a/src/cpu/aarch64/acl_thread.cpp b/src/cpu/aarch64/acl_thread.cpp
-index fd2c76d01..2d7c76d48 100644
+index 1b098629a..abd4b477d 100644
 --- a/src/cpu/aarch64/acl_thread.cpp
 +++ b/src/cpu/aarch64/acl_thread.cpp
 @@ -17,6 +17,8 @@
@@ -27,17 +27,20 @@ index fd2c76d01..2d7c76d48 100644
  #endif
  #include "cpu/aarch64/acl_benchmark_scheduler.hpp"
  
-@@ -30,9 +32,10 @@ namespace acl_thread_utils {
+@@ -30,12 +32,13 @@ namespace acl_thread_utils {
  #if DNNL_CPU_THREADING_RUNTIME == DNNL_RUNTIME_OMP
  void acl_thread_bind() {
      static std::once_flag flag_once;
 -    // The threads in Compute Library are bound for the cores 0..max_threads-1
 -    // dnnl_get_max_threads() returns OMP_NUM_THREADS
 -    const int max_threads = dnnl_get_max_threads();
-+    // Cap the number of threads to 90% of the total core count
-+    // to ensure Compute Library doesn't use too much resource
-+    int capped_threads = (int)std::floor(0.9*std::thread::hardware_concurrency());
-+    const int max_threads = std::min(capped_threads, dnnl_get_max_threads());
      // arm_compute::Scheduler does not support concurrent access thus a
      // workaround here restricts it to only one call
      std::call_once(flag_once, [&]() {
++        // Cap the number of threads to 90% of the total core count
++        // to ensure Compute Library doesn't use too much resource
++        int capped_threads = (int)std::floor(0.9*std::thread::hardware_concurrency());
++        const int max_threads = std::min(capped_threads, dnnl_get_max_threads());
+         arm_compute::Scheduler::get().set_num_threads(max_threads);
+     });
+ }

--- a/docker/tensorflow-aarch64/patches/tf_acl.patch
+++ b/docker/tensorflow-aarch64/patches/tf_acl.patch
@@ -1,5 +1,5 @@
  *******************************************************************************
- Copyright 2023 Arm Limited and affiliates.
+ Copyright 2023-2024 Arm Limited and affiliates.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,59 +14,40 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  *******************************************************************************
-diff --git a/tensorflow/tsl/mkl/build_defs.bzl b/tensorflow/tsl/mkl/build_defs.bzl
-index c89fb8c5461..f44262f3b75 100644
---- a/tensorflow/tsl/mkl/build_defs.bzl
-+++ b/tensorflow/tsl/mkl/build_defs.bzl
-@@ -115,7 +115,7 @@ def onednn_v3_define():
-       An empty list of all other cases (include ARM builds).
-     """
-     return select({
--        "@org_tensorflow//tensorflow/tsl/mkl:build_with_mkl_aarch64": [],
-+        "@org_tensorflow//tensorflow/tsl/mkl:build_with_mkl_aarch64": ["-DENABLE_ONEDNN_V3"],
-         "@org_tensorflow//tensorflow/tsl:linux_x86_64": ["-DENABLE_ONEDNN_V3"],
-         "@org_tensorflow//tensorflow/tsl:windows": ["-DENABLE_ONEDNN_V3"],
-         "//conditions:default": [],
 diff --git a/tensorflow/workspace2.bzl b/tensorflow/workspace2.bzl
-index 7e9faa558a4..cb5093e18ed 100644
+index 056df85ffdb..619e1e0927e 100644
 --- a/tensorflow/workspace2.bzl
 +++ b/tensorflow/workspace2.bzl
-@@ -204,24 +204,21 @@ def _tf_repositories():
-         build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
-         patch_file = [
-             "//third_party/mkl_dnn:onednn_acl_threadcap.patch",
--            "//third_party/mkl_dnn:onednn_acl_remove_winograd.patch",
--            "//third_party/mkl_dnn:onednn_acl_fixed_format_kernels.patch",
--            "//third_party/mkl_dnn:onednn_acl_depthwise_convolution.patch",
--            "//third_party/mkl_dnn:onednn_acl_threadpool_scheduler.patch",
--            "//third_party/mkl_dnn:onednn_acl_reorder_padded.patch",
--            "//third_party/mkl_dnn:onednn_acl_reorder_update.patch",
+@@ -218,11 +218,11 @@ def _tf_repositories():
              "//third_party/mkl_dnn:onednn_acl_reorder.patch",
-+            "//third_party/mkl_dnn:onednn_acl_fp32_bf16_reorder.patch",
              "//third_party/mkl_dnn:onednn_acl_thread_local_scheduler.patch",
+             "//third_party/mkl_dnn:onednn_acl_fp32_bf16_reorder.patch",
+-            "//third_party/mkl_dnn:onednn_acl_bf16_capability_detection_for_ubuntu20.04.patch",
 +            "//third_party/mkl_dnn:onednn_acl_use_indirect_conv.patch",
          ],
--        sha256 = "a50993aa6265b799b040fe745e0010502f9f7103cc53a9525d59646aef006633",
--        strip_prefix = "oneDNN-2.7.3",
--        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/v2.7.3.tar.gz"),
+-        sha256 = "2f76b407ef8893cca71340f88cd800019a1f14f8ac1bbdbb89a84be1370b52e3",
+-        strip_prefix = "oneDNN-3.2.1",
+-        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/v3.2.1.tar.gz"),
 +        sha256 = "8d150a77025f38bff182aaef4dd643625563b2f311c635f86cf4b769b04d7b48",
 +        strip_prefix = "oneDNN-3.3",
 +        urls = tf_mirror_urls("https://github.com/oneapi-src/oneDNN/archive/refs/tags/v3.3.tar.gz"),
      )
-
+ 
      tf_http_archive(
-         name = "compute_library",
+@@ -230,6 +230,7 @@ def _tf_repositories():
          patch_file = [
              "//third_party/compute_library:compute_library.patch",
-+            "//third_party/compute_library:acl_fp32_bf16_reorder.patch",
              "//third_party/compute_library:acl_thread_local_scheduler.patch",
++            "//third_party/compute_library:acl_fp32_bf16_reorder.patch",
          ],
          sha256 = "c4ca329a78da380163b2d86e91ba728349b6f0ee97d66e260a694ef37f0b0d93",
+         strip_prefix = "ComputeLibrary-23.05.1",
+
 diff --git a/third_party/mkl_dnn/mkldnn_acl.BUILD b/third_party/mkl_dnn/mkldnn_acl.BUILD
-index a1085427ec0..2023a134d0a 100644
+index 0653bcb5523..93b1be4873b 100644
 --- a/third_party/mkl_dnn/mkldnn_acl.BUILD
 +++ b/third_party/mkl_dnn/mkldnn_acl.BUILD
-@@ -61,6 +61,13 @@ _DNNL_RUNTIME_THREADPOOL = {
+@@ -62,6 +62,12 @@ _DNNL_RUNTIME_THREADPOOL = {
      "#cmakedefine01 BUILD_XEHPG": "#define BUILD_XEHPG 0",
      "#cmakedefine01 BUILD_XEHPC": "#define BUILD_XEHPC 0",
      "#cmakedefine01 BUILD_XEHP": "#define BUILD_XEHP 0",
@@ -76,11 +57,10 @@ index a1085427ec0..2023a134d0a 100644
 +    "#cmakedefine01 BUILD_GEMM_SSE41": "#define BUILD_GEMM_SSE41 0",
 +    "#cmakedefine01 BUILD_GEMM_AVX2": "#define BUILD_GEMM_AVX2 0",
 +    "#cmakedefine01 BUILD_GEMM_AVX512": "#define BUILD_GEMM_AVX512 0",
-+    "#cmakedefine ONEDNN_BUILD_GRAPH": "#undef ONEDNN_BUILD_GRAPH",
  }
-
+ 
  _DNNL_RUNTIME_OMP = {
-@@ -108,6 +115,13 @@ _DNNL_RUNTIME_OMP = {
+@@ -110,6 +116,12 @@ _DNNL_RUNTIME_OMP = {
      "#cmakedefine01 BUILD_XEHPG": "#define BUILD_XEHPG 0",
      "#cmakedefine01 BUILD_XEHPC": "#define BUILD_XEHPC 0",
      "#cmakedefine01 BUILD_XEHP": "#define BUILD_XEHP 0",
@@ -90,28 +70,17 @@ index a1085427ec0..2023a134d0a 100644
 +    "#cmakedefine01 BUILD_GEMM_SSE41": "#define BUILD_GEMM_SSE41 0",
 +    "#cmakedefine01 BUILD_GEMM_AVX2": "#define BUILD_GEMM_AVX2 0",
 +    "#cmakedefine01 BUILD_GEMM_AVX512": "#define BUILD_GEMM_AVX512 0",
-+    "#cmakedefine ONEDNN_BUILD_GRAPH": "#undef ONEDNN_BUILD_GRAPH",
  }
-
+ 
  expand_template(
-@@ -124,9 +138,9 @@ expand_template(
-     name = "dnnl_version_h",
+@@ -127,8 +139,8 @@ expand_template(
      out = "include/oneapi/dnnl/dnnl_version.h",
      substitutions = {
--        "@DNNL_VERSION_MAJOR@": "2",
--        "@DNNL_VERSION_MINOR@": "7",
--        "@DNNL_VERSION_PATCH@": "3",
-+        "@DNNL_VERSION_MAJOR@": "3",
+         "@DNNL_VERSION_MAJOR@": "3",
+-        "@DNNL_VERSION_MINOR@": "2",
+-        "@DNNL_VERSION_PATCH@": "1",
 +        "@DNNL_VERSION_MINOR@": "3",
 +        "@DNNL_VERSION_PATCH@": "0",
          "@DNNL_VERSION_HASH@": "N/A",
      },
      template = "include/oneapi/dnnl/dnnl_version.h.in",
-@@ -142,6 +156,7 @@ cc_library(
-         ],
-         exclude = [
-             "src/cpu/x64/**",
-+            "src/cpu/rv64/**",
-         ],
-     ),
-     copts = select({

--- a/docker/tensorflow-aarch64/patches/tf_threadpool_threadcap.patch
+++ b/docker/tensorflow-aarch64/patches/tf_threadpool_threadcap.patch
@@ -1,5 +1,5 @@
  *******************************************************************************
- Copyright 2023 Arm Limited and affiliates.
+ Copyright 2023-2024 Arm Limited and affiliates.
  SPDX-License-Identifier: Apache-2.0
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -14,25 +14,25 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  *******************************************************************************
-diff --git a/tensorflow/tsl/platform/threadpool.cc b/tensorflow/tsl/platform/threadpool.cc
-index 271aa58c804..b4abf97a1f1 100644
---- a/tensorflow/tsl/platform/threadpool.cc
-+++ b/tensorflow/tsl/platform/threadpool.cc
+diff --git a/third_party/xla/third_party/tsl/tsl/platform/threadpool.cc b/third_party/xla/third_party/tsl/tsl/platform/threadpool.cc
+index 218226611b1..7e0b59ad7ac 100644
+--- a/third_party/xla/third_party/tsl/tsl/platform/threadpool.cc
++++ b/third_party/xla/third_party/tsl/tsl/platform/threadpool.cc
 @@ -27,6 +27,7 @@ limitations under the License.
- #include "tensorflow/tsl/platform/numa.h"
- #include "tensorflow/tsl/platform/setround.h"
- #include "tensorflow/tsl/platform/tracing.h"
+ #include "tsl/platform/numa.h"
+ #include "tsl/platform/setround.h"
+ #include "tsl/platform/tracing.h"
 +#include <thread>
-
+ 
  #ifdef TENSORFLOW_THREADSCALING_EXPERIMENTAL
  ABSL_FLAG(float, tensorflow_num_threads_scale_factor, 1.0,
 @@ -107,6 +108,10 @@ ThreadPool::ThreadPool(Env* env, const ThreadOptions& thread_options,
                         bool low_latency_hint, Eigen::Allocator* allocator) {
    CHECK_GE(num_threads, 1);
-
-+if(num_threads == std::thread::hardware_concurrency() && num_threads > 1){
-+  num_threads = num_threads - 1;
-+}
+ 
++  if(num_threads == std::thread::hardware_concurrency() && num_threads > 1){
++    num_threads = num_threads - 1;
++  }
 +
  #ifdef TENSORFLOW_THREADSCALING_EXPERIMENTAL
    CHECK_GT(absl::GetFlag(FLAGS_tensorflow_num_threads_scale_factor), 0);


### PR DESCRIPTION
Updates for the 24.01 release, including:
- Fix for pytorch regression due to capped thread calculation
- Update pytorch to v2.2.0-rc8 and oneDNN to v3.3.4
- Update Tensorflow to v2.15.0