### PR TITLE
r24.06 Additional Updates

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -23,7 +23,7 @@ https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--
 ### Changed
 - Updated PyTorch to v2.3.0
 - Updated ideep to Git Hash: 55ca019
-- Updated oneDNN to Git Hash: ecda5fa, which includes among other things:
+- Updated oneDNN to Git Hash: eb013e3, which includes among other things:
     - Removing fall through to oneDNN reference implementation for depthwise convolution when padding greater than kernel
 - Updated ACL to Git Hash: 4c3f716
 - Updated torchtext to v0.18.0
@@ -40,7 +40,6 @@ https://github.com/ARM-software/Tool-Solutions/tree/tensorflow-pytorch-aarch64--
   - onednn_add_Acdb8a_and_Acdb4a_acl_reorders.patch
   - onednn_bf16_matmul_kernel.patch
   - onednn_dynamic_quantization.patch
-  - onednn_enable_indirect_conv.patch
   - onednn_fp32_bf16_reorder.patch
   - onednn_in_place_sum.patch
   - onednn_stop_linking_to_arm_core_library.patch

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -259,7 +259,7 @@ ENV ONEDNN_BUILD="${onednn_opt}" \
 
 # Key version numbers
 ENV PY_VERSION="${default_py_version}" \
-    ONEDNN_VERSION="ecda5fa99b6b4b922d16d8377761d3adb50bfa01" \
+    ONEDNN_VERSION="4f2360e1c8" \
     TORCH_VERSION=2.3.0 \
     TORCHVISION_VERSION=0.17.1 \
     TORCHDATA_VERSION=0.7.1 \

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -259,7 +259,7 @@ ENV ONEDNN_BUILD="${onednn_opt}" \
 
 # Key version numbers
 ENV PY_VERSION="${default_py_version}" \
-    ONEDNN_VERSION="4f2360e1c8" \
+    ONEDNN_VERSION="eb013e386e47d021b2ab169500ce6ab1147142e1" \
     TORCH_VERSION=2.3.0 \
     TORCHVISION_VERSION=0.17.1 \
     TORCHDATA_VERSION=0.7.1 \

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -66,6 +66,10 @@ git checkout $ONEDNN_VERSION
 # rename test_api to test_api_dnnl so it does not clash with PyTorch test_api
 patch -p1 < $PACKAGE_DIR/onednn.patch
 patch -p1 < $PACKAGE_DIR/onednn_acl_thread_local_scheduler.patch
+wget -O onednn_enable_indirect_conv.patch https://patch-diff.githubusercontent.com/raw/oneapi-src/oneDNN/pull/1948.patch
+patch -p1 < onednn_enable_indirect_conv.patch
+wget -O onednn_enable_acl_indirect_conv_for_bf16.patch https://patch-diff.githubusercontent.com/raw/oneapi-src/oneDNN/pull/1933.patch
+patch -p1 < onednn_enable_acl_indirect_conv_for_bf16.patch
 
 cd $PACKAGE_DIR/$src_repo
 


### PR DESCRIPTION
Adds some functionality that was missing in the previous release:
- dynamic quantization in oneDNN
- fuse sum post-op in acl_matmul in oneDNN
- ACL's indirect conv enabled for any thread number (not just those > 28)
- ACL's indirect conv enabled for BF16 