### PR TITLE
Add Pytorch convolution static quantisation

### DIFF
--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -8,8 +8,11 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [Unreleased]
 
 ### Added
+- ACL and oneDNN patches to enable PyTorch static quantization for convolution.
+- ACL patch for mixed sign GEMM support
 
 ### Changed
+- Update ACL to Git hash: c2237ec
 
 ### Removed
 

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -139,7 +139,7 @@ ENV NP_MAKE="${njobs}" \
     ACL_ARCH="${acl_arch}"
 
 # Key version numbers
-ENV ACL_VERSION="4c3f716371da92977d4a998fe5c89dee04ddbced" \
+ENV ACL_VERSION="c2237ec4094c7824f8f7e61bc89504d01c5b59ff" \
     OPENBLAS_VERSION=0.3.27 \
     NINJA_VERSION=1.9.0
 
@@ -167,6 +167,7 @@ ENV LD_LIBRARY_PATH=$OPENBLAS_DIR/lib:$LD_LIBRARY_PATH
 
 # Build Arm Compute Library from source
 COPY scripts/build-acl.sh $PACKAGE_DIR/.
+COPY patches/acl_static_quantization.patch $PACKAGE_DIR/.
 
 RUN $PACKAGE_DIR/build-acl.sh
 ENV ACL_ROOT_DIR=$PROD_DIR/ComputeLibrary
@@ -282,9 +283,12 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 COPY scripts/build-pytorch.sh $PACKAGE_DIR/.
 COPY patches/onednn.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_thread_local_scheduler.patch $PACKAGE_DIR/.
+COPY patches/onednn_static_quantization.patch $PACKAGE_DIR/.
 COPY patches/torchvision.patch $PACKAGE_DIR/.
 COPY patches/ideep_dynamic_quantization.patch $PACKAGE_DIR/.
+COPY patches/ideep_static_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
+COPY patches/pytorch_static_quantization.patch $PACKAGE_DIR/.
 
 COPY scripts/build-torchvision.sh $PACKAGE_DIR/.
 COPY scripts/build-torchtext.sh $PACKAGE_DIR/.

