### PR TITLE
Clang 17 and pin bazelisk

### DIFF
--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -11,6 +11,8 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Changed
 
+- Move to Clang 17 from GCC
+
 ### Removed
 
 ### Fixed

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -103,10 +103,14 @@ RUN apt-get -y update && \
       zip \
       zlib1g-dev
 
+# Add clang 17
+RUN wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+RUN add-apt-repository "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main"
+RUN apt-get install -y  --no-install-recommends llvm-17 clang-17 clang++-17 python3-dev libomp-17-dev lld-17
 
-# Set default gcc, python and pip versions
-RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 1 && \
-    update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 1 && \
+# Set default clang, python and pip versions
+RUN update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 1 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 1 && \
     update-alternatives --install /usr/bin/gfortran gfortran /usr/bin/gfortran-11 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3 1 && \
     update-alternatives --install /usr/bin/pip pip /usr/bin/pip3 1
@@ -154,8 +158,8 @@ RUN mkdir -p $PACKAGE_DIR && \
     mkdir -p $PROD_DIR
 
 # Common compiler settings
-ENV CC=gcc \
-    CXX=g++ \
+ENV CC=clang \
+    CXX=clang++ \
     BASE_CFLAGS="-mcpu=${CPU} -march=${ARCH} -O3" \
     BASE_LDFLAGS=""
 

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -274,12 +274,10 @@ ENV VIRTUAL_ENV=/home/$DOCKER_USER/python3-venv
 COPY --chown=$DOCKER_USER:$DOCKER_USER --from=tensorflow-tools $VIRTUAL_ENV /home/$DOCKER_USER/python3-venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# Get Bazel binary for AArch64 using the latest Bazelisk release
