### PR TITLE
Pytorch updates for release r24.02

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -15,6 +15,20 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Fixed
 
+## [r24.02] 2024-02-28
+https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r24.02/docker/pytorch-aarch64
+
+### Added
+- ACL and oneDNN patches to add matmul kernel to enable bf16 to bf16 operations
+  via PyTorch® autocast() function.
+
+### Changed
+- Updated OpenBLAS version to v0.3.26
+
+### Removed
+
+### Fixed
+
 ## [r24.01] 2024-01-23
 https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r24.01/docker/pytorch-aarch64
 

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -140,7 +140,7 @@ ENV NP_MAKE="${njobs}" \
 
 # Key version numbers
 ENV ACL_VERSION="v23.08" \
-    OPENBLAS_VERSION=0.3.20 \
+    OPENBLAS_VERSION=0.3.26 \
     NINJA_VERSION=1.9.0
 
 # Package build parameters
@@ -170,6 +170,7 @@ COPY scripts/build-acl.sh $PACKAGE_DIR/.
 COPY patches/acl_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/acl_fp32_bf16_reorder.patch $PACKAGE_DIR/.
 COPY patches/acl_in_place_sum.patch $PACKAGE_DIR/.
+COPY patches/acl_bf16_dispatch.patch $PACKAGE_DIR/.
 
 RUN $PACKAGE_DIR/build-acl.sh
 ENV ACL_ROOT_DIR=$PROD_DIR/ComputeLibrary
@@ -294,6 +295,7 @@ COPY patches/onednn_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/ideep_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/onednn_in_place_sum.patch $PACKAGE_DIR/.
+COPY patches/onednn_bf16_matmul_kernel.patch $PACKAGE_DIR/.
 
 COPY scripts/build-torchvision.sh $PACKAGE_DIR/.
 COPY scripts/build-torchtext.sh $PACKAGE_DIR/.