--- a/docker/pytorch-aarch64/examples/README.md
+++ b/docker/pytorch-aarch64/examples/README.md
@@ -23,6 +23,18 @@ The file [resnet_v1-50.yml](resnet_v1-50.yml) provides, in [YAML format](https:/
 - `source`: URL from where to download saved checkpoint
 - `labels`: URL from where to download labels for the model.
 
+### Statically Quantized Convolution
+
+The script [static_quantize_conv.py](static_quantize_conv.py) demostrates Pytorch static quantization using the Post-Training Quantisation (PTQ) method with FX Graph Mode that automatically quantizes modules.
+
+To run inference on an image call:
+
+```
+python static_quantize_conv.py
+```
+
+This example outputs the execution time of an F32 single convolution model and the output of the same model, but then statically quantized. It also prints the Mean Square Error (MSE) between the results of the F32 model and the int8 model. With this example, we demonstrate that although the difference in performance can be pretty big, the difference between the L2 error result can be relatively small.
+
 ### Object detection
 
 The script [detect_objects.py](detect_object.py) demonstrates how to run inference using different models. Currently supported models are the SSD-ResNet-34 and RetinaNet (also known as ResNext50).

--- a/docker/pytorch-aarch64/examples/static_quantize_conv.py
+++ b/docker/pytorch-aarch64/examples/static_quantize_conv.py
@@ -1,0 +1,122 @@
+# *******************************************************************************
+# Copyright 2024 Arm Limited and affiliates.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# *******************************************************************************
+"""
+This example showcases Pytorch static quantization using the Post-Training
+Quantisation (PTQ) method with FX Graph Mode that automatically quantizes modules.
+"""
+import numpy as np
+
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import torch.nn.init as init
+
+import torch
+from torch.ao.quantization import get_default_qconfig_mapping, default_symmetric_qnnpack_qconfig, get_default_qconfig
+from torch.ao.quantization import QConfig, QConfigMapping
+from torch.ao.quantization.quantize_fx import prepare_fx, convert_fx
+from torch.ao.quantization.observer import MinMaxObserver, default_observer
+
+from time import time
+
+torch.manual_seed(42)
+
+from torch.ao.quantization.backend_config import (
+    BackendConfig,
+    BackendPatternConfig,
+    DTypeConfig,
+    ObservationType,
+)
+
+weighted_int8_dtype_config = DTypeConfig(
+    input_dtype=torch.qint8,
+    output_dtype=torch.qint8,
+    weight_dtype=torch.qint8,
+    bias_dtype=torch.qint32)
+
+# For quantizing convolution
+conv2d_config = BackendPatternConfig(torch.nn.Conv2d) \
+    .set_observation_type(ObservationType.OUTPUT_USE_DIFFERENT_OBSERVER_AS_INPUT) \
+    .add_dtype_config(weighted_int8_dtype_config) \
+    .set_root_module(torch.nn.Conv2d) \
+    .set_qat_module(torch.ao.nn.qat.Conv2d) \
+    .set_reference_quantized_module(torch.ao.nn.quantized.reference.Conv2d)
+
+aarch64_backend_config = BackendConfig("aarch64") \
+    .set_backend_pattern_config(conv2d_config)
+
+# model to be quantized
+class Net(nn.Module):
+    def __init__(self):
+        super(Net, self).__init__()
+
+        self.conv1 = nn.Conv2d(3, 64, 7, 7)
+
+        self._initialize_weights()
+
+    def forward(self, x):
+        x = self.conv1(x)
+        return x
+
+    def _initialize_weights(self):
+        init.uniform_(self.conv1.weight)
+
+model = Net()
+
+my_qconfig = QConfigMapping().set_global(default_symmetric_qnnpack_qconfig)
+
+# generate some fake data
+data = torch.randn(8, 3, 896, 896)
+
+# warm-up
+model = model.eval()
+model(data)
+
+# run the model in f32
+times = []
+with torch.no_grad():
+    for _ in range(100):
+        start = time()
+        x = model(data)
+        times.append(time() - start)
+print("F32 average time: %.4fms" %(np.average(times)*1e3))
+
+# do fake quantization where the parameters are calculated but everything is still f32.
+# That is why it is called "fake"
+model_prepared = prepare_fx(model, my_qconfig, data, None, None, aarch64_backend_config)
+# the prepared model uses HistogramObserver observer that derives the quantization parameters by creating a histogram
+# of running minimums and maximums. More options here:
+# https://glaringlee.github.io/quantization.html#:~:text=Observers%20for%20computing%20the%20quantization%20parameters
+
+# calibrate using the data
+model_prepared(data) # we need this to calculate the quantised parameters for the activations
+
+# do the real quantization here based on the parameters, scale and zero point, calculated in the previous step
+model_quantized = convert_fx(model_prepared, qconfig_mapping=my_qconfig, backend_config=aarch64_backend_config)
+model_quantized.eval()
+
+# run the model in qunatized mode (int8)
+quantized_times = []
+with torch.no_grad():
+    for _ in range(100):
+        start = time()
+        y = model_quantized(data)
+        quantized_times.append(time() - start)
+print("Quantized average time: %.4fms" % (np.average(quantized_times)*1e3))
+
+# comparing the results
+print("L2 error between f32 and s8: %.4f" % (((x-y)**2).mean()))

--- a/docker/pytorch-aarch64/examples/utils/image.py
+++ b/docker/pytorch-aarch64/examples/utils/image.py
@@ -34,7 +34,7 @@ import cv2
 from . import common
 
 
-def _download_image(image_loc):
+def download_image(image_loc):
     """
     Download image to file
     :param image_loc: URL or path for the image
@@ -82,7 +82,7 @@ def _preprocess_image_for_classification(image_url, model_descriptor):
     :param model_descriptor: Parsed yaml file describing model
     :returns: Preprocessed image for image classification
     """
-    image_file = _download_image(image_url)
+    image_file = download_image(image_url)
 
     input_image = Image.open(image_file)
     preprocess = transforms.Compose(
@@ -108,7 +108,7 @@ def _preprocess_image_for_detection(image_url, model_descriptor):
     :param model_descriptor: Parsed yaml file describing model
     :returns: Preprocess image for object detection
     """
-    image_file = _download_image(image_url)
+    image_file = download_image(image_url)
 
     input_image = cv2.imread(image_file)
 

--- a/docker/pytorch-aarch64/patches/acl_static_quantization.patch
+++ b/docker/pytorch-aarch64/patches/acl_static_quantization.patch
@@ -1,0 +1,785 @@
+*******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/examples/neon_gemm_qasymm8_signed.cpp b/examples/neon_gemm_qasymm8_signed.cpp
+new file mode 100644
+index 000000000..59666a786
+--- /dev/null
++++ b/examples/neon_gemm_qasymm8_signed.cpp
+@@ -0,0 +1,249 @@
++/*
++ * Copyright (c) 2020-2021,2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++#include "arm_compute/core/Types.h"
++#include "arm_compute/core/utils/quantization/AsymmHelpers.h"
++#include "arm_compute/core/WindowIterator.h"
++#include "arm_compute/runtime/NEON/NEFunctions.h"
++#include "arm_compute/runtime/NEON/NEScheduler.h"
++
++#include "support/ToolchainSupport.h"
++#include "utils/Utils.h"
++
++#include <cstdlib>
++#include <stdlib.h>
++
++using namespace arm_compute;
++using namespace utils;
++
++// Find min and max value in a float array
++void find_min_max(int size, const float *data, float *min, float *max)
++{
++    *min = *max = data[0];
++    for (int i = 0; i < size; i++)
++    {
++        const float val = data[i];
++        *min            = std::min(*min, val);
++        *max            = std::max(*max, val);
++    }
++}
++
++// Return reasonable quantisation parameters to use for an array of floats
++// based on min and max values
++QuantizationInfo choose_quantization_params(float min, float max)
++{
++    // Extend the [min,max] interval to contain 0 so we can represent it exactly
++    min = std::min(min, 0.f);
++    max = std::max(max, 0.f);
++
++    // Set the quantized min and max in float values
++    const float qmin = -128;
++    const float qmax = 127;
++
++    // Determine the scale
++    const float scale = (max - min) / (qmax - qmin);
++
++    // Determine the zero-point; using affine equation val = (qval-zerop) * scale
++    const float zero_point_real = qmin - min / scale;
++
++    // But we need to nudge the zero_point to an integer (exact quantized value)
++    std::int8_t zero_point_nudged = 0;
++    if (zero_point_real < qmin)
++    {
++        zero_point_nudged = qmin;
++    }
++    else if (zero_point_real > qmax)
++    {
++        zero_point_nudged = qmax;
++    }
++    else
++    {
++        zero_point_nudged = static_cast<std::int8_t>(support::cpp11::round(zero_point_real));
++    }
++
++    QuantizationInfo qinfo = QuantizationInfo(scale, zero_point_nudged);
++    return qinfo;
++}
++
++void invert_qinfo_offset(Tensor &t)
++{
++    QuantizationInfo qinfo = t.info()->quantization_info();
++    t.info()->set_quantization_info(QuantizationInfo(qinfo.scale()[0], -qinfo.offset()[0], qinfo.is_dynamic()));
++}
++
++int main(int argc, char **argv)
++{
++    Tensor src1;
++    Tensor src2;
++    Tensor dst0;
++    Tensor q_src1;
++    Tensor q_src2;
++    Tensor q_dst0;
++    Tensor q_res;
++    Tensor q_res_output;
++    size_t M = 4;
++    size_t N = 4;
++    size_t K = 4;
++
++    // Parse args
++    if (argc < 3) /* case default matrix sizes */
++    {
++        // Print help
++        std::cout << "Usage: ./build/neon_gemm_qasymm8_signed M N K\n";
++        std::cout << "Too few or no inputs provided. Using default M=4, N=4, K=4\n\n";
++    }
++    else /* case M N K arguments provided */
++    {
++        M = strtol(argv[1], nullptr, 10);
++        N = strtol(argv[2], nullptr, 10);
++        K = strtol(argv[3], nullptr, 10);
++    }
++
++    /*** Floating point matrix multiplication ***/
++
++    // Initialise input matrices
++    NEGEMM fgemm{};
++
++    src1.allocator()->init(TensorInfo(TensorShape(K, M), 1, DataType::F32));
++    src2.allocator()->init(TensorInfo(TensorShape(N, K), 1, DataType::F32));
++    dst0.allocator()->init(TensorInfo(TensorShape(N, M), 1, DataType::F32));
++    fgemm.configure(&src1, &src2, nullptr, &dst0, 1, 0);
++
++    // Allocate matrices
++    src1.allocator()->allocate();
++    src2.allocator()->allocate();
++    dst0.allocator()->allocate();
++
++    // Fill in tensors, by default fill in with known data - for easy testing
++    auto *src1_ptr = reinterpret_cast<float *>(src1.buffer());
++    auto *src2_ptr = reinterpret_cast<float *>(src2.buffer());
++    auto *dst0_ptr = reinterpret_cast<float *>(dst0.buffer());
++
++    // Fill in with random values
++    fill_random_tensor(src1, -1.f, 1.f);
++    fill_random_tensor(src2, -1.f, 1.f);
++
++    // Run single precision gemm and print result
++    fgemm.run();
++
++#if ARM_COMPUTE_DEBUG_ENABLED
++    std::cout << "Result matrix:\n";
++    src1.print(std::cout);
++    src2.print(std::cout);
++    dst0.print(std::cout);
++#endif // ARM_COMPUTE_DEBUG_ENABLED
++
++    /*** Quantised asymmetric 8bit matrix multiplication ***/
++
++    // Start by finding the quantisation parameters for each set of values
++    float src1_min;
++    float src1_max;
++    float src2_min;
++    float src2_max;
++    float dst0_min;
++    float dst0_max;
++
++    find_min_max(M * K, src1_ptr, &src1_min, &src1_max);
++    find_min_max(K * N, src2_ptr, &src2_min, &src2_max);
++    find_min_max(M * N, dst0_ptr, &dst0_min, &dst0_max);
++
++    const QuantizationInfo src1_qinfo = choose_quantization_params(src1_min, src1_max);
++    const QuantizationInfo src2_qinfo = choose_quantization_params(src2_min, src2_max);
++    const QuantizationInfo dst0_qinfo = choose_quantization_params(dst0_min, dst0_max);
++
++    std::cout << "Matrix 1: min=" << src1_min << ", max=" << src1_max << ", ";
++    std::cout << "QuantisationInfo(" << src1_qinfo.scale()[0] << ", " << src1_qinfo.offset()[0] << ")\n";
++    std::cout << "Matrix 2: min=" << src2_min << ", max=" << src2_max << ", ";
++    std::cout << "QuantisationInfo(" << src2_qinfo.scale()[0] << ", " << src2_qinfo.offset()[0] << ")\n";
++    std::cout << "Result  : min=" << dst0_min << ", max=" << dst0_max << ", ";
++    std::cout << "QuantisationInfo(" << dst0_qinfo.scale()[0] << ", " << dst0_qinfo.offset()[0] << ")\n";
++
++    // We now have the quantisation info and can configure the quantised tensors
++    q_src1.allocator()->init(TensorInfo(TensorShape(K, M), 1, DataType::QASYMM8_SIGNED, src1_qinfo));
++    q_src2.allocator()->init(TensorInfo(TensorShape(N, K), 1, DataType::QASYMM8_SIGNED, src2_qinfo));
++    q_dst0.allocator()->init(TensorInfo(TensorShape(N, M), 1, DataType::QASYMM8_SIGNED, dst0_qinfo));
++
++    // In this approach we use the QuantizationLayer construct to perform quantization
++    NEQuantizationLayer q1;
++    NEQuantizationLayer q2;
++    NEQuantizationLayer q3;
++    q1.configure(&src1, &q_src1);
++    q2.configure(&src2, &q_src2);
++    q3.configure(&dst0, &q_dst0);
++
++    // Allocate all tensors
++    q_src1.allocator()->allocate();
++    q_src2.allocator()->allocate();
++    q_dst0.allocator()->allocate();
++
++    // Run quantization layers (quantizes values of each tensor)
++    q1.run();
++    q2.run();
++    q3.run();
++
++    // Configure low precision gemm and initialise result tensor (pre-output)
++    NEGEMMLowpMatrixMultiplyCore qgemm;
++    q_res.allocator()->init(TensorInfo(TensorShape(N, M), 1, DataType::QASYMM8_SIGNED, dst0_qinfo));
++    q_res.allocator()->allocate();
++
++    invert_qinfo_offset(q_src1);
++    invert_qinfo_offset(q_src2);
++
++    // Configure output stage after computing shift and multiplier parameters
++    int   output_multiplier;
++    int   output_shift;
++    float multiplier = (src1_qinfo.uniform().scale * src2_qinfo.uniform().scale) / dst0_qinfo.uniform().scale;
++    quantization::calculate_quantized_multiplier_less_than_one(multiplier, &output_multiplier, &output_shift);
++    std::cout << "(q_multiplier, q_shift) = (" << output_multiplier << ", " << output_shift << ")\n\n";
++
++    GEMMLowpOutputStageInfo info;
++    info.type                = GEMMLowpOutputStageType::QUANTIZE_DOWN_FIXEDPOINT;
++    info.gemmlowp_multiplier = output_multiplier;
++    info.gemmlowp_shift      = output_shift;
++    info.gemmlowp_offset     = dst0_qinfo.uniform().offset;
++    info.gemmlowp_min_bound  = -128;
++    info.gemmlowp_max_bound  = 127;
++    info.output_data_type    = DataType::QASYMM8_SIGNED;
++    GEMMInfo gemm_info = GEMMInfo(false, false, true, 2, false, false, info, false, false, false, ActivationLayerInfo(),
++                                  false, arm_compute::WeightFormat::UNSPECIFIED, false);
++    qgemm.configure(&q_src1, &q_src2, nullptr, &q_res, gemm_info);
++
++    std::cout << "(q_multiplier, q_shift) = (" << info.gemmlowp_multiplier << ", " << info.gemmlowp_shift
++              << ") dst0_qinfo.uniform().offset = " << dst0_qinfo.uniform().offset << "\n\n";
++
++    // Run low precision matrix multiply kernel
++    qgemm.run();
++    std::cout << "\nTest Executed!\n";
++#if ARM_COMPUTE_DEBUG_ENABLED
++    // Print quantized source matrices
++    std::cout << "Quantized matrices:\n";
++    q_src1.print(std::cout);
++    q_src2.print(std::cout);
++    // Print result matrix in int32 form - before output stage processing
++    std::cout << "Lowp GEMM output:\n";
++    q_res.print(std::cout);
++    // Expected result
++    std::cout << "Expected result:\n";
++    q_dst0.print(std::cout);
++#endif // ARM_COMPUTE_DEBUG_ENABLED
++}
+diff --git a/src/core/NEON/kernels/arm_gemm/gemm_hybrid_indirect.hpp b/src/core/NEON/kernels/arm_gemm/gemm_hybrid_indirect.hpp
+index 8bbb877c1..fa034e812 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemm_hybrid_indirect.hpp
++++ b/src/core/NEON/kernels/arm_gemm/gemm_hybrid_indirect.hpp
+@@ -276,8 +276,8 @@ class GemmHybridIndirect : public GemmCommon<To, Tw, Tr> {
+     const unsigned int _rounded_Ksize;
+
+     /* Blocking info */
++    unsigned int _n_block;
+     const unsigned int _k_block;
+-    const unsigned int _n_block;
+     const unsigned int _Mround;
+
+     /* Pretransposed buffer. */
+@@ -389,7 +389,7 @@ public:
+     GemmHybridIndirect(const GemmArgs &args, const OutputStage &os)
+               : _args(args), _os(os), _Ktotal(get_ktotal(args)),
+                 _rounded_Ksize(roundup(args._Ksize, strategy::k_unroll())),
+-                _k_block(compute_k_block(args)), _n_block(compute_n_block(args, os)),
++                _n_block(compute_n_block(args, os)), _k_block(compute_k_block(args)),
+                 _Mround(roundup(args._Msize, strategy::out_height())),
+                 _window_range(iceildiv(args._Msize, strategy::out_height()), args._nbatches,
+                               iceildiv(args._Nsize, _n_block), args._nmulti)
+@@ -403,7 +403,7 @@ public:
+     GemmHybridIndirect(const GemmArgs &args)
+               : _args(args), _Ktotal(get_ktotal(args)),
+                 _rounded_Ksize(roundup(args._Ksize, strategy::k_unroll())),
+-                _k_block(compute_k_block(args)), _n_block(compute_n_block(args)),
++                _n_block(compute_n_block(args)), _k_block(compute_k_block(args)),
+                 _Mround(roundup(args._Msize, strategy::out_height())),
+                 _window_range(iceildiv(args._Msize, strategy::out_height()), args._nbatches,
+                               iceildiv(args._Nsize, _n_block), args._nmulti)
+@@ -832,6 +832,26 @@ public:
+
+         return c;
+     }
++
++    void update_quantization_parameters(const Requantize32 &re) override {
++        if (std::is_same<OutputStage, Requantize32>::value) {
++            Requantize32 *qp = reinterpret_cast<Requantize32 *>(&_os);
++            qp->bias = re.bias;
++            qp->a_offset = re.a_offset;
++            qp->b_offset = re.b_offset;
++            qp->c_offset = re.c_offset;
++            qp->per_layer_left_shift = re.per_layer_left_shift;
++            qp->per_layer_right_shift = re.per_layer_right_shift;
++            qp->per_layer_mul = re.per_layer_mul;
++            qp->per_channel_requant = re.per_channel_requant;
++            qp->per_channel_left_shifts = re.per_channel_left_shifts;
++            qp->per_channel_right_shifts = re.per_channel_right_shifts;
++            qp->per_channel_muls = re.per_channel_muls;
++            qp->minval = re.minval;
++            qp->maxval = re.maxval;
++            _n_block = compute_n_block(_args, _os);
++        }
++    }
+ };
+
+ template<typename strategy, typename To, typename Tr, typename OutputStage=Nothing>
+diff --git a/src/core/NEON/kernels/arm_gemm/gemm_hybrid_quantized_inline.hpp b/src/core/NEON/kernels/arm_gemm/gemm_hybrid_quantized_inline.hpp
+index 820b54202..d044bb8a9 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemm_hybrid_quantized_inline.hpp
++++ b/src/core/NEON/kernels/arm_gemm/gemm_hybrid_quantized_inline.hpp
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2017-2019,2021 Arm Limited.
++ * Copyright (c) 2017-2019,2021,2024 Arm Limited.
+  *
+  * SPDX-License-Identifier: MIT
+  *
+@@ -264,6 +264,27 @@ public:
+         _qp.bias = bias;
+         _qp.bias_multi_stride = bias_multi_stride;
+     }
++
++    void update_quantization_parameters(const Requantize32 &re) override {
++        if (std::is_same<OutputStage, Requantize32>::value) {
++            Requantize32 *qp = reinterpret_cast<Requantize32 *>(&_os);
++            qp->bias = re.bias;
++            qp->a_offset = re.a_offset;
++            qp->b_offset = re.b_offset;
++            qp->c_offset = re.c_offset;
++            qp->per_layer_left_shift = re.per_layer_left_shift;
++            qp->per_layer_right_shift = re.per_layer_right_shift;
++            qp->per_layer_mul = re.per_layer_mul;
++            qp->per_channel_requant = re.per_channel_requant;
++            qp->per_channel_left_shifts = re.per_channel_left_shifts;
++            qp->per_channel_right_shifts = re.per_channel_right_shifts;
++            qp->per_channel_muls = re.per_channel_muls;
++            qp->minval = re.minval;
++            qp->maxval = re.maxval;
++            qp->is_dynamic = re.is_dynamic;
++            _n_block = compute_n_block(_args, _os);
++        }
++    }
+ };
+
+ } // namespace arm_gemm
+diff --git a/src/core/NEON/kernels/arm_gemm/gemm_interleaved.hpp b/src/core/NEON/kernels/arm_gemm/gemm_interleaved.hpp
+index 5214a71cc..25570a5f6 100644
+--- a/src/core/NEON/kernels/arm_gemm/gemm_interleaved.hpp
++++ b/src/core/NEON/kernels/arm_gemm/gemm_interleaved.hpp
+@@ -1362,6 +1362,26 @@ public:
+
+         return c;
+     }
++
++
++    void update_quantization_parameters(const Requantize32 &re) override {
++        if (std::is_same<OutputStage, Requantize32>::value) {
++            Requantize32 *qp = reinterpret_cast<Requantize32 *>(&_os);
++            qp->bias = re.bias;
++            qp->a_offset = re.a_offset;
++            qp->b_offset = re.b_offset;
++            qp->c_offset = re.c_offset;
++            qp->per_layer_left_shift = re.per_layer_left_shift;
++            qp->per_layer_right_shift = re.per_layer_right_shift;
++            qp->per_layer_mul = re.per_layer_mul;
++            qp->per_channel_requant = re.per_channel_requant;
++            qp->per_channel_left_shifts = re.per_channel_left_shifts;
++            qp->per_channel_right_shifts = re.per_channel_right_shifts;
++            qp->per_channel_muls = re.per_channel_muls;
++            qp->minval = re.minval;
++            qp->maxval = re.maxval;
++        }
++    }
+ };
+
+ // Aliases for the variations
+diff --git a/src/cpu/kernels/CpuGemmLowpOffsetContributionKernel.cpp b/src/cpu/kernels/CpuGemmLowpOffsetContributionKernel.cpp
+index 2a76a5958..eb6ccfb37 100644
+--- a/src/cpu/kernels/CpuGemmLowpOffsetContributionKernel.cpp
++++ b/src/cpu/kernels/CpuGemmLowpOffsetContributionKernel.cpp
+@@ -51,7 +51,8 @@ Status validate_arguments(const ITensorInfo *mm_result,
+                           int32_t            a_offset,
+                           int32_t            b_offset)
+ {
+-    ARM_COMPUTE_RETURN_ERROR_ON_DATA_TYPE_CHANNEL_NOT_IN(mm_result, 1, DataType::S32, DataType::F32);
++    ARM_COMPUTE_RETURN_ERROR_ON_DATA_TYPE_CHANNEL_NOT_IN(mm_result, 1, DataType::QASYMM8, DataType::QASYMM8_SIGNED,
++                                                         DataType::S32, DataType::F32);
+
+     // We run if the offset is nonzero or a sum col has been provided, we need
+     // the second option in case the QuantizationInfo is dynamic
+diff --git a/src/cpu/kernels/CpuWeightsReshapeKernel.cpp b/src/cpu/kernels/CpuWeightsReshapeKernel.cpp
+index 297ba6382..f8e9d123b 100644
+--- a/src/cpu/kernels/CpuWeightsReshapeKernel.cpp
++++ b/src/cpu/kernels/CpuWeightsReshapeKernel.cpp
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2017-2021 Arm Limited.
++ * Copyright (c) 2017-2021,2024 Arm Limited.
+  *
+  * SPDX-License-Identifier: MIT
+  *
+@@ -72,7 +72,10 @@ Status validate_arguments(const ITensorInfo *src, const ITensorInfo *biases, con
+         ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_DIMENSIONS(dst->tensor_shape(),
+                                                            get_output_shape(src, biases != nullptr));
+         ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_DATA_TYPES(src, dst);
+-        ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_QUANTIZATION_INFO(src, dst);
++        if (!src->quantization_info().is_dynamic())
++        {
++            ARM_COMPUTE_RETURN_ERROR_ON_MISMATCHING_QUANTIZATION_INFO(src, dst);
++        }
+     }
+
+     return Status{};
+diff --git a/src/cpu/kernels/assembly/gemm_common.hpp b/src/cpu/kernels/assembly/gemm_common.hpp
+index 6c25d0757..dc6183413 100644
+--- a/src/cpu/kernels/assembly/gemm_common.hpp
++++ b/src/cpu/kernels/assembly/gemm_common.hpp
+@@ -35,6 +35,7 @@ namespace arm_gemm
+ {
+ // Avoid circular dependency with arm_gemm.hpp
+ struct GemmConfig;
++struct Requantize32;
+
+ // Abstract class for the GEMM/GEMV functions.
+ //
+@@ -160,6 +161,12 @@ public:
+     {
+     }
+
++    /*** "Quantization update" interface (optional) ***/
++    /* Update quantization parameters ar run time */
++    virtual void update_quantization_parameters(const Requantize32 &)
++    {
++    }
++
+     /*** Convolution interface (optional) ***/
+     /* Set the convolution parameters. */
+     virtual void set_convolution_parameters(ConvolutionParameters)
+diff --git a/src/cpu/operators/CpuGemmConv2d.cpp b/src/cpu/operators/CpuGemmConv2d.cpp
+index 55d950ff4..feb4a0ee7 100644
+--- a/src/cpu/operators/CpuGemmConv2d.cpp
++++ b/src/cpu/operators/CpuGemmConv2d.cpp
+@@ -227,7 +227,11 @@ CpuGemmConv2d::CpuGemmConv2d()
+       _is_prepared(false),
+       _wt_method(WeightTransformMethod::ReshapeThenTranspose),
+       _run_wt(true),
+-      _aux_mem(AuxTensorIdx::Count)
++      _aux_mem(AuxTensorIdx::Count),
++      _retain_internal_weights(false),
++      _min_activation(0),
++      _max_activation(0),
++      _gemm_info{}
+ {
+ }
+ CpuGemmConv2d::~CpuGemmConv2d() = default;
+@@ -275,27 +279,28 @@ void CpuGemmConv2d::configure_mm(const ITensorInfo         *src,
+         PixelValue type_min{};
+         PixelValue type_max{};
+         std::tie(type_min, type_max) = get_min_max(data_type);
+-        int32_t min_activation       = type_min.get<int32_t>();
+-        int32_t max_activation       = type_max.get<int32_t>();
++        _min_activation              = type_min.get<int32_t>();
++        _max_activation              = type_max.get<int32_t>();
+
+         if (supported_acts.count(act_info.activation()) != 0)
+         {
+-            std::tie(min_activation, max_activation) = get_quantized_activation_min_max(act_info, data_type, uoqinfo);
++            std::tie(_min_activation, _max_activation) = get_quantized_activation_min_max(act_info, data_type, uoqinfo);
+         }
+
+         GEMMLowpOutputStageInfo output_info;
+         output_info.type                     = GEMMLowpOutputStageType::QUANTIZE_DOWN_FIXEDPOINT;
+         output_info.gemmlowp_offset          = uoqinfo.offset;
+-        output_info.gemmlowp_min_bound       = min_activation;
+-        output_info.gemmlowp_max_bound       = max_activation;
++        output_info.gemmlowp_min_bound       = _min_activation;
++        output_info.gemmlowp_max_bound       = _max_activation;
+         output_info.is_quantized_per_channel = (tmp_weights.data_type() == DataType::QSYMM8_PER_CHANNEL);
+         quantization::calculate_quantized_multipliers(iqinfo, wqinfo, oqinfo, output_info);
+
++        _gemm_info =
++            GEMMInfo(false, false, true, gemm_3d_depth, _skip_im2col, false, output_info, false, enable_fast_math,
++                     false, act_info, fixed_format, weight_format, false /* pretranspose_B. TODO: COMPMID-6596 */);
++
+         _mm_gemmlowp = std::make_unique<CpuGemmLowpMatrixMultiplyCore>();
+-        _mm_gemmlowp->configure(&tmp_src, &tmp_weights, biases, dst,
+-                                GEMMInfo(false, false, true, gemm_3d_depth, _skip_im2col, false, output_info, false,
+-                                         enable_fast_math, false, act_info, fixed_format, weight_format,
+-                                         false /* pretranspose_B. TODO: COMPMID-6596 */));
++        _mm_gemmlowp->configure(&tmp_src, &tmp_weights, biases, dst, _gemm_info);
+
+         auto mm_mem_req = _mm_gemmlowp->workspace();
+         for (unsigned int cont = 0; cont < mm_mem_req.size(); ++cont)
+@@ -445,10 +450,11 @@ void CpuGemmConv2d::configure(const ITensorInfo         *src,
+     const unsigned int kernel_width  = weights->dimension(idx_width);
+     const unsigned int kernel_height = weights->dimension(idx_height);
+
+-    _is_prepared  = weights_info.retain_internal_weights();
+-    _is_quantized = is_data_type_quantized_asymmetric(src->data_type());
+-    _data_layout  = data_layout;
+-    _skip_im2col  = (data_layout == DataLayout::NHWC && kernel_width == 1 && kernel_height == 1 &&
++    _retain_internal_weights = weights_info.retain_internal_weights();
++    _is_prepared             = _retain_internal_weights;
++    _is_quantized            = is_data_type_quantized_asymmetric(src->data_type());
++    _data_layout             = data_layout;
++    _skip_im2col             = (data_layout == DataLayout::NHWC && kernel_width == 1 && kernel_height == 1 &&
+                     conv_info.stride().first == 1 && conv_info.stride().second == 1);
+
+     const ITensorInfo *gemm_input_to_use  = src;
+@@ -796,12 +802,46 @@ Status CpuGemmConv2d::validate(const ITensorInfo         *src,
+
+ void CpuGemmConv2d::run(ITensorPack &tensors)
+ {
+-    prepare(tensors);
+-
+     auto src               = tensors.get_const_tensor(ACL_SRC_0);
+     auto dst               = tensors.get_tensor(ACL_DST);
+     auto gemm_input_to_use = src;
+
++    if (_is_quantized && src->info()->quantization_info().is_dynamic())
++    {
++        auto       wei = tensors.get_const_tensor(TensorType::ACL_SRC_1);
++        TensorInfo tmp_src{*src->info()};
++        TensorInfo tmp_weights{*wei->info()};
++
++        const QuantizationInfo iqinfo = src->info()->quantization_info();
++        const QuantizationInfo wqinfo = wei->info()->quantization_info();
++        const QuantizationInfo oqinfo = (dst->info()->total_size() == 0) ? iqinfo : dst->info()->quantization_info();
++        const UniformQuantizationInfo uiqinfo   = iqinfo.uniform();
++        const UniformQuantizationInfo uoqinfo   = oqinfo.uniform();
++        const DataType                data_type = src->info()->data_type();
++
++        if (!is_data_type_quantized_per_channel(tmp_weights.data_type()))
++        {
++            const UniformQuantizationInfo uwqinfo = wqinfo.uniform();
++            tmp_weights.set_quantization_info(QuantizationInfo(uwqinfo.scale, -uwqinfo.offset));
++        }
++
++        GEMMLowpOutputStageInfo output_info;
++        output_info.type                     = GEMMLowpOutputStageType::QUANTIZE_DOWN_FIXEDPOINT;
++        output_info.gemmlowp_offset          = uoqinfo.offset;
++        output_info.gemmlowp_min_bound       = _min_activation;
++        output_info.gemmlowp_max_bound       = _max_activation;
++        output_info.is_quantized_per_channel = (tmp_weights.data_type() == DataType::QSYMM8_PER_CHANNEL);
++        quantization::calculate_quantized_multipliers(iqinfo, wqinfo, oqinfo, output_info);
++
++        // maybe it is needed to run prepare again
++        _is_prepared = _retain_internal_weights;
++
++        _mm_gemmlowp->update_quantization_parameters(output_info, src->info()->quantization_info(),
++                                                     wei->info()->quantization_info(), _is_prepared);
++    }
++
++    prepare(tensors);
++
+     CpuAuxTensorHandler im2col_output(offset_int_vec(Im2ColOutput), _im2col_output, tensors, false);
+     CpuAuxTensorHandler gemm_output(offset_int_vec(GemmOutput), _gemm_output, tensors, false);
+
+@@ -868,6 +908,16 @@ void CpuGemmConv2d::run(ITensorPack &tensors)
+         gemm_pack.add_const_tensor(TensorType::ACL_SRC_1, reshaped_wei.get());
+     }
+
++    if (_is_quantized && src->info()->quantization_info().is_dynamic())
++    {
++        auto _src = gemm_pack.get_const_tensor(ACL_SRC_0);
++        auto _wei = gemm_pack.get_const_tensor(TensorType::ACL_SRC_1);
++        auto wei  = tensors.get_const_tensor(TensorType::ACL_SRC_1);
++
++        _src->info()->set_quantization_info(src->info()->quantization_info());
++        _wei->info()->set_quantization_info(wei->info()->quantization_info());
++    }
++
+     // Runs CpuGemm or CpuGemmLowpMatrixMultiplyCore functions
+     _is_quantized ? _mm_gemmlowp->run(gemm_pack) : _mm_gemm->run(gemm_pack);
+
+diff --git a/src/cpu/operators/CpuGemmConv2d.h b/src/cpu/operators/CpuGemmConv2d.h
+index ae5023a71..e0882ed79 100644
+--- a/src/cpu/operators/CpuGemmConv2d.h
++++ b/src/cpu/operators/CpuGemmConv2d.h
+@@ -293,6 +293,11 @@ private:
+     bool                  _is_prepared;
+     WeightTransformMethod _wt_method;
+     bool                  _run_wt;
++    bool                  _retain_internal_weights;
++    int32_t               _min_activation;
++    int32_t               _max_activation;
++
++    GEMMInfo _gemm_info;
+
+     experimental::MemoryRequirements _aux_mem{Count};
+ };
+diff --git a/src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.cpp b/src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.cpp
+index f3396fbb5..41d10c522 100644
+--- a/src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.cpp
++++ b/src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.cpp
+@@ -614,7 +614,6 @@ void CpuGemmLowpMatrixMultiplyCore::run(ITensorPack &tensors)
+     if (_asm_glue->is_configured())
+     {
+         ITensorPack asm_glue_tensors = tensors;
+-        auto        output_to_use    = (_fuse_output_stage ? mm_result_s32.get() : dst);
+         if (is_data_type_quantized_asymmetric(a_to_use->info()->data_type()) &&
+             _gemm_info.gemmlowp_output_stage().type == GEMMLowpOutputStageType::QUANTIZE_DOWN_FIXEDPOINT)
+         {
+@@ -625,6 +624,7 @@ void CpuGemmLowpMatrixMultiplyCore::run(ITensorPack &tensors)
+         }
+         else
+         {
++            auto output_to_use = (_fuse_output_stage ? mm_result_s32.get() : dst);
+             asm_glue_tensors.add_const_tensor(TensorType::ACL_SRC_0, a_to_use);
+             asm_glue_tensors.add_const_tensor(TensorType::ACL_SRC_1, b);
+             asm_glue_tensors.add_tensor(TensorType::ACL_DST, output_to_use);
+@@ -775,5 +775,25 @@ experimental::MemoryRequirements CpuGemmLowpMatrixMultiplyCore::workspace() cons
+ {
+     return _aux_mem;
+ }
++
++void CpuGemmLowpMatrixMultiplyCore::update_quantization_parameters(const GEMMLowpOutputStageInfo &output_info,
++                                                                   const QuantizationInfo        &a,
++                                                                   const QuantizationInfo        &b,
++                                                                   const bool                     is_prepared)
++{
++    auto lowp_os                     = _gemm_info.gemmlowp_output_stage();
++    lowp_os.gemmlowp_offset          = output_info.gemmlowp_offset;
++    lowp_os.gemmlowp_min_bound       = output_info.gemmlowp_min_bound;
++    lowp_os.gemmlowp_max_bound       = output_info.gemmlowp_max_bound;
++    lowp_os.is_quantized_per_channel = output_info.is_quantized_per_channel;
++    lowp_os.output_data_type         = output_info.output_data_type;
++    lowp_os.gemmlowp_multipliers     = output_info.gemmlowp_multipliers;
++    lowp_os.gemmlowp_shifts          = output_info.gemmlowp_shifts;
++    lowp_os.gemmlowp_multiplier      = output_info.gemmlowp_multiplier;
++    lowp_os.gemmlowp_shift           = output_info.gemmlowp_shift;
++    _gemm_info.set_gemmlowp_output_stage(lowp_os);
++    _asm_glue->update_quantization_parameters(output_info, a, b, is_prepared, false);
++    _is_prepared = is_prepared;
++}
+ } // namespace cpu
+ } // namespace arm_compute
+diff --git a/src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.h b/src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.h
+index 11fe6f9ef..e35576bb8 100644
+--- a/src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.h
++++ b/src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.h
+@@ -133,6 +133,10 @@ public:
+     void                             run(ITensorPack &tensors) override;
+     void                             prepare(ITensorPack &tensors) override;
+     experimental::MemoryRequirements workspace() const override;
++    void                             update_quantization_parameters(const GEMMLowpOutputStageInfo &output_info,
++                                                                    const QuantizationInfo        &a,
++                                                                    const QuantizationInfo        &b,
++                                                                    const bool                     is_prepared);
+
+ private:
+     enum AuxTensorIdx
+diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+index 9eb1ca033..39b8a75a4 100644
+--- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
++++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.cpp
+@@ -218,6 +218,37 @@ public:
+         return wf != arm_compute::WeightFormat::UNSPECIFIED && wf != arm_compute::WeightFormat::ANY;
+     }
+
++    void update_quantization_parameters(const GEMMLowpOutputStageInfo &output_info,
++                                        const QuantizationInfo        &a,
++                                        const QuantizationInfo        &b,
++                                        const bool                     is_prepared,
++                                        const bool                     negated_offsets) override
++    {
++        const int32_t negation = negated_offsets ? 1 : -1;
++        const int32_t a_offset = -a.uniform().offset * negation;
++        const int32_t b_offset = -b.uniform().offset * negation;
++
++        arm_gemm::Requantize32 gemm_requant_info{};
++        if (output_info.gemmlowp_shifts.size() > 1)
++        {
++            const auto requantize_data =
++                this->set_requantize_data(output_info.gemmlowp_multipliers, output_info.gemmlowp_shifts);
++            gemm_requant_info = arm_gemm::Requantize32(
++                nullptr, 0, a_offset, b_offset, output_info.gemmlowp_offset,
++                (std::get<0>(requantize_data)) ? std::get<1>(requantize_data) : nullptr, std::get<2>(requantize_data),
++                std::get<3>(requantize_data), output_info.gemmlowp_min_bound, output_info.gemmlowp_max_bound);
++        }
++        else
++        {
++            gemm_requant_info = arm_gemm::Requantize32(nullptr, 0, a_offset, b_offset, output_info.gemmlowp_offset,
++                                                       -output_info.gemmlowp_shift, output_info.gemmlowp_multiplier,
++                                                       output_info.gemmlowp_min_bound, output_info.gemmlowp_max_bound);
++        }
++
++        _gemm_kernel_asm->update_quantization_parameters(gemm_requant_info);
++        _is_prepared = is_prepared;
++    }
++
+ private:
+     enum AuxTensorIdx
+     {
+@@ -1150,5 +1180,14 @@ experimental::MemoryRequirements CpuGemmAssemblyDispatch::workspace() const
+     ARM_COMPUTE_ERROR_ON(_arm_gemm == nullptr);
+     return _arm_gemm->workspace();
+ }
++
++void CpuGemmAssemblyDispatch::update_quantization_parameters(const GEMMLowpOutputStageInfo &output_info,
++                                                             const QuantizationInfo        &a,
++                                                             const QuantizationInfo        &b,
++                                                             const bool                     is_prepared,
++                                                             const bool                     negated_offsets)
++{
++    _arm_gemm->update_quantization_parameters(output_info, a, b, is_prepared, negated_offsets);
++}
+ } // namespace cpu
+ } // namespace arm_compute
+diff --git a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.h b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.h
+index 44c5c189a..0b6f22d45 100644
+--- a/src/cpu/operators/internal/CpuGemmAssemblyDispatch.h
++++ b/src/cpu/operators/internal/CpuGemmAssemblyDispatch.h
+@@ -28,6 +28,7 @@
+
+ #include "src/core/common/Macros.h"
+ #include "src/cpu/ICpuOperator.h"
++#include "src/cpu/kernels/assembly/arm_gemm.hpp"
+
+ namespace arm_compute
+ {
+@@ -81,12 +82,17 @@ public:
+     class IFallback
+     {
+     public:
+-        virtual void                             run(ITensorPack &tensors)     = 0;
+-        virtual void                             prepare(ITensorPack &tensors) = 0;
+-        virtual experimental::MemoryRequirements workspace() const             = 0;
+-        virtual bool                             is_configured() const         = 0;
+-        virtual bool                             isVarWeightsKernel() const    = 0;
+-        virtual ~IFallback()                                                   = default;
++        virtual void                             run(ITensorPack &tensors)                  = 0;
++        virtual void                             prepare(ITensorPack &tensors)              = 0;
++        virtual experimental::MemoryRequirements workspace() const                          = 0;
++        virtual bool                             is_configured() const                      = 0;
++        virtual bool                             isVarWeightsKernel() const                 = 0;
++        virtual void                             update_quantization_parameters(const GEMMLowpOutputStageInfo &,
++                                                                                const QuantizationInfo &,
++                                                                                const QuantizationInfo &,
++                                                                                const bool,
++                                                                                const bool) = 0;
++        virtual ~IFallback()                                                                = default;
+     };
+
+ public:
+@@ -185,6 +191,12 @@ public:
+         return _arm_gemm && _arm_gemm->isVarWeightsKernel();
+     }
+
++    void update_quantization_parameters(const GEMMLowpOutputStageInfo &output_info,
++                                        const QuantizationInfo        &a,
++                                        const QuantizationInfo        &b,
++                                        const bool                     is_prepared,
++                                        const bool                     negated_offsets);
++
+     // Inherited methods overridden:
+     void                             prepare(ITensorPack &tensors) override;
+     void                             run(ITensorPack &tensors) override;
+--
+2.25.1

--- a/docker/pytorch-aarch64/patches/ideep_static_quantization.patch
+++ b/docker/pytorch-aarch64/patches/ideep_static_quantization.patch
@@ -1,0 +1,55 @@
+*******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/include/ideep/operators/conv.hpp b/include/ideep/operators/conv.hpp
+index 839eea2..8afdf4c 100644
+--- a/include/ideep/operators/conv.hpp
++++ b/include/ideep/operators/conv.hpp
+@@ -194,7 +194,7 @@ struct conv_deconv_utils {
+       }
+
+       if (with_bias) {
+-        bias_desc = {bias.get_dims(), data_type::f32, tag::any}; // Use f32 instead of s32 to improve accuracy
++        bias_desc = {bias.get_dims(), data_type::s32, tag::any};
+       }
+     } else {
+       if (src.has_scale()) {
+@@ -218,7 +218,7 @@ struct conv_deconv_utils {
+
+       if (with_bias) {
+         IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
+-                                    data_type::f32, data_type::bf16),
++                                    data_type::f32, data_type::bf16, data_type::s32),
+                       "Incorrect data type in bias");
+         bias_desc = bias.get_desc();
+       }
+@@ -277,7 +277,7 @@ struct conv_deconv_utils {
+
+     if (with_bias) {
+       IDEEP_ENFORCE(utils::one_of(bias.get_data_type(),
+-                                  data_type::f32, data_type::bf16, data_type::f16),
++                                  data_type::f32, data_type::bf16, data_type::f16, data_type::s32),
+                     "Incorrect data type in bias");
+       bias_desc = bias.get_desc();
+     }
+@@ -2354,4 +2354,4 @@ struct convolution_backward_weights
+ };
+ }  // namespace ideep
+
+-#endif
+\ No newline at end of file
++#endif

--- a/docker/pytorch-aarch64/patches/onednn_static_quantization.patch
+++ b/docker/pytorch-aarch64/patches/onednn_static_quantization.patch
@@ -1,0 +1,195 @@
+*******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/src/cpu/aarch64/acl_convolution_utils.cpp b/src/cpu/aarch64/acl_convolution_utils.cpp
+index de18f6d348..0da5ed956a 100644
+--- a/src/cpu/aarch64/acl_convolution_utils.cpp
++++ b/src/cpu/aarch64/acl_convolution_utils.cpp
+@@ -65,8 +65,13 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+                               everyone_is(data_type::f16, src_d.data_type(),
+                                       wei_d.data_type(), dst_d.data_type()),
+                               everyone_is(data_type::bf16, src_d.data_type(),
+-                                      wei_d.data_type(), dst_d.data_type())),
+-            " src, dst and wei must be fp16, bf16 or fp32");
++                                      wei_d.data_type(), dst_d.data_type()),
++                              everyone_is(data_type::s8, src_d.data_type(),
++                                      wei_d.data_type(), dst_d.data_type()),
++                              (everyone_is(data_type::u8, src_d.data_type(),
++                                       dst_d.data_type())
++                                      && wei_d.data_type() == data_type::s8)),
++            " src, dst and wei must be s8, u8, bf16, fp16 or fp32");
+     // batch size
+     const int mb = src_d.dims()[0];
+
+@@ -164,8 +169,11 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     const auto acl_layout = is_nhwc ? arm_compute::DataLayout::NHWC
+                                     : arm_compute::DataLayout::NCHW;
+
++    bool is_quantized
++            = utils::one_of(src_d.data_type(), data_type::s8, data_type::u8);
+     // all have the same datatype
+-    auto acl_data_type = acl_utils::get_acl_data_t(src_d.data_type());
++    auto acl_data_type
++            = acl_utils::get_acl_data_t(src_d.data_type(), is_quantized);
+
+     // clang-format off
+     acp.src_tensor_info = arm_compute::TensorInfo(
+@@ -179,8 +187,9 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+             is_nhwc ? arm_compute::TensorShape(ic, kw, kh, oc) :
+             arm_compute::TensorShape(kw, kh, ic, oc),
+             1,
+-            acl_data_type,
++            acl_utils::get_acl_data_t(wei_d.data_type(), is_quantized),
+             acl_layout);
++
+     if(is_depthwise) {
+        // We need to set that values are not constant so that we
+        // we can update them in-place in ACL
+@@ -198,10 +207,17 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+             acp.with_bias ? arm_compute::TensorShape(oc)
+                           : arm_compute::TensorShape(),
+             1,
+-            acl_data_type,
++            is_quantized ? acl_utils::get_acl_data_t(data_type::s32) : acl_data_type,
+             acl_layout);
+     // clang-format on
+
++    if (is_quantized) {
++        arm_compute::QuantizationInfo qi {1.0, 0, true};
++        acp.src_tensor_info.set_quantization_info(qi);
++        acp.wei_tensor_info.set_quantization_info(qi);
++        acp.dst_tensor_info.set_quantization_info(qi);
++    }
++
+     // ACL Winograd is not prepared for fixed format kernels
+     if (acp.alg_winograd) {
+         const bool is_1d = ndims == 3;
+@@ -216,7 +232,7 @@ status_t acl_init_conf(acl_conv_conf_t &acp, memory_desc_t &src_md,
+     // Are we allowed to cast down to bf16 or not?
+     acp.fast_math
+             = one_of(attr.fpmath_.mode_, fpmath_mode::bf16, fpmath_mode::any);
+-    if (is_depthwise) {
++    if (is_depthwise || is_quantized) {
+         // There is no support for fixed format kernels for depthwise convolution
+         // in ACL so we are going to use weight format that we set up earlier
+         return status::success;
+diff --git a/src/cpu/aarch64/acl_gemm_convolution.cpp b/src/cpu/aarch64/acl_gemm_convolution.cpp
+index a569d7e2b7..efd6c3c355 100644
+--- a/src/cpu/aarch64/acl_gemm_convolution.cpp
++++ b/src/cpu/aarch64/acl_gemm_convolution.cpp
+@@ -1,5 +1,5 @@
+ /*******************************************************************************
+-* Copyright 2020-2022 Arm Ltd. and affiliates
++* Copyright 2020-2022, 2024 Arm Ltd. and affiliates
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+@@ -44,6 +44,7 @@ using namespace data_type;
+ template struct acl_gemm_convolution_fwd_t<f32>;
+ template struct acl_gemm_convolution_fwd_t<f16>;
+ template struct acl_gemm_convolution_fwd_t<s8, s8, s8, s32>;
++template struct acl_gemm_convolution_fwd_t<u8, s8, u8, s32>;
+
+ } // namespace aarch64
+ } // namespace cpu
+diff --git a/src/cpu/aarch64/acl_gemm_convolution.hpp b/src/cpu/aarch64/acl_gemm_convolution.hpp
+index efae57f0b2..adfa62f878 100644
+--- a/src/cpu/aarch64/acl_gemm_convolution.hpp
++++ b/src/cpu/aarch64/acl_gemm_convolution.hpp
+@@ -18,6 +18,7 @@
+ #define CPU_AARCH64_ACL_GEMM_CONVOLUTION_HPP
+
+ #include "cpu/cpu_convolution_pd.hpp"
++#include "cpu/cpu_primitive.hpp"
+
+ #include "cpu/aarch64/acl_convolution_utils.hpp"
+ #include "cpu/aarch64/acl_post_ops.hpp"
+@@ -79,9 +80,8 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+                     && expect_data_types(
+                             src_type, wei_type, bia_type, dst_type, undef)
+                     && !has_zero_dim_memory()
+-                    && attr()->has_default_values(
+-                            smask_t::post_ops | smask_t::fpmath_mode, dst_type)
+                     && output_scales_mask_ok() && zero_points_ok();
++
+             if (!ok) return status::unimplemented;
+
+             CHECK(acl_convolution_utils::init_conf_gemm(acp_, src_md_,
+@@ -117,8 +117,8 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+
+         bool zero_points_ok() const {
+             using namespace data_type;
+-            // TODO: add support for asymmetric quantization
+-            return attr()->zero_points_.has_default_values();
++            return IMPLICATION(!utils::one_of(src_type, s8, u8),
++                    attr()->zero_points_.has_default_values());
+         }
+     };
+
+@@ -146,6 +146,38 @@ struct acl_gemm_convolution_fwd_t : public primitive_t {
+     typedef typename prec_traits<bia_type>::type bia_data_t;
+
+     status_t execute(const exec_ctx_t &ctx) const override {
++        auto &acl_obj = ctx.get_resource_mapper()
++                                ->get<acl_resource_t>(this)
++                                ->get_acl_obj();
++
++        bool is_quantized
++                = utils::one_of(acl_obj.dst_tensor.info()->data_type(),
++                        arm_compute::DataType::QASYMM8,
++                        arm_compute::DataType::QASYMM8_SIGNED);
++
++        if (is_quantized) {
++            DEFINE_ARG_SCALES_BUFFER(src_scale, DNNL_ARG_SRC);
++            DEFINE_ZERO_POINT_VALUE(src_zero_point, DNNL_ARG_SRC);
++            DEFINE_ARG_SCALES_BUFFER(wei_scale, DNNL_ARG_WEIGHTS);
++            DEFINE_ZERO_POINT_VALUE(wei_zero_point, DNNL_ARG_WEIGHTS);
++            DEFINE_ARG_SCALES_BUFFER(dst_scale, DNNL_ARG_DST);
++            DEFINE_ZERO_POINT_VALUE(dst_zero_point, DNNL_ARG_DST);
++
++            // s8s8s8 uses D = Sx*Sy*(XY + X*zy + Y*zx + zx*zy) and u8s8u8 uses D = Sx*Sy*(XW - X*zw - W*zx + zx*zw)
++            if (acl_obj.dst_tensor.info()->data_type() == arm_compute::DataType::QASYMM8)
++            {
++                acl_obj.src_tensor.info()->set_quantization_info(arm_compute::QuantizationInfo(*src_scale, -src_zero_point, true));
++                acl_obj.wei_tensor.info()->set_quantization_info(arm_compute::QuantizationInfo(*wei_scale, -wei_zero_point, true));
++            } else
++            {
++                acl_obj.src_tensor.info()->set_quantization_info(arm_compute::QuantizationInfo(*src_scale, src_zero_point, true));
++                acl_obj.wei_tensor.info()->set_quantization_info(arm_compute::QuantizationInfo(*wei_scale, wei_zero_point, true));
++            }
++
++            // for efficiency reasons, OneDNN saves the inverse of the destination
++            acl_obj.dst_tensor.info()->set_quantization_info(arm_compute::QuantizationInfo(1.0/(*dst_scale), dst_zero_point, true));
++        }
++
+         return execute_forward(ctx);
+     }
+
+diff --git a/src/cpu/cpu_convolution_list.cpp b/src/cpu/cpu_convolution_list.cpp
+index 67a0093cde..4ec8eb369f 100644
+--- a/src/cpu/cpu_convolution_list.cpp
++++ b/src/cpu/cpu_convolution_list.cpp
+@@ -614,6 +614,7 @@ const std::map<pk_dt_impl_key_t, std::vector<impl_list_item_t>> &impl_list_map()
+             nullptr,
+         }},
+         {{forward, u8, s8, u8}, {
++            CPU_INSTANCE_AARCH64_ACL(acl_gemm_convolution_fwd_t<u8, s8, u8, s32>)
+             CPU_INSTANCE_AVX512(brdgmm_dw_convolution_fwd_t)
+             CPU_INSTANCE_X64(ip_convolution_fwd_t)
+             CPU_INSTANCE_AMX(brgemm_1x1_convolution_fwd_t<avx512_core_amx>)
+--
+2.25.1

--- a/docker/pytorch-aarch64/patches/pytorch_static_quantization.patch
+++ b/docker/pytorch-aarch64/patches/pytorch_static_quantization.patch
@@ -1,0 +1,466 @@
+ *******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/aten/src/ATen/native/mkldnn/Conv.cpp b/aten/src/ATen/native/mkldnn/Conv.cpp
+index b5e53732a47..a4db9501635 100644
+--- a/aten/src/ATen/native/mkldnn/Conv.cpp
++++ b/aten/src/ATen/native/mkldnn/Conv.cpp
+@@ -329,7 +329,8 @@ Tensor mkldnn_convolution(
+     IntArrayRef stride,
+     IntArrayRef dilation,
+     int64_t groups) {
+-  bool use_channels_last = mkldnn_conv_use_channels_last(input_t, weight_t);
++  //bool use_channels_last = mkldnn_conv_use_channels_last(input_t, weight_t);
++  bool use_channels_last = true;
+   return _mkldnn_convolution(
+       input_t,
+       weight_t,
+diff --git a/aten/src/ATen/native/quantized/cpu/qconv.cpp b/aten/src/ATen/native/quantized/cpu/qconv.cpp
+index 9112fdd7f25..09eb7a90e5d 100644
+--- a/aten/src/ATen/native/quantized/cpu/qconv.cpp
++++ b/aten/src/ATen/native/quantized/cpu/qconv.cpp
+@@ -1165,13 +1165,12 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+   ConvDimChecks<kSpatialDim>(
+       act.ndimension(), stride().size(), padding().size(),
+       output_padding().size(), dilation().size(), func_name, transpose());
+-  TORCH_CHECK(act.scalar_type() == c10::ScalarType::QUInt8,
+-      func_name, " (ONEDNN): data type of input should be QUint8.");
+-
++  TORCH_CHECK(act.scalar_type() == c10::ScalarType::QUInt8 || act.scalar_type() == c10::ScalarType::QInt8,
++      func_name, " (ONEDNN): data type of input should be QUint8 or QInt8.");
+   // src
+   auto act_contig = act.contiguous(kSpatialDim == 2 ? c10::MemoryFormat::ChannelsLast : c10::MemoryFormat::ChannelsLast3d);
+   auto src_dims = act_contig.sizes().vec();
+-  auto src_data_type = dnnl::memory::data_type::u8;
++  auto src_data_type = act.scalar_type() == c10::ScalarType::QUInt8 ? dnnl::memory::data_type::u8 : dnnl::memory::data_type::s8;
+   auto src_desc = ideep::tensor::desc(src_dims, src_data_type,
+       kSpatialDim == 2 ? ideep::format_tag::nhwc : ideep::format_tag::ndhwc);
+   ideep::tensor src(src_desc, act_contig.data_ptr());
+@@ -1213,7 +1212,7 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+   at::Tensor output = at::_empty_affine_quantized(
+       dst_dims,
+       device(c10::kCPU)
+-          .dtype(c10::kQUInt8)
++          .dtype(act.scalar_type() == c10::ScalarType::QUInt8 ? c10::kQUInt8 : c10::kQInt8)
+           .memory_format(kSpatialDim == 2 ?
+               c10::MemoryFormat::ChannelsLast :
+               c10::MemoryFormat::ChannelsLast3d),
+@@ -1233,7 +1232,8 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+     // When fused with sum, the dst tensor will share the data ptr as the accum tensor.
+     dst.init(dst_desc, accum_contig.data_ptr());
+   } else {
+-    dst = ideep::tensor({dst_dims, ideep::tensor::data_type::u8, {output.strides().cbegin(), output.strides().cend()}},
++    auto dst_data_type = act.scalar_type() == c10::ScalarType::QUInt8 ? ideep::tensor::data_type::u8 : ideep::tensor::data_type::s8;
++    dst = ideep::tensor({dst_dims, dst_data_type, {output.strides().cbegin(), output.strides().cend()}},
+                       output.data_ptr());
+   }
+
+@@ -1274,6 +1274,7 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+   }
+   const auto& b = with_bias ? bias_.value() : ideep::tensor();
+   int num_threads = at::get_num_threads();
++  auto allowp_kind = act.scalar_type() == c10::ScalarType::QUInt8 ? ideep::u8s8 : ideep::s8s8;
+   if (transpose()) {
+     // Primitive cache is initialized when called for the first time
+     // and won't be updated afterwards.
+@@ -1288,7 +1289,7 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+             src_zero_points, dst_zero_points, op_attr,
+             dnnl::algorithm::deconvolution_direct,
+             dnnl::prop_kind::forward_inference,
+-            ideep::u8s8, ideep::engine::cpu_engine());
++            allowp_kind, ideep::engine::cpu_engine());
+         get_deconv_cache() = DeconvPrimitiveCache(cache_key, params);
+         auto expected_weight_desc = ideep::tensor::desc(params.pd.weights_desc(), groups());
+         weights = weights.reorder_if_differ_in(expected_weight_desc);
+@@ -1306,7 +1307,7 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+           src_zero_points, dst_zero_points, op_attr,
+           dnnl::algorithm::deconvolution_direct,
+           dnnl::prop_kind::forward_inference,
+-          ideep::u8s8, ideep::engine::cpu_engine());
++          allowp_kind, ideep::engine::cpu_engine());
+     }
+   } else {  // not transposed
+     PrimitiveCacheKey cache_key = std::make_tuple(
+@@ -1320,7 +1321,7 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+             src_zero_points, dst_zero_points,
+             op_attr, dnnl::algorithm::convolution_direct,
+             dnnl::prop_kind::forward_inference,
+-            ideep::u8s8, ideep::engine::cpu_engine());
++            allowp_kind, ideep::engine::cpu_engine());
+         get_conv_cache() = ConvPrimitiveCache(cache_key, params);
+         auto expected_weight_desc = ideep::tensor::desc(params.pd.weights_desc(), groups());
+         weights = weights.reorder_if_differ_in(expected_weight_desc);
+@@ -1337,7 +1338,7 @@ at::Tensor PackedConvWeightsOnednn<kSpatialDim>::apply_impl(
+           src_zero_points, dst_zero_points, op_attr,
+           dnnl::algorithm::convolution_direct,
+           dnnl::prop_kind::forward_inference,
+-          ideep::u8s8, ideep::engine::cpu_engine());
++          allowp_kind, ideep::engine::cpu_engine());
+     }
+   }
+   if (has_accum) {
+diff --git a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+index 6f996691c09..555be5a3312 100644
+--- a/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
++++ b/aten/src/ATen/native/quantized/cpu/qconv_prepack.cpp
+@@ -467,7 +467,8 @@ c10::intrusive_ptr<ConvPackedParamsBase<kSpatialDim>> PackedConvWeightsOnednn<
+     TORCH_CHECK(
+         bias_vec.size(0) == output_channels,
+         "bias should have K elements: " + std::to_string(output_channels));
+-    auto bias_desc = ideep::tensor::desc(bias.value().sizes().vec(), dnnl::memory::data_type::f32);
++    auto bias_type = bias_vec.scalar_type() == c10::ScalarType::Float ? dnnl::memory::data_type::f32 : dnnl::memory::data_type::s32;
++    auto bias_desc = ideep::tensor::desc(bias.value().sizes().vec(), bias_type);
+     ideep::tensor packed_bias;
+     packed_bias.init(bias_desc, bias.value().data_ptr());
+     onednn_bias = c10::optional<ideep::tensor>(packed_bias);
+diff --git a/aten/src/ATen/native/quantized/cpu/qlinear.cpp b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+index d31a28b6bec..114851cd252 100644
+--- a/aten/src/ATen/native/quantized/cpu/qlinear.cpp
++++ b/aten/src/ATen/native/quantized/cpu/qlinear.cpp
+@@ -788,8 +788,8 @@ at::Tensor PackedLinearWeightsOnednn::apply_impl(
+   TORCH_CHECK(
+       dim != 0,
+       "qlinear (ONEDNN): input dim should be at least 1, but got 0");
+-  TORCH_CHECK(input.scalar_type() == c10::ScalarType::QUInt8,
+-      "qlinear (ONEDNN): data type of input should be QUint8.");
++  TORCH_CHECK(input.scalar_type() == c10::ScalarType::QUInt8 || input.scalar_type() == c10::ScalarType::QInt8,
++      "qlinear (ONEDNN): data type of input should be QUint8 or QInt8.");
+
+   auto input_contig = input.expect_contiguous();
+   auto& w = *(weight_.get());
+diff --git a/torch/ao/nn/quantized/modules/conv.py b/torch/ao/nn/quantized/modules/conv.py
+index 22a11014375..f5bd5585175 100644
+--- a/torch/ao/nn/quantized/modules/conv.py
++++ b/torch/ao/nn/quantized/modules/conv.py
+@@ -74,11 +74,12 @@ class _ConvNd(WeightedQuantizedModule):
+             weight_shape + list(kernel_size),
+             scale=1, zero_point=0, dtype=torch.qint8,
+             **{k: v for k, v in factory_kwargs.items() if k != 'dtype'})
+-        bias_float = (
+-            torch.zeros(out_channels, dtype=torch.float,
+-                        **{k: v for k, v in factory_kwargs.items() if k != 'dtype'}) if bias else None)
+
+-        self.set_weight_bias(qweight, bias_float)
++        qbias = torch._empty_affine_quantized(
++            out_channels, scale=1, zero_point=0, dtype=torch.qint32,
++            **{k: v for k, v in factory_kwargs.items() if k != 'dtype'})
++
++        self.set_weight_bias(qweight, qbias)
+         self.scale = 1.0
+         self.zero_point = 0
+
+@@ -262,7 +263,8 @@ class _ConvNd(WeightedQuantizedModule):
+             device=ref_qconv.weight.device,
+             dtype=ref_qconv.weight.dtype)
+         qweight = ref_qconv.get_quantized_weight()
+-        qconv.set_weight_bias(qweight, ref_qconv.bias)
++        qbias = ref_qconv.get_quantized_bias()
++        qconv.set_weight_bias(qweight, qbias)
+         qconv.scale = float(output_scale)
+         qconv.zero_point = int(output_zero_point)
+         return qconv
+diff --git a/torch/ao/nn/quantized/reference/modules/conv.py b/torch/ao/nn/quantized/reference/modules/conv.py
+index 910223056fb..6ad1748e454 100644
+--- a/torch/ao/nn/quantized/reference/modules/conv.py
++++ b/torch/ao/nn/quantized/reference/modules/conv.py
+@@ -17,7 +17,7 @@ class _ConvNd(torch.nn.modules.conv._ConvNd, ReferenceQuantizedModule):
+     _IS_REFERENCE = True
+
+     @staticmethod
+-    def from_float(cls, float_conv, weight_qparams):
++    def from_float(cls, float_conv, weight_qparams, bias_qparams = None):
+         qref_conv = cls(
+             float_conv.in_channels,
+             float_conv.out_channels,
+@@ -30,7 +30,8 @@ class _ConvNd(torch.nn.modules.conv._ConvNd, ReferenceQuantizedModule):
+             float_conv.padding_mode,
+             device=float_conv.weight.device,
+             dtype=float_conv.weight.dtype,
+-            weight_qparams=weight_qparams)
++            weight_qparams=weight_qparams,
++            bias_qparams=bias_qparams)
+         qref_conv.weight = torch.nn.Parameter(float_conv.weight.detach())
+         if float_conv.bias is not None:
+             qref_conv.bias = torch.nn.Parameter(float_conv.bias.detach())
+@@ -85,11 +86,13 @@ class Conv2d(_ConvNd, nn.Conv2d):
+                  padding_mode='zeros',
+                  device=None,
+                  dtype=None,
+-                 weight_qparams: Optional[Dict[str, Any]] = None):
++                 weight_qparams: Optional[Dict[str, Any]] = None,
++                 bias_qparams: Optional[Dict[str, Any]] = None):
+         nn.Conv2d.__init__(
+             self, in_channels, out_channels, kernel_size, stride, padding, dilation,
+             groups, bias, padding_mode, device, dtype)
+         self._init_weight_qparams(weight_qparams, device)
++        self._init_bias_qparams(bias_qparams, device)
+
+     def forward(self, x: torch.Tensor) -> torch.Tensor:
+         """
+@@ -112,8 +115,8 @@ class Conv2d(_ConvNd, nn.Conv2d):
+         return "QuantizedConv2d(Reference)"
+
+     @classmethod
+-    def from_float(cls, float_conv, weight_qparams):
+-        return _ConvNd.from_float(cls, float_conv, weight_qparams)
++    def from_float(cls, float_conv, weight_qparams, bias_qparams = None):
++        return _ConvNd.from_float(cls, float_conv, weight_qparams, bias_qparams)
+
+ class Conv3d(_ConvNd, nn.Conv3d):
+     def __init__(self, in_channels, out_channels, kernel_size, stride=1,
+diff --git a/torch/ao/nn/quantized/reference/modules/linear.py b/torch/ao/nn/quantized/reference/modules/linear.py
+index 378fe0eb6ee..370f39da55b 100644
+--- a/torch/ao/nn/quantized/reference/modules/linear.py
++++ b/torch/ao/nn/quantized/reference/modules/linear.py
+@@ -23,9 +23,11 @@ class Linear(nn.Linear, ReferenceQuantizedModule):
+             bias_: bool = True,
+             device: Optional[torch.device] = None,
+             dtype: Optional[torch.dtype] = None,
+-            weight_qparams: Optional[Dict[str, Any]] = None):
++            weight_qparams: Optional[Dict[str, Any]] = None,
++            bias_qparams: Optional[Dict[str, Any]] = None):
+         super().__init__(in_features, out_features, bias_, device, dtype)
+         self._init_weight_qparams(weight_qparams, device)
++        self._init_bias_qparams(bias_qparams, device)
+
+     def _get_name(self):
+         return "QuantizedLinear(Reference)"
+@@ -46,11 +48,11 @@ class Linear(nn.Linear, ReferenceQuantizedModule):
+         return result
+
+     @classmethod
+-    def from_float(cls, float_linear, weight_qparams):
++    def from_float(cls, float_linear, weight_qparams, bias_qparams = None):
+         qref_linear = Linear(
+             float_linear.in_features, float_linear.out_features,
+             float_linear.bias is not None, device=float_linear.weight.device,
+-            dtype=float_linear.weight.dtype, weight_qparams=weight_qparams)
++            dtype=float_linear.weight.dtype, weight_qparams=weight_qparams, bias_qparams=bias_qparams)
+         qref_linear.weight = torch.nn.Parameter(float_linear.weight.detach())
+         if float_linear.bias is not None:
+             qref_linear.bias = torch.nn.Parameter(float_linear.bias.detach())
+diff --git a/torch/ao/nn/quantized/reference/modules/utils.py b/torch/ao/nn/quantized/reference/modules/utils.py
+index 2c1f52cdf88..e9ac1d5c91a 100644
+--- a/torch/ao/nn/quantized/reference/modules/utils.py
++++ b/torch/ao/nn/quantized/reference/modules/utils.py
+@@ -6,6 +6,15 @@ __all__ = [
+ ]
+
+ class ReferenceQuantizedModule(torch.nn.Module):
++    def _init_bias_qparams(self, bias_qparams, device):
++        if bias_qparams is None:
++            bias_qparams = torch.tensor(1, dtype=torch.float, device=device)
++
++        b_scale_tensor = bias_qparams.clone().detach() \
++            if isinstance(bias_qparams, torch.Tensor) \
++            else torch.tesnor(bias_qparams, dtype=torch.float, device=device)
++        self.register_buffer("bias_scale", b_scale_tensor)
++
+     def _init_weight_qparams(self, weight_qparams, device):
+         if weight_qparams is None:
+             weight_qparams = {
+@@ -110,6 +119,9 @@ class ReferenceQuantizedModule(torch.nn.Module):
+                 self.weight_zero_point,
+                 self.weight_axis_int)
+
++    def get_quantized_bias(self):
++        return torch.quantize_per_tensor(self.bias, self.bias_scale, torch.tensor(0, dtype=torch.int), torch.qint32)
++
+     def _save_to_state_dict(self, destination, prefix, keep_vars):
+         super()._save_to_state_dict(destination, prefix, keep_vars)
+         _save_weight_qparams(
+diff --git a/torch/ao/quantization/fx/convert.py b/torch/ao/quantization/fx/convert.py
+index 589aa6df2e8..228eafe2fa1 100644
+--- a/torch/ao/quantization/fx/convert.py
++++ b/torch/ao/quantization/fx/convert.py
+@@ -317,7 +317,7 @@ def _replace_observer_with_quantize_dequantize_node(
+         node: Node,
+         modules: Dict[str, torch.nn.Module],
+         node_name_to_scope: Dict[str, Tuple[str, type]],
+-        node_name_to_qconfig: Dict[str, QConfigAny]) -> None:
++        node_name_to_qconfig: Dict[str, QConfigAny]) -> Dict[Node, Tuple[float, int]]:
+     """ Replace activation_post_process module call node with quantize and
+     dequantize node
+
+@@ -340,7 +340,7 @@ def _replace_observer_with_quantize_dequantize_node(
+         with graph.inserting_before(node):
+             node.replace_all_uses_with(node.args[0])
+             graph.erase_node(node)
+-        return
++        return None
+
+     # otherwise, we can convert the activation_post_process module call to quantize/dequantize node
+     dtype = activation_post_process.dtype  # type: ignore[attr-defined]
+@@ -392,6 +392,8 @@ def _replace_observer_with_quantize_dequantize_node(
+             dequantized_node = graph.call_method("dequantize", args=(quantized_node,))
+             node.replace_all_uses_with(dequantized_node)
+             graph.erase_node(node)
++
++            return {dequantized_node: (scale, zero_point)}
+     elif is_dynamic:
+
+         # uint8/int8/fp16 dynamic quantization branch
+@@ -413,6 +415,8 @@ def _replace_observer_with_quantize_dequantize_node(
+             dequantized_node = graph.call_method("dequantize", args=(quantized_node,))
+             node.replace_all_uses_with(dequantized_node)
+             graph.erase_node(node)
++
++            return None
+     elif dtype == torch.float16:
+         node_type = "call_method"
+         quantize_op = "to"  # type: ignore[assignment]
+@@ -430,6 +434,8 @@ def _replace_observer_with_quantize_dequantize_node(
+             node.replace_all_uses_with(dequantized_node)
+             graph.erase_node(node)
+
++            return None
++
+     # should not reach since we have checks in the beginning to make sure the
+     # activation_post_process is supported
+
+@@ -658,6 +664,7 @@ def convert_weighted_module(
+         backend_config: BackendConfig,
+         is_decomposed: bool = False,
+         is_reference: bool = False,
++        activation_qparams: Tuple[float, int] = None,
+ ) -> None:
+     """ Convert a weighted module to reference quantized module in the model
+     If the QConfig of a QAT module is not set, the module will still be converted to
+@@ -770,6 +777,8 @@ def convert_weighted_module(
+
+         wq_or_wq_dict.update(get_qparam_dict(weight_post_process))
+
++    weights_qparam_scale = wq_or_wq_dict["scale"][0]
++    bias_qparam_scale = weights_qparam_scale * activation_qparams[0]
+     # We use the same reference module for all modes of quantization: static, dynamic, weight_only
+     # root_module_to_quantized_reference_module: module mapping from root (floating point) module class
+     # to quantized reference module class, e.g. nn.Conv2d to nn.quantized._reference.Conv2d
+@@ -778,7 +787,7 @@ def convert_weighted_module(
+     assert (
+         ref_qmodule_cls is not None
+     ), f"No reference quantized module class configured for {type_before_parametrizations(float_module)}"
+-    ref_qmodule = ref_qmodule_cls.from_float(float_module, wq_or_wq_dict)  # type: ignore[attr-defined]
++    ref_qmodule = ref_qmodule_cls.from_float(float_module, wq_or_wq_dict, bias_qparam_scale)  # type: ignore[attr-defined]
+     if fused_module is not None:
+         fused_module[0] = ref_qmodule  # type: ignore[operator]
+     else:
+@@ -1020,6 +1029,7 @@ def convert(
+     qat_module_classes = get_qat_module_classes(backend_config)
+     fused_module_classes = get_fused_module_classes(backend_config)
+     statically_quantized_custom_module_nodes: Set[Node] = set()
++    dequantized_node_scale : Dict[Node, Tuple[float, int]] = dict()
+
+     for node in list(model.graph.nodes):
+         if node.op == 'placeholder':
+@@ -1065,9 +1075,12 @@ def convert(
+                             model, node, modules, node_name_to_scope,
+                             node_name_to_qconfig)
+                     else:
+-                        _replace_observer_with_quantize_dequantize_node(
++                        dequantized_node_map = _replace_observer_with_quantize_dequantize_node(
+                             model, node, modules, node_name_to_scope,
+                             node_name_to_qconfig)
++                        for dequantized_node in dequantized_node_map.keys():
++                            assert dequantized_node not in dequantized_node_scale
++                            dequantized_node_scale[dequantized_node] = dequantized_node_map[dequantized_node]
+             elif isinstance(mod, DeQuantStub):
+                 _replace_observer_or_dequant_stub_with_dequantize_node(node, model.graph)
+             elif _is_observed_standalone_module(mod):
+@@ -1082,9 +1095,13 @@ def convert(
+                 if type_before_parametrizations(mod) in fused_module_classes and \
+                    type_before_parametrizations(mod[0]) not in root_module_classes:  # type: ignore[index]
+                     continue
++                prev_node = node.prev
++                activation_qparams = None
++                if prev_node in dequantized_node_scale:
++                    activation_qparams = (dequantized_node_scale[prev_node][0], dequantized_node_scale[prev_node][1])
+                 convert_weighted_module(
+                     node, modules, observed_node_names, node_name_to_qconfig, backend_config,
+-                    is_decomposed, is_reference)
++                    is_decomposed, is_reference, activation_qparams)
+             elif type_before_parametrizations(mod) in custom_module_classes:
+                 convert_custom_module(
+                     node, model.graph, modules, custom_module_class_mapping,
+diff --git a/torch/ao/quantization/fx/qconfig_mapping_utils.py b/torch/ao/quantization/fx/qconfig_mapping_utils.py
+index 0b906a1777d..df8e3edc67d 100644
+--- a/torch/ao/quantization/fx/qconfig_mapping_utils.py
++++ b/torch/ao/quantization/fx/qconfig_mapping_utils.py
+@@ -232,7 +232,6 @@ def _is_qconfig_supported_by_dtype_configs(qconfig: QConfig, dtype_configs: List
+             is_dynamic = False
+         input_dtype = dtype_config.input_dtype or torch.float
+         weight_dtype = dtype_config.weight_dtype or torch.float
+-        bias_dtype = dtype_config.bias_dtype or torch.float
+         output_dtype = dtype_config.output_dtype or torch.float
+         qconfig_activation_dtype, qconfig_weight_dtype, qconfig_input_act_is_dynamic = \
+             get_qconfig_dtypes(qconfig)
+@@ -251,8 +250,8 @@ def _is_qconfig_supported_by_dtype_configs(qconfig: QConfig, dtype_configs: List
+         else:
+             is_match = input_dtype == qconfig_activation_dtype and \
+                 output_dtype == qconfig_activation_dtype and \
+-                weight_dtype == qconfig_weight_dtype and \
+-                bias_dtype == qconfig_bias_dtype
++                weight_dtype == qconfig_weight_dtype
++                # FIXME: should we check for bias data type too
+         if is_match:
+             return True
+     return False
+diff --git a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+index 9270028b988..00c57afd475 100644
+--- a/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
++++ b/torch/csrc/jit/passes/onnx/unpack_quantized_weights.cpp
+@@ -222,14 +222,14 @@ std::vector<Node*> CreateQuantizedWeights(
+ }
+
+ Node* CreateQuantizedBias(
+-    std::vector<float> data,
++    std::vector<int> data,
+     std::shared_ptr<Graph>& graph,
+     std::vector<int64_t> shapes) {
+   Node* const_node_1 = graph->create(prim::Constant);
+   auto const_bias =
+-      at::from_blob(data.data(), c10::IntArrayRef(shapes), at::kFloat)
++      at::from_blob(data.data(), c10::IntArrayRef(shapes), at::kInt)
+           .to(at::kCPU);
+-  auto options = c10::TensorOptions().dtype(at::kFloat).device(at::kCPU);
++  auto options = c10::TensorOptions().dtype(at::kInt).device(at::kCPU);
+   at::Tensor const_bias_copy = at::empty(c10::IntArrayRef(shapes), options);
+   const_bias_copy.copy_(const_bias);
+   const_node_1->t_(Symbol::attr("value"), const_bias_copy);
+@@ -581,8 +581,8 @@ void unpackQuantizedWeightsHelper(
+       c2_bias->insertBefore(qlinear_node);
+       qlinear_node->insertInput(2, c2_bias->output());
+     } else {
+-      std::vector<float> bias_values(original_bias.numel());
+-      auto bias_data = original_bias.const_data_ptr<float>();
++      std::vector<int> bias_values(original_bias.numel());
++      auto bias_data = original_bias.const_data_ptr<int>();
+       for (const auto i : c10::irange(original_bias.numel())) {
+         bias_values[i] = bias_data[i];
+       }
+diff --git a/torch/onnx/symbolic_helper.py b/torch/onnx/symbolic_helper.py
+index c8b55c7dec9..e21bcfa8005 100644
+--- a/torch/onnx/symbolic_helper.py
++++ b/torch/onnx/symbolic_helper.py
+@@ -1667,7 +1667,7 @@ def quantize_helper(
+         _type_utils.JitScalarType.UINT8,
+         _type_utils.JitScalarType.INT8,
+     }:
+-        zero_point = g.op("Cast", zero_point, to_i=_C_onnx.TensorProtoDataType.UINT8)
++        zero_point = g.op("Cast", zero_point, to_i=_C_onnx.TensorProtoDataType.INT8)
+     output = g.op(
+         "QuantizeLinear",
+         tensor,

--- a/docker/pytorch-aarch64/scripts/build-acl.sh
+++ b/docker/pytorch-aarch64/scripts/build-acl.sh
@@ -29,11 +29,15 @@ readonly num_cpus=$(nproc)
 
 install_dir=$PROD_DIR/$package
 
-# Clone oneDNN
+# Clone ACL
 [[ ! -d ${src_repo} ]] && git clone ${src_host}/${src_repo}.git
 cd ${src_repo}
 
 git checkout $version
+
+# Patch ACL
+wget -O patch.zip https://eu-gerrit-1.euhpc.arm.com/changes/VisualCompute%2FComputeLibrary~633455/revisions/29/patch?zip && unzip patch.zip && patch -p1 < ./7271dfa.diff
+patch -p1 < ../acl_static_quantization.patch
 
 # Default to v8a if $acl_arch is unset.
 arch=${ACL_ARCH:-"arm64-v8a"}

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -48,6 +48,7 @@ if [[ $ONEDNN_BUILD ]]; then
 fi
 
 patch -p1 < $PACKAGE_DIR/pytorch_dynamic_quantization.patch
+patch --ignore-whitespace -p1 < $PACKAGE_DIR/pytorch_static_quantization.patch
 
 # Apply https://github.com/pytorch/pytorch/pull/122616 to make torch 2.3.0 backwards
 # compatible with torchdata
@@ -57,6 +58,7 @@ patch -p1 < torch2.3_bc_torchdata.patch
 cd third_party/ideep
 git checkout 55ca0191687aaf19aca5cdb7881c791e3bea442b
 patch -p1 < $PACKAGE_DIR/ideep_dynamic_quantization.patch
+patch -p1 < $PACKAGE_DIR/ideep_static_quantization.patch
 
 # Update the oneDNN tag in third_party/ideep
 cd mkl-dnn
@@ -70,6 +72,7 @@ wget -O onednn_enable_indirect_conv.patch https://patch-diff.githubusercontent.c
 patch -p1 < onednn_enable_indirect_conv.patch
 wget -O onednn_enable_acl_indirect_conv_for_bf16.patch https://patch-diff.githubusercontent.com/raw/oneapi-src/oneDNN/pull/1933.patch
 patch -p1 < onednn_enable_acl_indirect_conv_for_bf16.patch
+patch -p1 < $PACKAGE_DIR/onednn_static_quantization.patch
 
 cd $PACKAGE_DIR/$src_repo
 


### PR DESCRIPTION
This PR is about enabling Pytorch convolution static quantization via ACL.

  - Add Pytorch and ideep patches
  - Add ACL and OneDNN patches
  - Add ACL mixed sign GEMM support patch
  - Set ACL version to c2237ec so mixed sign GEMM can merge properly
  - Add statically quantised convolution example
  - Move method image._download_image from private to public: image.download_image
  - Update CHANGELOG.md
  - Update README.md