-RUN mkdir -p $PACKAGE_DIR/bazel
-RUN bazelisk_url=$(curl -L -s https://api.github.com/repos/bazelbuild/bazelisk/releases/latest \
-    | grep -o -E "https://(.*)bazelisk-linux-arm64") && \
-    wget $bazelisk_url -O $PACKAGE_DIR/bazel/bazel
-RUN chmod a+x $PACKAGE_DIR/bazel/bazel
+# Get Bazel binary for AArch64 using Bazelisk
+RUN mkdir -p $PACKAGE_DIR/bazel \
+    && wget https://github.com/bazelbuild/bazelisk/releases/download/v1.19.0/bazelisk-linux-arm64 -O $PACKAGE_DIR/bazel/bazel \
+    && chmod a+x $PACKAGE_DIR/bazel/bazel
 ENV PATH="$PACKAGE_DIR/bazel:$PATH"
 
 # Build TensorFlow

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -8,16 +8,14 @@ Release versions of TensorFlow are available from: https://pypi.org/project/tens
 
 ## Contents
 * [Getting started with TensorFlow on AArch64](#getting-started-with-tensorflow-on-aarch64)
-   * [Downloading an image from Docker Hub](#downloading-an-image-from-docker-hub)
-   * [Running the Docker image](#running-the-docker-image)
+  * [Downloading an image from Docker Hub](#downloading-an-image-from-docker-hub)
+  * [Running the Docker image](#running-the-docker-image)
 * [Image contents](#image-contents)
-   * [Optimized backend for AArch64](#optimized-backend-for-aarch64)
-      * [oneDNN runtime flags](#onednn-runtime-flags)
-   * [Hardware support](#hardware-support)
-   * [Examples](#examples)
+  * [Optimized backend for AArch64](#optimized-backend-for-aarch64)
+    * [oneDNN runtime flags](#onednn-runtime-flags)
+  * [Hardware support](#hardware-support)
+  * [Examples](#examples)
 * [Build TensorFlow (2.x) for AArch64 using Docker](#build-tensorflow-2x-for-aarch64-using-docker)
-   * [Building a TensorFlow Serving image](#building-a-tensorflow-serving-image)
-      * [Running a simple example with TensorFlow Serving](#running-a-simple-example-with-tensorflow-serving)
 
 ## Getting started with TensorFlow on AArch64
 This [component](https://github.com/ARM-software/Tool-Solutions/tree/master/docker/tensorflow-aarch64) of [ARM-Software's](https://github.com/ARM-software) [Tool Solutions](https://github.com/ARM-software/Tool-Solutions) repository provides instructions to obtain, and scripts to build, a Docker image containing [TensorFlow](https://www.tensorflow.org/) and dependencies for the [Armv8-A architecture](https://developer.arm.com/architectures/cpu-architecture/a-profile), optionally with AArch64 specific optimizations via [Compute Library for the Arm® Architecture (ACL)](https://developer.arm.com/ip-products/processors/machine-learning/compute-library), as well as a selection of [examples and benchmarks](./examples/README.md).
@@ -58,7 +56,7 @@ where `<image name> `is the name of the image, i.e. `armswdev/tensorflow-arm-neo
 ## Image contents
 
   * OS: Ubuntu 22.04
-  * Compiler: GCC 11.3
+  * Compiler: Clang 17
   * Maths libraries: [OpenBLAS](https://www.openblas.net/) 0.3.20, used for NumPy's BLAS functionality
   * [oneDNN](https://github.com/oneapi-src/oneDNN) 3.2
     - ACL 23.05.1 provides optimized implementations on AArch64 for main oneDNN primitives
@@ -122,7 +120,7 @@ Use the `build.sh` script to build the image.
 
 This script implements a multi-stage build to minimize the size of the final image:
 
-  * Stage 1: 'base' image including Ubuntu with core packages and GCC
+  * Stage 1: 'base' image including Ubuntu with core packages and Clang 17
   * Stage 2: 'libs' image including essential tools and libraries such as Python and OpenBLAS
   * Stage 3: 'tools' image, including a Python3 virtual environment in userspace and a build of NumPy and SciPy against OpenBLAS, as well as other Python essentials
   * Stage 4: 'dev' image, including Bazel and TensorFlow and the source code

--- a/docker/tensorflow-aarch64/build.sh
+++ b/docker/tensorflow-aarch64/build.sh
@@ -49,7 +49,7 @@ function print_usage_and_exit {
   echo "                                 * neoverse       - generic optimization for all Neoverse cores"
   echo "                                 * thunderx2t99   - optimize for Marvell ThunderX2."
   echo "                                 * custom         - use custom settings defined in cpu_info.sh"
-  echo "                                 GCC provides support for additional target cpu's refer to the gcc manual for details."
+  echo "                                 Clang provides support for additional target cpus, refer to the LLVM manual for details."
   echo "      --no-cache / --clean     Pull a new base image and build without using any cached images."
   echo "      --tag                    Specify a tag name for the image (default 'latest')."
   echo ""

--- a/docker/tensorflow-aarch64/cpu_info.sh
+++ b/docker/tensorflow-aarch64/cpu_info.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2021 Arm Limited and affiliates.
+# Copyright 2021-2024 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -72,7 +72,7 @@ echo $target
 #   -mcpu  = Target processor, can include one or more feature modifiers.
 #   -mtune = Target processor for which the compiler should tune the performance of the code
 #   -march = Target architecture, can include  one or more feature modifiers
-# Note: further details can be found in the GCC documentation
+# Note: further details can be found in the LLVM documentation
 #
 # Eigen settings:
 #   eigen_l{1,2,3}_cache = Sets the L1, 2, 3 cache size used for Eigen's GEBP

--- a/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
+++ b/docker/tensorflow-aarch64/scripts/build-tensorflow.sh
@@ -32,8 +32,8 @@ cd ${src_repo}
 git checkout $version
 
 # Env vars used to avoid interactive elements of the build.
-export HOST_C_COMPILER=(which gcc)
-export HOST_CXX_COMPILER=(which g++)
+export HOST_C_COMPILER=(which clang)
+export HOST_CXX_COMPILER=(which clang++)
 export PYTHON_BIN_PATH=(which python)
 export USE_DEFAULT_PYTHON_LIB_PATH=1
 export TF_ENABLE_XLA=1
@@ -55,13 +55,14 @@ export TF_NEED_OPENCL_SYCL=0
 export TF_NEED_COMPUTECPP=0
 export TF_NEED_KAFKA=0
 export TF_NEED_TENSORRT=0
-export TF_NEED_CLANG=0
+export TF_NEED_CLANG=1
 
 ./configure
 
 # Bazel build options
 config_flags=""
-compile_flags="--copt=-mtune=${TUNE} --copt=-march=${ARCH} --copt=-O3 --copt=-flax-vector-conversions --copt=-Wno-error=stringop-overflow"
+compile_flags="--copt=-mtune=${TUNE} --copt=-march=${ARCH} --copt=-O3 \
+    --copt=-flax-vector-conversions --copt=-Wno-gnu-offsetof-extensions"
 link_flags="--linkopt=-fuse-ld=lld --linkopt=-lm --linkopt=-Wl,--undefined-version"
 extra_flags="--verbose_failures -s"
 


### PR DESCRIPTION
Change from GCC to Clang 17 to match upstream TensorFlow and pin bazelisk version to be more reproducible.