### PR TITLE
Enable oneDNN for tanh based GELU on aarch64

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -288,8 +288,8 @@ COPY patches/torchvision.patch $PACKAGE_DIR/.
 COPY patches/ideep_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/ideep_static_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
-COPY patches/pytorch_gelu.patch $PACKAGE_DIR/.
 COPY patches/pytorch_static_quantization.patch $PACKAGE_DIR/.
+COPY patches/pytorch_gelu.patch $PACKAGE_DIR/.
 
 COPY scripts/build-torchvision.sh $PACKAGE_DIR/.
 COPY scripts/build-torchtext.sh $PACKAGE_DIR/.

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -285,6 +285,7 @@ COPY patches/onednn_acl_thread_local_scheduler.patch $PACKAGE_DIR/.
 COPY patches/torchvision.patch $PACKAGE_DIR/.
 COPY patches/ideep_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
+COPY patches/pytorch_gelu.patch $PACKAGE_DIR/.
 
 COPY scripts/build-torchvision.sh $PACKAGE_DIR/.
 COPY scripts/build-torchtext.sh $PACKAGE_DIR/.

--- a/docker/pytorch-aarch64/patches/pytorch_gelu.patch
+++ b/docker/pytorch-aarch64/patches/pytorch_gelu.patch
@@ -1,0 +1,35 @@
+ *******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/aten/src/ATen/native/Activation.cpp b/aten/src/ATen/native/Activation.cpp
+index 7f5c696d1f6..14be46923b0 100644
+--- a/aten/src/ATen/native/Activation.cpp
++++ b/aten/src/ATen/native/Activation.cpp
+@@ -397,6 +397,13 @@ auto approximate_type = get_gelutype_enum(approximate);
+     ideep::tensor y = itensor_from_tensor(result);
+     ideep::eltwise_forward::compute(
+       x, y, ideep::algorithm::eltwise_gelu_erf, ideep::prop_kind::forward_training, /*alpha*/ 0.0);
++#ifdef __aarch64__
++  } else if (use_mkldnn(self) && (approximate_type == GeluType::Tanh)) {
++    const ideep::tensor& x = itensor_from_tensor(self);
++    ideep::tensor y = itensor_from_tensor(result);
++    ideep::eltwise_forward::compute(
++      x, y, ideep::algorithm::eltwise_gelu_tanh, ideep::prop_kind::forward_training, /*alpha*/ 0.0);
++#endif  // ifdef __aarch64__
+   } else {
+     GeluKernel(kCPU, *this, approximate_type);
+   }

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -48,8 +48,8 @@ if [[ $ONEDNN_BUILD ]]; then
 fi
 
 patch -p1 < $PACKAGE_DIR/pytorch_dynamic_quantization.patch
-patch -p1 < $PACKAGE_DIR/pytorch_gelu.patch
 patch --ignore-whitespace -p1 < $PACKAGE_DIR/pytorch_static_quantization.patch
+patch -p1 < $PACKAGE_DIR/pytorch_gelu.patch
 
 # Apply https://github.com/pytorch/pytorch/pull/122616 to make torch 2.3.0 backwards
 # compatible with torchdata

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -48,6 +48,7 @@ if [[ $ONEDNN_BUILD ]]; then
 fi
 
 patch -p1 < $PACKAGE_DIR/pytorch_dynamic_quantization.patch
+patch -p1 < $PACKAGE_DIR/pytorch_gelu.patch
 
 # Apply https://github.com/pytorch/pytorch/pull/122616 to make torch 2.3.0 backwards
 # compatible with torchdata


### PR DESCRIPTION
Provides significant speedup for GELU on aarch64 e.g.:

8.5x speedup compared to native implementation for 1x1x16384 on 32 threads