--- a/docker/pytorch-aarch64/patches/acl_bf16_dispatch.patch
+++ b/docker/pytorch-aarch64/patches/acl_bf16_dispatch.patch
@@ -1,0 +1,71 @@
+ *******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+index 3069d6b54..6a2c567c8 100644
+--- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
++++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2018-2023 Arm Limited.
++ * Copyright (c) 2018-2024 Arm Limited.
+  *
+  * SPDX-License-Identifier: MIT
+  *
+@@ -739,8 +739,15 @@ Status CpuGemmAssemblyDispatch::has_opt_impl(arm_compute::WeightFormat &expected
+ #if defined(ARM_COMPUTE_ENABLE_BF16)
+         case DataType::BFLOAT16:
+         {
+-            ARM_COMPUTE_RETURN_ERROR_ON_MSG(!(arm_gemm::has_opt_gemm<bfloat16, float, arm_gemm::Nothing>(arm_gemm_expected_wf, args, {})),
+-                                            "We could not find an optimized kernel for BFLOAT16 input and F32 output");
++            if (d->data_type() == DataType::BFLOAT16) {
++                ARM_COMPUTE_RETURN_ERROR_ON_MSG(
++                    !(arm_gemm::has_opt_gemm<bfloat16, bfloat16, arm_gemm::Nothing>(arm_gemm_expected_wf, args, {})),
++                    "We could not find an optimized kernel for BFLOAT16 input and BFLOAT16 output");
++            } else {
++                ARM_COMPUTE_RETURN_ERROR_ON_MSG(
++                    !(arm_gemm::has_opt_gemm<bfloat16, float, arm_gemm::Nothing>(arm_gemm_expected_wf, args, {})),
++                    "We could not find an optimized kernel for BFLOAT16 input and F32 output");
++            }
+             break;
+         }
+ #endif /* defined(ARM_COMPUTE_ENABLE_BF16) */
+@@ -789,7 +796,8 @@ Status CpuGemmAssemblyDispatch::validate(const ITensorInfo *a, const ITensorInfo
+     }
+     ARM_COMPUTE_RETURN_ERROR_ON_MSG(a->data_type() == DataType::F32 && d->data_type() != DataType::F32, "Only F32 output supported for F32 input");
+     ARM_COMPUTE_RETURN_ERROR_ON_MSG(a->data_type() == DataType::F16 && d->data_type() != DataType::F16, "Only F16 output supported for F16 input");
+-    ARM_COMPUTE_RETURN_ERROR_ON_MSG(a->data_type() == DataType::BFLOAT16 && d->data_type() != DataType::F32, "Only F32 output supported for BFLOAT16 input");
++    ARM_COMPUTE_RETURN_ERROR_ON_MSG(a->data_type() == DataType::BFLOAT16 && (d->data_type() != DataType::F32 && d->data_type() != DataType::BFLOAT16),
++                                    "Only F32/BFLOAT16 output supported for BFLOAT16 input");
+     ARM_COMPUTE_RETURN_ERROR_ON_MSG(a->data_type() == DataType::U8 && d->data_type() != DataType::U32, "Only U32 output supported for U8 input");
+     ARM_COMPUTE_RETURN_ERROR_ON_MSG(a->data_type() == DataType::S8 && d->data_type() != DataType::S32, "Only S32 output supported for S8 input");
+     ARM_COMPUTE_RETURN_ERROR_ON_MSG(a->data_type() == DataType::QASYMM8 && (d->data_type() != DataType::QASYMM8 && d->data_type() != DataType::S32),
+@@ -855,7 +863,11 @@ void CpuGemmAssemblyDispatch::configure(const ITensorInfo *a, const ITensorInfo
+ #endif /* __aarch64__ */
+ #if defined(ARM_COMPUTE_ENABLE_BF16)
+         case DataType::BFLOAT16:
+-            create_arm_gemm<bfloat16, float>(_arm_gemm, a, b, c, d, act, info);
++            if (d->data_type() == DataType::BFLOAT16) {
++                create_arm_gemm<bfloat16, bfloat16>(_arm_gemm, a, b, c, d, act, info);
++            } else {
++                create_arm_gemm<bfloat16, float>(_arm_gemm, a, b, c, d, act, info);
++            }
+             break;
+ #endif /* defined(ARM_COMPUTE_ENABLE_BF16) */
+ #ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
+--
+2.25.1

--- a/docker/pytorch-aarch64/patches/onednn_bf16_matmul_kernel.patch
+++ b/docker/pytorch-aarch64/patches/onednn_bf16_matmul_kernel.patch
@@ -1,0 +1,37 @@
+ *******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/matmul/acl_matmul.hpp b/src/cpu/aarch64/matmul/acl_matmul.hpp
+index 451cc78d5..6296940c2 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
++++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
+@@ -76,8 +76,12 @@ struct acl_matmul_t : public primitive_t {
+                     = utils::everyone_is(data_type::f16, src_md()->data_type,
+                               weights_md()->data_type, dst_md()->data_type)
+                     && platform::has_data_type_support(data_type::f16);
++           const bool is_bf16_ok
++                    = utils::everyone_is(data_type::bf16, src_md()->data_type,
++                             weights_md()->data_type, dst_md()->data_type)
++                    && platform::has_data_type_support(data_type::bf16);
+             bool ok = is_dense_data()
+-                    && utils::one_of(true, is_fp32_ok, is_fp16_ok)
++                    && utils::one_of(true, is_fp32_ok, is_fp16_ok, is_bf16_ok)
+                     && !has_zero_dim_memory()
+                     && weights_md_.format_kind == format_kind::any
+                     && set_default_formats()
+--
+2.25.1

--- a/docker/pytorch-aarch64/scripts/build-acl.sh
+++ b/docker/pytorch-aarch64/scripts/build-acl.sh
@@ -44,6 +44,11 @@ patch -p1 < ../acl_dynamic_quantization.patch
 
 patch -p1 < ../acl_in_place_sum.patch
 
+wget https://review.mlplatform.org/changes/ml%2FComputeLibrary\~11169/revisions/3/patch\?zip -O acl_bf16bf16_matmul.patch.zip && unzip acl_bf16bf16_matmul.patch.zip
+sed "5233,5279d" abd3394.diff > tmp.patch
+cat tmp.patch ../acl_bf16_dispatch.patch > acl_bf16bf16_matmul.patch
+patch -p1 < acl_bf16bf16_matmul.patch
+
 # Default to v8a if $acl_arch is unset.
 arch=${ACL_ARCH:-"arm64-v8a"}
 echo "Compute Library arch = ${arch}"

--- a/docker/pytorch-aarch64/scripts/build-openblas.sh
+++ b/docker/pytorch-aarch64/scripts/build-openblas.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # *******************************************************************************
-# Copyright 2020-2021 Arm Limited and affiliates.
+# Copyright 2020-2024 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -22,7 +22,7 @@ set -euo pipefail
 cd $PACKAGE_DIR
 readonly package=openblas
 readonly version=$OPENBLAS_VERSION
-readonly src_host="https://github.com/xianyi"
+readonly src_host="https://github.com/OpenMathLib"
 readonly src_repo="OpenBLAS"
 
 git clone ${src_host}/${src_repo}.git

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -73,6 +73,8 @@ patch -p1 < $PACKAGE_DIR/onednn_acl_thread_local_scheduler.patch
 
 patch -p1 < $PACKAGE_DIR/onednn_in_place_sum.patch
 
+patch -p1 < $PACKAGE_DIR/onednn_bf16_matmul_kernel.patch
+
 cd $PACKAGE_DIR/$src_repo
 
 if [[ $XLA_BUILD ]]; then

--- a/docker/tensorflow-aarch64/CHANGELOG.md
+++ b/docker/tensorflow-aarch64/CHANGELOG.md
@@ -10,9 +10,20 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 
 ### Changed
-- Disabled layer norm fusions for aarch64
 
-- Move to Clang 17 from GCC
+### Removed
+
+### Fixed
+
+## [r24.02] 2034-01-28
+https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--r24.02/docker/tensorflow-aarch64
+
+### Added
+
+### Changed
+ - Disabled layer norm fusions for aarch64
+
+ - Move to Clang 17 from GCC
 
 ### Removed
 

--- a/docker/tensorflow-aarch64/README.md
+++ b/docker/tensorflow-aarch64/README.md
@@ -57,7 +57,7 @@ where `<image name> `is the name of the image, i.e. `armswdev/tensorflow-arm-neo
 
   * OS: Ubuntu 22.04
   * Compiler: Clang 17
-  * Maths libraries: [OpenBLAS](https://www.openblas.net/) 0.3.20, used for NumPy's BLAS functionality
+  * Maths libraries: [OpenBLAS](https://www.openblas.net/) 0.3.26, used for NumPy's BLAS functionality
   * [oneDNN](https://github.com/oneapi-src/oneDNN) 3.2
     - ACL 23.05.1 provides optimized implementations on AArch64 for main oneDNN primitives
   * Python 3.10 environment containing:


### PR DESCRIPTION
Pytorch updates:

- ACL and oneDNN patches to add matmul kernel to enable bf16 to bf16 operations via PyTorch® autocast() function.

- Updated OpenBLAS version to v0.3.26