### PR TITLE
Disable LNorm fusions for aarch64

### DIFF
--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -10,6 +10,7 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 
 ### Changed
+- Disabled layer norm fusions for aarch64
 
 ### Removed
 

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -285,6 +285,7 @@ ENV PATH="$PACKAGE_DIR/bazel:$PATH"
 # Build TensorFlow
 COPY patches/tf_acl.patch $PACKAGE_DIR/.
 COPY patches/tf_threadpool_threadcap.patch $PACKAGE_DIR/.
+COPY patches/tf_disable_lnorm_fusions.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_thread_local_scheduler.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_reorder.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_fp32_bf16_reorder.patch $PACKAGE_DIR/.

--- a/docker/tensorflow-aarch64/patches/tf_disable_lnorm_fusions.patch
+++ b/docker/tensorflow-aarch64/patches/tf_disable_lnorm_fusions.patch
@@ -1,0 +1,67 @@
+ *******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/tensorflow/core/grappler/optimizers/remapper.cc b/tensorflow/core/grappler/optimizers/remapper.cc
+index 3c37150f496..13f33f5bce6 100644
+--- a/tensorflow/core/grappler/optimizers/remapper.cc
++++ b/tensorflow/core/grappler/optimizers/remapper.cc
+@@ -2074,6 +2074,14 @@ bool FindMklLayerNorm(RemapperContext* ctx, int node_index,
+                       std::set<int>* remove_node_indices,
+                       std::vector<string>* input_node_names, float* epsilon) {
+   if (!IsMKLEnabled()) return false;
++// Fusing LNorm patterns into MklLayerNorm causes a regression on aarch64 since
++// Arm Compute Library's accelerated LNorm kernels do not support the scale and
++// shift parameters (beta and gamma). Hence, the sub-optimal oneDNN ref kernel
++// for LNorm will be  executed which is, in most cases, slower than running
++// the operations unfused.
++#ifdef DNNL_AARCH64_USE_ACL
++  return false;
++#endif // DNNL_AARCH64_USE_ACL
+ 
+   // The following pattern will be searched in the graph with additional
+   // contraints. Here * means any type of op.
+@@ -2160,7 +2168,6 @@ bool FindMklLayerNorm(RemapperContext* ctx, int node_index,
+     found_op_type_match = IsCommonNormPattern(
+         ctx, node_index, matched_nodes_map, remove_node_indices);
+   }
+-
+   // Additional check for LayerNorm
+   if (found_op_type_match) {
+     if (!ctx->inferred_graph_properties) {
+diff --git a/tensorflow/core/grappler/optimizers/remapper_test.cc b/tensorflow/core/grappler/optimizers/remapper_test.cc
+index d3a66525893..b77e68719ac 100644
+--- a/tensorflow/core/grappler/optimizers/remapper_test.cc
++++ b/tensorflow/core/grappler/optimizers/remapper_test.cc
+@@ -1408,6 +1408,9 @@ TEST_F(RemapperFuseSoftplusTanhMul, BF16) {
+ 
+ TEST_F(RemapperTest, FuseMklLayerNorm) {
+   if (!IsMKLEnabled()) GTEST_SKIP() << "Test only applicable to MKL.";
++#ifdef DNNL_AARCH64_USE_ACL
++    GTEST_SKIP() << "Test not applicable to AARCH64";
++#endif
+   using ::tensorflow::ops::Placeholder;
+   tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+ 
+@@ -1474,6 +1477,9 @@ class FuseMklLayerNormPattern : public RemapperTest {
+   template <DataType DTYPE>
+   void RunTest() {
+     if (!IsMKLEnabled()) GTEST_SKIP() << "Test only applicable to MKL.";
++#ifdef DNNL_AARCH64_USE_ACL
++    GTEST_SKIP() << "Test not applicable to AARCH64";
++#endif
+     using ::tensorflow::ops::Placeholder;
+     tensorflow::Scope s = tensorflow::Scope::NewRootScope();
+ 

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -87,6 +87,7 @@ if [[ $ONEDNN_BUILD ]]; then
 
         patch -p1 < ../tf_acl.patch
         patch -p1 < ../tf_threadpool_threadcap.patch
+        patch -p1 < ../tf_disable_lnorm_fusions.patch
         mv ../onednn_acl_reorder.patch ./third_party/mkl_dnn/.
         mv ../onednn_acl_fp32_bf16_reorder.patch ./third_party/mkl_dnn/.
         mv ../onednn_acl_thread_local_scheduler.patch ./third_party/mkl_dnn/.


### PR DESCRIPTION
Fusing LNorm operations into MklLayerNorm cause a regression on aarch64 since Arm Compute Library's accelerated LNorm kernels do not support the scale and shift parameters (beta and gamma). Hence, the sub-optimal oneDNN ref kernel for LNorm will be executed which is, in most cases, slower than running the operations unfused.