### PR TITLE
Removed the fixed cython versions

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -207,7 +207,7 @@ ENV PATH="/home/$DOCKER_USER/.cargo/bin:${PATH}"
 
 # Install some basic python packages needed for NumPy
 RUN pip install --no-cache-dir --upgrade pip
-RUN pip install --no-cache-dir "setuptools>=41.0.0" six mock wheel cython==0.29.36
+RUN pip install --no-cache-dir "setuptools>=41.0.0" six mock wheel cython
 
 # Install some  basic python packages needed for SciPy
 RUN pip install --no-cache-dir pybind11[global]==2.6.2 pyangbind pythran

--- a/docker/tensorflow-aarch64/Dockerfile
+++ b/docker/tensorflow-aarch64/Dockerfile
@@ -204,7 +204,7 @@ ENV PATH="/home/$DOCKER_USER/.cargo/bin:${PATH}"
 
 # Install some basic python packages
 RUN pip install --no-cache-dir --upgrade pip
-RUN pip install --no-cache-dir "setuptools>=41.0.0" six mock wheel cython==0.29.36 sh
+RUN pip install --no-cache-dir "setuptools>=41.0.0" six mock wheel cython sh
 
 # Install some  basic python packages needed for SciPy
 RUN pip install --no-cache-dir pybind11[global] pyangbind pythran


### PR DESCRIPTION
This PR is about removing the fixed Cython version tag 0.29.36 from Cython's pip installs.