### PR TITLE
Add ACL and oneDNN stateless matmuls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+build.log

--- a/docker/pytorch-aarch64/CHANGELOG.md
+++ b/docker/pytorch-aarch64/CHANGELOG.md
@@ -10,9 +10,12 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 - ACL and oneDNN patches to enable PyTorch static quantization for convolution.
 - ACL patch for mixed sign GEMM support
+- Modified oneDNN to v3.5
 
 ### Changed
 - Update ACL to Git hash: c2237ec
+- Added stateless matmul APIs to ACL and oneDNN
+- Added .gitignore
 
 ### Removed
 

--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -168,6 +168,7 @@ ENV LD_LIBRARY_PATH=$OPENBLAS_DIR/lib:$LD_LIBRARY_PATH
 # Build Arm Compute Library from source
 COPY scripts/build-acl.sh $PACKAGE_DIR/.
 COPY patches/acl_static_quantization.patch $PACKAGE_DIR/.
+COPY patches/acl_stateless_matmul.patch $PACKAGE_DIR/.
 
 RUN $PACKAGE_DIR/build-acl.sh
 ENV ACL_ROOT_DIR=$PROD_DIR/ComputeLibrary
@@ -260,7 +261,7 @@ ENV ONEDNN_BUILD="${onednn_opt}" \
 
 # Key version numbers
 ENV PY_VERSION="${default_py_version}" \
-    ONEDNN_VERSION="eb013e386e47d021b2ab169500ce6ab1147142e1" \
+    ONEDNN_VERSION=v3.5 \
     TORCH_VERSION=2.3.0 \
     TORCHVISION_VERSION=0.17.1 \
     TORCHDATA_VERSION=0.7.1 \
@@ -290,6 +291,8 @@ COPY patches/ideep_static_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_static_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_gelu.patch $PACKAGE_DIR/.
+
+COPY patches/onednn_stateless_matmul.patch $PACKAGE_DIR/.
 
 COPY scripts/build-torchvision.sh $PACKAGE_DIR/.
 COPY scripts/build-torchtext.sh $PACKAGE_DIR/.

--- a/docker/pytorch-aarch64/patches/acl_stateless_matmul.patch
+++ b/docker/pytorch-aarch64/patches/acl_stateless_matmul.patch
@@ -1,0 +1,1689 @@
+*******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+ 
+diff --git a/Android.bp b/Android.bp
+index 1f1e591bd1..e69ea03c39 100644
+--- a/Android.bp
++++ b/Android.bp
+@@ -1019,6 +1019,9 @@ cc_library_static {
+         "src/runtime/heuristics/matmul_native/ClMatMulNativeDefaultConfigValhall.cpp",
+         "src/runtime/heuristics/matmul_native/ClMatMulNativeDefaultVariantValhall.cpp",
+         "src/runtime/heuristics/matmul_native/ClMatMulNativeHelpers.cpp",
++        "src/runtime/operators/CpuActivation.cpp",
++        "src/runtime/operators/CpuGemmAssemblyDispatch.cpp",
++        "src/runtime/operators/CpuTranspose.cpp",
+         "utils/CommonGraphOptions.cpp",
+         "utils/GraphUtils.cpp",
+         "utils/Utils.cpp",
+diff --git a/arm_compute/runtime/operators/CpuActivation.h b/arm_compute/runtime/operators/CpuActivation.h
+new file mode 100644
+index 0000000000..bc8b5d2028
+--- /dev/null
++++ b/arm_compute/runtime/operators/CpuActivation.h
+@@ -0,0 +1,63 @@
++/*
++ * Copyright (c) 2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++
++#ifndef ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUACTIVATION_H
++#define ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUACTIVATION_H
++
++#include "arm_compute/core/ITensorPack.h"
++#include "arm_compute/core/TensorInfo.h"
++
++namespace arm_compute
++{
++namespace op
++{
++/** Wrapper class for CpuActivation. For information on the functions,
++ * see "src/cpu/operators/CpuActivation.h"
++*/
++class CpuActivation
++{
++public:
++    /** Constructor **/
++    CpuActivation();
++    /** Prevent instances of this class from being copied (As this class contains pointers) */
++    CpuActivation(const CpuActivation &) = delete;
++    /** Default move constructor */
++    CpuActivation(CpuActivation &&) = default;
++    /** Default destructor */
++    ~CpuActivation();
++
++    void configure(const ITensorInfo *src, ITensorInfo *dst, const ActivationLayerInfo &act_info);
++
++    static Status validate(const ITensorInfo *src, const ITensorInfo *dst, const ActivationLayerInfo &act_info);
++
++    void run(ITensorPack &tensors);
++
++private:
++    struct Impl;
++    std::unique_ptr<Impl> _impl;
++};
++} // namespace op
++} // namespace arm_compute
++
++#endif // ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUACTIVATION_H
+diff --git a/arm_compute/runtime/operators/CpuGemmAssemblyDispatch.h b/arm_compute/runtime/operators/CpuGemmAssemblyDispatch.h
+new file mode 100644
+index 0000000000..88e311c31f
+--- /dev/null
++++ b/arm_compute/runtime/operators/CpuGemmAssemblyDispatch.h
+@@ -0,0 +1,88 @@
++/*
++ * Copyright (c) 2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++
++#ifndef ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUGEMMASSEMBLYDISPATCH_H
++#define ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUGEMMASSEMBLYDISPATCH_H
++
++#include "arm_compute/core/ITensorPack.h"
++#include "arm_compute/core/TensorInfo.h"
++#include "arm_compute/function_info/GEMMInfo.h"
++#include "arm_compute/runtime/IOperator.h"
++
++namespace arm_compute
++{
++namespace op
++{
++/** Wrapper class for CpuGemmAssemblyDispatch. For information on the functions,
++ * see "src/cpu/operators/CpuGemmAssemblyDispatch.h"
++*/
++class CpuGemmAssemblyDispatch : arm_compute::experimental::IOperator
++{
++public:
++    /** Constructor **/
++    CpuGemmAssemblyDispatch();
++    /** Prevent instances of this class from being copied (As this class contains pointers) */
++    CpuGemmAssemblyDispatch(const CpuGemmAssemblyDispatch &) = delete;
++    /** Default move constructor */
++    CpuGemmAssemblyDispatch(CpuGemmAssemblyDispatch &&) = default;
++    /** Default destructor */
++    ~CpuGemmAssemblyDispatch();
++
++    void configure(const ITensorInfo *a,
++                   const ITensorInfo *b,
++                   const ITensorInfo *c,
++                   ITensorInfo       *d,
++                   const GEMMInfo    &gemm_info = GEMMInfo());
++
++    static Status validate(const ITensorInfo *a,
++                           const ITensorInfo *b,
++                           const ITensorInfo *c,
++                           const ITensorInfo *d,
++                           const GEMMInfo    &gemm_info = GEMMInfo());
++
++    static Status has_opt_impl(arm_compute::WeightFormat &weight_format,
++                               const ITensorInfo         *a,
++                               const ITensorInfo         *b,
++                               const ITensorInfo         *c,
++                               const ITensorInfo         *d,
++                               const GEMMInfo            &gemm_info = GEMMInfo());
++
++    static bool is_activation_supported(const ActivationLayerInfo &activation);
++
++    bool is_configured() const;
++
++    void                             run(ITensorPack &tensors);
++    void                             prepare(ITensorPack &constants);
++    experimental::MemoryRequirements workspace() const;
++
++    bool isVarWeightsKernel() const;
++
++private:
++    struct Impl;
++    std::unique_ptr<Impl> _impl;
++};
++} // namespace op
++} // namespace arm_compute
++
++#endif // ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUGEMMASSEMBLYDISPATCH_H
+diff --git a/arm_compute/runtime/operators/CpuTranspose.h b/arm_compute/runtime/operators/CpuTranspose.h
+new file mode 100644
+index 0000000000..afb9640df3
+--- /dev/null
++++ b/arm_compute/runtime/operators/CpuTranspose.h
+@@ -0,0 +1,63 @@
++/*
++ * Copyright (c) 2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++
++#ifndef ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUTRANSPOSE_H
++#define ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUTRANSPOSE_H
++
++#include "arm_compute/core/ITensorPack.h"
++#include "arm_compute/core/TensorInfo.h"
++
++namespace arm_compute
++{
++namespace op
++{
++/** Wrapper class for CpuTranspose. For information on the functions,
++ * see "src/cpu/operators/CpuTranspose.h"
++*/
++class CpuTranspose
++{
++public:
++    /** Constructor **/
++    CpuTranspose();
++    /** Prevent instances of this class from being copied (As this class contains pointers) */
++    CpuTranspose(const CpuTranspose &) = delete;
++    /** Default move constructor */
++    CpuTranspose(CpuTranspose &&) = default;
++    /** Default destructor */
++    ~CpuTranspose();
++
++    void configure(const ITensorInfo *src, ITensorInfo *dst);
++
++    static Status validate(const ITensorInfo *src, const ITensorInfo *dst);
++
++    void run(ITensorPack &tensors);
++
++private:
++    struct Impl;
++    std::unique_ptr<Impl> _impl;
++};
++} // namespace op
++} // namespace arm_compute
++
++#endif // ACL_ARM_COMPUTE_RUNTIME_OPERATORS_CPUTRANSPOSE_H
+diff --git a/filelist.json b/filelist.json
+index e833de9fc7..0fc3e7b9e8 100644
+--- a/filelist.json
++++ b/filelist.json
+@@ -1592,7 +1592,10 @@
+             "src/cpu/operators/CpuGemmLowpMatrixMultiplyCore.cpp",
+             "src/runtime/NEON/functions/NEGEMM.cpp",
+             "src/runtime/NEON/functions/NEGEMMLowpMatrixMultiplyCore.cpp",
+-            "src/runtime/NEON/functions/NEGEMMLowpOutputStage.cpp"
++            "src/runtime/NEON/functions/NEGEMMLowpOutputStage.cpp",
++            "src/runtime/operators/CpuActivation.cpp",
++            "src/runtime/operators/CpuGemmAssemblyDispatch.cpp",
++            "src/runtime/operators/CpuTranspose.cpp"
+           ],
+           "neon": {
+             "common": [
+diff --git a/src/BUILD.bazel b/src/BUILD.bazel
+index f270824ab4..1c421378e2 100644
+--- a/src/BUILD.bazel
++++ b/src/BUILD.bazel
+@@ -1008,7 +1008,10 @@ filegroup(
+ 	"runtime/SubTensor.cpp",
+ 	"runtime/Tensor.cpp",
+ 	"runtime/TensorAllocator.cpp",
+-	"runtime/Utils.cpp"]  +
++	"runtime/Utils.cpp",
++	"runtime/operators/CpuActivation.cpp",
++	"runtime/operators/CpuGemmAssemblyDispatch.cpp",
++	"runtime/operators/CpuTranspose.cpp"]  +
+     glob(["**/*.h",
+     "**/*.hpp",
+     "**/*.inl"]),
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index 87c5f8b21d..151991baf5 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -346,9 +346,9 @@ target_sources(
+ )
+ 
+ target_sources(
+-    arm_compute
+-    PRIVATE
+-    c/AclContext.cpp
++	arm_compute
++	PRIVATE
++	c/AclContext.cpp
+ 	c/AclOperator.cpp
+ 	c/AclQueue.cpp
+ 	c/AclTensor.cpp
+@@ -1000,4 +1000,7 @@ target_sources(
+ 	runtime/Tensor.cpp
+ 	runtime/TensorAllocator.cpp
+ 	runtime/Utils.cpp
+-)
+\ No newline at end of file
++	runtime/operators/CpuActivation.cpp
++	runtime/operators/CpuGemmAssemblyDispatch.cpp
++	runtime/operators/CpuTranspose.cpp
++)
+diff --git a/src/runtime/operators/CpuActivation.cpp b/src/runtime/operators/CpuActivation.cpp
+new file mode 100644
+index 0000000000..0ad5cbd042
+--- /dev/null
++++ b/src/runtime/operators/CpuActivation.cpp
+@@ -0,0 +1,62 @@
++/*
++ * Copyright (c) 2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++
++#include "arm_compute/runtime/operators/CpuActivation.h"
++
++#include "src/cpu/operators/CpuActivation.h"
++
++namespace arm_compute
++{
++namespace op
++{
++
++struct CpuActivation::Impl
++{
++    std::unique_ptr<cpu::CpuActivation> op{nullptr};
++};
++
++CpuActivation::CpuActivation() : _impl(std::make_unique<Impl>())
++{
++    _impl->op = std::make_unique<cpu::CpuActivation>();
++}
++
++CpuActivation::~CpuActivation() = default;
++
++void CpuActivation::configure(const ITensorInfo *src, ITensorInfo *dst, const ActivationLayerInfo &act_info)
++{
++    _impl->op->configure(src, dst, act_info);
++}
++
++Status CpuActivation::validate(const ITensorInfo *src, const ITensorInfo *dst, const ActivationLayerInfo &act_info)
++{
++    return cpu::CpuActivation::validate(src, dst, act_info);
++}
++
++void CpuActivation::run(ITensorPack &tensors)
++{
++    _impl->op->run(tensors);
++}
++
++} // namespace op
++} // namespace arm_compute
+diff --git a/src/runtime/operators/CpuGemmAssemblyDispatch.cpp b/src/runtime/operators/CpuGemmAssemblyDispatch.cpp
+new file mode 100644
+index 0000000000..e20b36f158
+--- /dev/null
++++ b/src/runtime/operators/CpuGemmAssemblyDispatch.cpp
+@@ -0,0 +1,117 @@
++/*
++ * Copyright (c) 2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++
++#include "arm_compute/runtime/operators/CpuGemmAssemblyDispatch.h"
++
++#include "src/cpu/operators/internal/CpuGemmAssemblyDispatch.h"
++
++namespace arm_compute
++{
++namespace op
++{
++
++namespace
++{
++cpu::AsmGemmInfo init_assembly_metadata(const GEMMInfo &info)
++{
++    cpu::AsmGemmInfo asm_info;
++    asm_info.method                  = cpu::AsmConvMethod::Im2Col;
++    asm_info.reinterpret_input_as_3d = info.reinterpret_input_as_3d();
++    asm_info.depth_output_gemm3d     = info.depth_output_gemm3d();
++    asm_info.activation_info         = info.activation_info();
++    asm_info.fast_mode               = info.fast_math();
++    asm_info.fixed_format            = info.fixed_format();
++    asm_info.weight_format           = info.weight_format();
++    asm_info.accumulate              = info.accumulate();
++    asm_info.transpose_b =
++        info.pretranspose_B(); // The "pretranspose_B" flag here is not the same as the pretranspose_B_array method. The flag here signals to pretranspose_B_array method if we want to perform additional transpose on B before the pretranspose_B_array method
++
++    return asm_info;
++}
++} // namespace
++
++struct CpuGemmAssemblyDispatch::Impl
++{
++    std::unique_ptr<cpu::CpuGemmAssemblyDispatch> cpu_gemm_assembly_dispatch{nullptr};
++};
++
++CpuGemmAssemblyDispatch::CpuGemmAssemblyDispatch() : _impl(std::make_unique<Impl>())
++{
++    _impl->cpu_gemm_assembly_dispatch = std::make_unique<cpu::CpuGemmAssemblyDispatch>();
++}
++
++CpuGemmAssemblyDispatch::~CpuGemmAssemblyDispatch() = default;
++
++void CpuGemmAssemblyDispatch::configure(
++    const ITensorInfo *a, const ITensorInfo *b, const ITensorInfo *c, ITensorInfo *d, const GEMMInfo &gemm_info)
++{
++    _impl->cpu_gemm_assembly_dispatch->configure(a, b, c, d, init_assembly_metadata(gemm_info));
++}
++
++Status CpuGemmAssemblyDispatch::validate(
++    const ITensorInfo *a, const ITensorInfo *b, const ITensorInfo *c, const ITensorInfo *d, const GEMMInfo &gemm_info)
++{
++    return cpu::CpuGemmAssemblyDispatch::validate(a, b, c, d, init_assembly_metadata(gemm_info));
++}
++
++Status CpuGemmAssemblyDispatch::has_opt_impl(arm_compute::WeightFormat &weight_format,
++                                             const ITensorInfo         *a,
++                                             const ITensorInfo         *b,
++                                             const ITensorInfo         *c,
++                                             const ITensorInfo         *d,
++                                             const GEMMInfo            &gemm_info)
++{
++    return cpu::CpuGemmAssemblyDispatch::has_opt_impl(weight_format, a, b, c, d, init_assembly_metadata(gemm_info));
++}
++
++bool CpuGemmAssemblyDispatch::is_activation_supported(const ActivationLayerInfo &activation)
++{
++    return cpu::CpuGemmAssemblyDispatch::is_activation_supported(activation);
++};
++
++bool CpuGemmAssemblyDispatch::is_configured() const
++{
++    return _impl->cpu_gemm_assembly_dispatch->is_configured();
++};
++
++void CpuGemmAssemblyDispatch::run(ITensorPack &tensors)
++{
++    _impl->cpu_gemm_assembly_dispatch->run(tensors);
++}
++void CpuGemmAssemblyDispatch::prepare(ITensorPack &constants)
++{
++    _impl->cpu_gemm_assembly_dispatch->prepare(constants);
++}
++experimental::MemoryRequirements CpuGemmAssemblyDispatch::workspace() const
++{
++    return _impl->cpu_gemm_assembly_dispatch->workspace();
++}
++
++bool CpuGemmAssemblyDispatch::isVarWeightsKernel() const
++{
++    return _impl->cpu_gemm_assembly_dispatch->isVarWeightsKernel();
++}
++
++} // namespace op
++} // namespace arm_compute
+diff --git a/src/runtime/operators/CpuTranspose.cpp b/src/runtime/operators/CpuTranspose.cpp
+new file mode 100644
+index 0000000000..85942a1992
+--- /dev/null
++++ b/src/runtime/operators/CpuTranspose.cpp
+@@ -0,0 +1,62 @@
++/*
++ * Copyright (c) 2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++
++#include "arm_compute/runtime/operators/CpuTranspose.h"
++
++#include "src/cpu/operators/CpuTranspose.h"
++
++namespace arm_compute
++{
++namespace op
++{
++
++struct CpuTranspose::Impl
++{
++    std::unique_ptr<cpu::CpuTranspose> op{nullptr};
++};
++
++CpuTranspose::CpuTranspose() : _impl(std::make_unique<Impl>())
++{
++    _impl->op = std::make_unique<cpu::CpuTranspose>();
++}
++
++CpuTranspose::~CpuTranspose() = default;
++
++void CpuTranspose::configure(const ITensorInfo *src, ITensorInfo *dst)
++{
++    _impl->op->configure(src, dst);
++}
++
++Status CpuTranspose::validate(const ITensorInfo *src, const ITensorInfo *dst)
++{
++    return cpu::CpuTranspose::validate(src, dst);
++}
++
++void CpuTranspose::run(ITensorPack &tensors)
++{
++    _impl->op->run(tensors);
++}
++
++} // namespace op
++} // namespace arm_compute
+diff --git a/tests/BUILD.bazel b/tests/BUILD.bazel
+index 5763938d3c..5c1e691810 100644
+--- a/tests/BUILD.bazel
++++ b/tests/BUILD.bazel
+@@ -1,4 +1,4 @@
+-# Copyright (c) 2023 Arm Limited.
++# Copyright (c) 2023-2024 Arm Limited.
+ #
+ # SPDX-License-Identifier: MIT
+ #
+@@ -72,6 +72,7 @@ cc_binary(
+         "NEON/*.h",
+         "validation/NEON/**/*.cpp",
+         "validation/NEON/**/*.h",
++        "validation/runtime/**/*.cpp",
+         "*.cpp",
+         "datasets/*.h",
+         "instruments/*.h",
+diff --git a/tests/SConscript b/tests/SConscript
+index fe9d6878e4..16267baf44 100644
+--- a/tests/SConscript
++++ b/tests/SConscript
+@@ -117,6 +117,9 @@ files_validation += Glob('validation/UNIT/*.cpp')
+ filter_pattern = test_env['test_filter']
+ files_validation += Glob('validation/CPP/' + filter_pattern)
+ 
++# Add wrapper tests
++files_validation += Glob('validation/runtime/*/' + filter_pattern)
++
+ if env['opencl']:
+     if env['experimental_dynamic_fusion']:
+         files_validation += Glob('validation/dynamic_fusion/gpu/' + filter_pattern)
+diff --git a/tests/validation/CMakeLists.txt b/tests/validation/CMakeLists.txt
+index 448e96c4f9..525f429bfc 100644
+--- a/tests/validation/CMakeLists.txt
++++ b/tests/validation/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-# Copyright (c) 2023 Arm Limited.
++# Copyright (c) 2023-2024 Arm Limited.
+ #
+ # SPDX-License-Identifier: MIT
+ #
+@@ -142,5 +142,8 @@ if(ENABLE_NEON)
+             NEON/UNIT/DynamicTensor.cpp
+             NEON/UNIT/TensorAllocator.cpp
+             NEON/UNIT/MemoryManager.cpp
+-            NEON/UNIT/RuntimeContext.cpp)
++            NEON/UNIT/RuntimeContext.cpp
++            runtime/operators/CpuActivation.cpp
++            runtime/operators/CpuGemmAssemblyDispatch.cpp
++            runtime/operators/CpuTranspose.cpp)
+ endif()
+diff --git a/tests/validation/fixtures/CpuActivationFixture.h b/tests/validation/fixtures/CpuActivationFixture.h
+new file mode 100644
+index 0000000000..792c7e9793
+--- /dev/null
++++ b/tests/validation/fixtures/CpuActivationFixture.h
+@@ -0,0 +1,281 @@
++/*
++ * Copyright (c) 2017-2021, 2023-2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++#ifndef ACL_TESTS_VALIDATION_FIXTURES_CPUACTIVATIONFIXTURE_H
++#define ACL_TESTS_VALIDATION_FIXTURES_CPUACTIVATIONFIXTURE_H
++
++#include "arm_compute/core/TensorShape.h"
++#include "arm_compute/core/Types.h"
++
++#include "tests/AssetsLibrary.h"
++#include "tests/framework/Asserts.h"
++#include "tests/framework/Fixture.h"
++#include "tests/framework/ParametersLibrary.h"
++#include "tests/Globals.h"
++#include "tests/IAccessor.h"
++#include "tests/validation/Helpers.h"
++#include "tests/validation/reference/ActivationLayer.h"
++
++#include <random>
++
++namespace arm_compute
++{
++namespace test
++{
++namespace validation
++{
++template <typename TensorType, typename AccessorType, typename FunctionType, typename T>
++class CpuActivationValidationGenericFixture : public framework::Fixture
++{
++public:
++    void setup(TensorShape                             shape,
++               bool                                    in_place,
++               ActivationLayerInfo::ActivationFunction function,
++               float                                   alpha_beta,
++               DataType                                data_type,
++               QuantizationInfo                        quantization_info)
++    {
++        ActivationLayerInfo info(function, alpha_beta, alpha_beta);
++
++        _in_place                 = in_place;
++        _data_type                = data_type;
++        _output_quantization_info = calculate_output_quantization_info(_data_type, info, quantization_info);
++        _input_quantization_info  = in_place ? _output_quantization_info : quantization_info;
++
++        _function  = function;
++        _target    = compute_target(shape, info);
++        _reference = compute_reference(shape, info);
++    }
++
++protected:
++    std::vector<T> get_boundary_values(T min, T max)
++    {
++        // This function will return a vector filled with the following values that can
++        // represent two partitions derived from equivalent partitioning.
++        // * Lower parition: min, min + delta, lower quarter (nominal), center - delta
++        // * Upper partition: center, center + delta, upper quarter (nominal), max - delta, max
++        const auto delta         = is_data_type_float(_data_type) ? T(0.1f) : T(1);
++        const auto center_value  = (min + max) / 2;
++        const auto lower_quarter = (min + center_value) / 2;
++        const auto upper_quarter = (center_value + max) / 2;
++
++        std::vector<T> boundary_values{};
++
++        // To ensure all the inserted values are within the given range after subtracing/adding delta
++        auto insert_values = [&boundary_values, &min, &max](const std::initializer_list<T> &new_values)
++        {
++            for (auto &v : new_values)
++            {
++                if (v >= min && v <= max)
++                {
++                    boundary_values.emplace_back(v);
++                }
++            }
++        };
++
++        insert_values({min, static_cast<T>(min + delta), static_cast<T>(lower_quarter),
++                       static_cast<T>(center_value - delta)}); // lower partition
++        insert_values({static_cast<T>(center_value), static_cast<T>(center_value + delta),
++                       static_cast<T>(upper_quarter), static_cast<T>(max - delta), max}); // upper partition
++
++        return boundary_values;
++    }
++
++    template <typename U>
++    void fill(U &&tensor)
++    {
++        if (is_data_type_float(_data_type))
++        {
++            float min_bound                = 0;
++            float max_bound                = 0;
++            std::tie(min_bound, max_bound) = get_activation_layer_test_bounds<T>(_function, _data_type);
++            library->fill_static_values(tensor,
++                                        get_boundary_values(static_cast<T>(min_bound), static_cast<T>(max_bound)));
++        }
++        else
++        {
++            PixelValue min{};
++            PixelValue max{};
++            std::tie(min, max) = get_min_max(tensor.data_type());
++            library->fill_static_values(tensor, get_boundary_values(min.get<T>(), max.get<T>()));
++        }
++    }
++
++    TensorType compute_target(const TensorShape &shape, ActivationLayerInfo info)
++    {
++        // Create tensors
++        TensorType src = create_tensor<TensorType>(shape, _data_type, 1, _input_quantization_info, DataLayout::NCHW);
++        TensorType dst = create_tensor<TensorType>(shape, _data_type, 1, _output_quantization_info, DataLayout::NCHW);
++
++        // Create and configure function
++        FunctionType act_layer;
++
++        TensorType *dst_ptr = _in_place ? &src : &dst;
++
++        if (!_in_place)
++        {
++            act_layer.configure(src.info(), dst.info(), info);
++        }
++        else
++        {
++            act_layer.configure(src.info(), nullptr, info);
++        }
++
++        ARM_COMPUTE_ASSERT(src.info()->is_resizable());
++        ARM_COMPUTE_ASSERT(dst.info()->is_resizable());
++
++        // Allocate tensors
++        src.allocator()->allocate();
++        ARM_COMPUTE_ASSERT(!src.info()->is_resizable());
++
++        if (!_in_place)
++        {
++            dst.allocator()->allocate();
++            ARM_COMPUTE_ASSERT(!dst.info()->is_resizable());
++        }
++
++        // Fill tensors
++        fill(AccessorType(src));
++
++        // Compute function
++        ITensorPack run_pack{{arm_compute::TensorType::ACL_SRC, &src}, {arm_compute::TensorType::ACL_DST, dst_ptr}};
++        act_layer.run(run_pack);
++
++        if (_in_place)
++        {
++            return src;
++        }
++        else
++        {
++            return dst;
++        }
++    }
++
++    SimpleTensor<T> compute_reference(const TensorShape &shape, ActivationLayerInfo info)
++    {
++        // Create reference
++        SimpleTensor<T> src{shape, _data_type, 1, _input_quantization_info};
++
++        // Fill reference
++        fill(src);
++
++        return reference::activation_layer<T>(src, info, _output_quantization_info);
++    }
++
++private:
++    QuantizationInfo calculate_output_quantization_info(DataType                   dt,
++                                                        const ActivationLayerInfo &act_info,
++                                                        const QuantizationInfo    &default_qinfo)
++    {
++        auto qasymm8_max        = float(std::numeric_limits<uint8_t>::max()) + 1.f;
++        auto qasymm8_signed_max = float(std::numeric_limits<int8_t>::max()) + 1.f;
++        auto qsymm16_max        = float(std::numeric_limits<int16_t>::max()) + 1.f;
++
++        switch (act_info.activation())
++        {
++            case ActivationLayerInfo::ActivationFunction::TANH:
++                if (dt == DataType::QSYMM16)
++                {
++                    return QuantizationInfo(1.f / qsymm16_max, 0);
++                }
++                else if (dt == DataType::QASYMM8)
++                {
++                    return QuantizationInfo(1.f / (0.5 * qasymm8_max), int(0.5 * qasymm8_max));
++                }
++                else if (dt == DataType::QASYMM8_SIGNED)
++                {
++                    return QuantizationInfo(1.f / qasymm8_signed_max, 0);
++                }
++                else
++                {
++                    return default_qinfo;
++                }
++            case ActivationLayerInfo::ActivationFunction::LOGISTIC:
++                if (dt == DataType::QSYMM16)
++                {
++                    return QuantizationInfo(1.f / qsymm16_max, 0);
++                }
++                else if (dt == DataType::QASYMM8)
++                {
++                    return QuantizationInfo(1.f / qasymm8_max, 0);
++                }
++                else if (dt == DataType::QASYMM8_SIGNED)
++                {
++                    return QuantizationInfo(1.f / (2.f * qasymm8_signed_max), -int(qasymm8_signed_max));
++                }
++                else
++                {
++                    return default_qinfo;
++                }
++            default:
++                return default_qinfo;
++        }
++    }
++
++protected:
++    TensorType                              _target{};
++    SimpleTensor<T>                         _reference{};
++    bool                                    _in_place{};
++    QuantizationInfo                        _input_quantization_info{};
++    QuantizationInfo                        _output_quantization_info{};
++    DataType                                _data_type{};
++    ActivationLayerInfo::ActivationFunction _function{};
++};
++
++template <typename TensorType, typename AccessorType, typename FunctionType, typename T>
++class CpuActivationValidationFixture
++    : public CpuActivationValidationGenericFixture<TensorType, AccessorType, FunctionType, T>
++{
++public:
++    void setup(TensorShape                             shape,
++               bool                                    in_place,
++               ActivationLayerInfo::ActivationFunction function,
++               float                                   alpha_beta,
++               DataType                                data_type)
++    {
++        CpuActivationValidationGenericFixture<TensorType, AccessorType, FunctionType, T>::setup(
++            shape, in_place, function, alpha_beta, data_type, QuantizationInfo());
++    }
++};
++
++template <typename TensorType, typename AccessorType, typename FunctionType, typename T>
++class CpuActivationValidationQuantizedFixture
++    : public CpuActivationValidationGenericFixture<TensorType, AccessorType, FunctionType, T>
++{
++public:
++    void setup(TensorShape                             shape,
++               bool                                    in_place,
++               ActivationLayerInfo::ActivationFunction function,
++               float                                   alpha_beta,
++               DataType                                data_type,
++               QuantizationInfo                        quantization_info)
++    {
++        CpuActivationValidationGenericFixture<TensorType, AccessorType, FunctionType, T>::setup(
++            shape, in_place, function, alpha_beta, data_type, quantization_info);
++    }
++};
++
++} // namespace validation
++} // namespace test
++} // namespace arm_compute
++#endif // ACL_TESTS_VALIDATION_FIXTURES_CPUACTIVATIONFIXTURE_H
+diff --git a/tests/validation/fixtures/TransposeFixture.h b/tests/validation/fixtures/TransposeFixture.h
+index 212c76cc9a..a3cf107a8e 100644
+--- a/tests/validation/fixtures/TransposeFixture.h
++++ b/tests/validation/fixtures/TransposeFixture.h
+@@ -1,5 +1,5 @@
+ /*
+- * Copyright (c) 2017-2021, 2023 Arm Limited.
++ * Copyright (c) 2017-2021, 2023-2024 Arm Limited.
+  *
+  * SPDX-License-Identifier: MIT
+  *
+@@ -103,6 +103,70 @@ protected:
+     TensorType      _target{};
+     SimpleTensor<T> _reference{};
+ };
++template <typename TensorType, typename AccessorType, typename FunctionType, typename T>
++class CpuTransposeValidationFixture : public framework::Fixture
++{
++public:
++    void setup(TensorShape shape, DataType data_type)
++    {
++        _target    = compute_target(shape, data_type);
++        _reference = compute_reference(shape, data_type);
++    }
++
++protected:
++    template <typename U>
++    void fill(U &&tensor)
++    {
++        library->fill_tensor_uniform(tensor, 0);
++    }
++
++    TensorType compute_target(const TensorShape &shape, DataType data_type)
++    {
++        // Make rows the columns of the original shape
++        TensorShape output_shape{shape[1], shape[0]};
++
++        // Create tensors
++        TensorType src = create_tensor<TensorType>(shape, data_type);
++        TensorType dst = create_tensor<TensorType>(output_shape, data_type);
++
++        // Create and configure function
++        FunctionType trans_func;
++        trans_func.configure(src.info(), dst.info());
++
++        ARM_COMPUTE_ASSERT(src.info()->is_resizable());
++        ARM_COMPUTE_ASSERT(dst.info()->is_resizable());
++
++        // Allocate tensors
++        src.allocator()->allocate();
++        dst.allocator()->allocate();
++
++        ARM_COMPUTE_ASSERT(!src.info()->is_resizable());
++        ARM_COMPUTE_ASSERT(!dst.info()->is_resizable());
++
++        // Fill tensors
++        fill(AccessorType(src));
++
++        // Compute function
++        ITensorPack run_pack{{arm_compute::TensorType::ACL_SRC, &src}, {arm_compute::TensorType::ACL_DST, &dst}};
++        trans_func.run(run_pack);
++
++        return dst;
++    }
++
++    SimpleTensor<T> compute_reference(const TensorShape &shape, DataType data_type)
++    {
++        // Create reference
++        SimpleTensor<T> src{shape, data_type};
++
++        // Fill reference
++        fill(src);
++
++        return reference::permute<T>(src, PermutationVector(1U, 0U));
++    }
++
++    TensorType      _target{};
++    SimpleTensor<T> _reference{};
++};
+ } // namespace validation
+ } // namespace test
+ } // namespace arm_compute
+diff --git a/tests/validation/runtime/operators/CpuActivation.cpp b/tests/validation/runtime/operators/CpuActivation.cpp
+new file mode 100644
+index 0000000000..2253583f67
+--- /dev/null
++++ b/tests/validation/runtime/operators/CpuActivation.cpp
+@@ -0,0 +1,420 @@
++/*
++ * Copyright (c) 2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++#include "arm_compute/runtime/operators/CpuActivation.h"
++
++#include "arm_compute/Acl.hpp"
++#include "arm_compute/core/Types.h"
++#include "arm_compute/core/utils/misc/Traits.h"
++#include "arm_compute/core/utils/StringUtils.h"
++#include "arm_compute/runtime/RuntimeContext.h"
++#include "arm_compute/runtime/Tensor.h"
++#include "arm_compute/runtime/TensorAllocator.h"
++
++#include "src/common/cpuinfo/CpuIsaInfo.h"
++#include "support/AclRequires.h"
++#include "tests/datasets/ActivationFunctionsDataset.h"
++#include "tests/datasets/ShapeDatasets.h"
++#include "tests/framework/Asserts.h"
++#include "tests/framework/datasets/Datasets.h"
++#include "tests/framework/Macros.h"
++#include "tests/NEON/Accessor.h"
++#include "tests/PaddingCalculator.h"
++#include "tests/validation/fixtures/CpuActivationFixture.h"
++#include "tests/validation/Validation.h"
++
++namespace arm_compute
++{
++namespace test
++{
++namespace validation
++{
++namespace
++{
++RelativeTolerance<float> tolerance_float_sqrt(0.0001f);
++
++/** Define relative tolerance of the activation layer.
++ *
++ * @param[in] data_type  The data type used.
++ * @param[in] activation The activation function used.
++ *
++ * @return Relative tolerance depending on the activation function.
++ */
++RelativeTolerance<float> relative_tolerance(DataType data_type, ActivationLayerInfo::ActivationFunction activation)
++{
++    switch (activation)
++    {
++        case ActivationLayerInfo::ActivationFunction::LOGISTIC:
++        case ActivationLayerInfo::ActivationFunction::ELU:
++        case ActivationLayerInfo::ActivationFunction::SQRT:
++        case ActivationLayerInfo::ActivationFunction::TANH:
++        case ActivationLayerInfo::ActivationFunction::HARD_SWISH:
++        case ActivationLayerInfo::ActivationFunction::SWISH:
++        case ActivationLayerInfo::ActivationFunction::GELU:
++            switch (data_type)
++            {
++                case DataType::F16:
++#if defined(ENABLE_SVE)
++                    return RelativeTolerance<float>(0.25f);
++#else  // !defined(ENABLE_SVE)
++                    return RelativeTolerance<float>(0.1f);
++#endif // defined(ENABLE_SVE)
++                default:
++                    return RelativeTolerance<float>(0.05f);
++            }
++        case ActivationLayerInfo::ActivationFunction::SOFT_RELU:
++            switch (data_type)
++            {
++                case DataType::F16:
++#if defined(ENABLE_SVE)
++                    return RelativeTolerance<float>(0.9f);
++#else  // !defined(ENABLE_SVE)
++                    return RelativeTolerance<float>(0.01f);
++#endif // defined(ENABLE_SVE)
++                default:
++                    return RelativeTolerance<float>(0.00001f);
++            }
++        default:
++            return RelativeTolerance<float>(0.f);
++    }
++}
++
++/** Define absolute tolerance of the activation layer.
++ *
++ * @param[in] data_type  The data type used.
++ * @param[in] activation The activation function used.
++ *
++ * @return Absolute tolerance depending on the activation function.
++ */
++AbsoluteTolerance<float> absolute_tolerance(DataType data_type, ActivationLayerInfo::ActivationFunction activation)
++{
++    switch (activation)
++    {
++        case ActivationLayerInfo::ActivationFunction::LOGISTIC:
++        case ActivationLayerInfo::ActivationFunction::SQRT:
++        case ActivationLayerInfo::ActivationFunction::TANH:
++        case ActivationLayerInfo::ActivationFunction::SWISH:
++        case ActivationLayerInfo::ActivationFunction::HARD_SWISH:
++            switch (data_type)
++            {
++                case DataType::F16:
++#if defined(ENABLE_SVE)
++                    return AbsoluteTolerance<float>(0.25f);
++#else  // !defined(ENABLE_SVE)
++                    return AbsoluteTolerance<float>(0.01f);
++#endif // defined(ENABLE_SVE)
++                default:
++                    return AbsoluteTolerance<float>(0.00001f);
++            }
++        case ActivationLayerInfo::ActivationFunction::SOFT_RELU:
++            switch (data_type)
++            {
++                case DataType::F16:
++#if defined(ENABLE_SVE)
++                    return AbsoluteTolerance<float>(0.9f);
++#else  // !defined(ENABLE_SVE)
++                    return AbsoluteTolerance<float>(0.01f);
++#endif // defined(ENABLE_SVE)
++                default:
++                    return AbsoluteTolerance<float>(0.00001f);
++            }
++        default:
++            return AbsoluteTolerance<float>(0.f);
++    }
++}
++
++/** Define absolute tolerance of the activation layer for qasymm8.
++ *
++ * @param[in] activation The activation function used.
++ *
++ * @return Absolute tolerance depending on the activation function.
++ */
++AbsoluteTolerance<uint8_t> tolerance_qasymm8(ActivationLayerInfo::ActivationFunction activation)
++{
++    switch (activation)
++    {
++        case ActivationLayerInfo::ActivationFunction::LOGISTIC:
++        case ActivationLayerInfo::ActivationFunction::SQRT:
++        case ActivationLayerInfo::ActivationFunction::TANH:
++        case ActivationLayerInfo::ActivationFunction::HARD_SWISH:
++        case ActivationLayerInfo::ActivationFunction::SOFT_RELU:
++        case ActivationLayerInfo::ActivationFunction::LEAKY_RELU:
++            return AbsoluteTolerance<uint8_t>(1);
++        default:
++            return AbsoluteTolerance<uint8_t>(0);
++    }
++}
++
++constexpr AbsoluteTolerance<int16_t> tolerance_qsymm16(1);
++
++/** CNN data types */
++const auto CNNDataTypes = framework::dataset::make("DataType",
++                                                   {
++#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
++                                                       DataType::F16,
++#endif /* __ARM_FEATURE_FP16_VECTOR_ARITHMETIC */
++                                                       DataType::F32,
++                                                   });
++
++const auto NeonActivationFunctionsDataset =
++    concat(datasets::ActivationFunctions(),
++           framework::dataset::make(
++               "ActivationFunction",
++               {ActivationLayerInfo::ActivationFunction::HARD_SWISH, ActivationLayerInfo::ActivationFunction::SWISH}));
++
++/** Input data sets. */
++const auto ActivationDataset =
++    combine(combine(framework::dataset::make("InPlace", {false, true}), NeonActivationFunctionsDataset),
++            framework::dataset::make("AlphaBeta", {0.5f, 1.f}));
++
++template <typename T, ARM_COMPUTE_REQUIRES_TA(arm_compute::utils::traits::is_floating_point<T>::value)>
++void test_float_sqrt_boundary_value()
++{
++    constexpr auto vector_size = uint32_t{16};
++
++    auto data_type = DataType::F32;
++#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
++    data_type = std::is_same<T, half>::value ? DataType::F16 : data_type;
++#endif /* __ARM_FEATURE_FP16_VECTOR_ARITHMETIC */
++
++    const auto boundary_value_vector = std::vector<T>{
++        std::numeric_limits<T>::min(),
++        T(0),
++        std::numeric_limits<T>::epsilon(),
++        std::numeric_limits<T>::max(),
++    };
++
++    // the following size ensures that the whole logic (vector + left-over) to be tested
++    // using all boundary values iff boundary_value_vecotr.size() is smaller than vector_size.
++    auto shape = TensorShape{vector_size + boundary_value_vector.size()};
++    auto info  = ActivationLayerInfo{ActivationLayerInfo::ActivationFunction::SQRT};
++    auto src   = create_tensor<Tensor>(shape, data_type);
++
++    op::CpuActivation act;
++    act.configure(src.info(), nullptr, info);
++    src.allocator()->allocate();
++    library->fill_static_values(Accessor(src), boundary_value_vector);
++    ITensorPack pack;
++    pack.add_tensor(ACL_SRC, &src);
++    pack.add_tensor(ACL_DST, &src);
++    act.run(pack);
++
++    auto reference_src = SimpleTensor<T>{shape, data_type};
++    library->fill_static_values(reference_src, boundary_value_vector);
++    auto reference_dst = reference::activation_layer<T>(reference_src, info);
++
++    validate(Accessor(src), reference_dst, tolerance_float_sqrt);
++}
++} // namespace
++
++TEST_SUITE(OPERATORS)
++TEST_SUITE(ActivationLayer)
++
++/** Test case for memory injection in @ref cpu::CpuWinogradConv2d.
++ *
++ * Configure the operator once and inject memory at run-time in multiple executions.
++ *
++ * Checks performed in order:
++ * - Both runs compute the same output
++ */
++TEST_CASE(ActivationAPI, framework::DatasetMode::ALL)
++{
++    acl::StatusCode err = acl::StatusCode::Success;
++
++    // Create context & Queue
++    acl::Context ctx(acl::Target::Cpu, &err);
++    ARM_COMPUTE_ASSERT(err == acl::StatusCode::Success);
++
++    acl::Queue queue(ctx, &err);
++    ARM_COMPUTE_ASSERT(err == acl::StatusCode::Success);
++
++    // Create activation operator
++    acl::TensorDescriptor src_info({2, 3}, acl::DataType::Float32);
++    acl::TensorDescriptor dst_info({2, 3}, acl::DataType::Float32);
++    acl::ActivationDesc   desc{AclRelu, 6.f, 0.f, false};
++
++    acl::Activation act(ctx, src_info, dst_info, desc, &err);
++    ARM_COMPUTE_ASSERT(err == acl::StatusCode::Success);
++
++    // Create tensors and feed
++    acl::Tensor src(ctx, src_info, &err);
++    ARM_COMPUTE_ASSERT(err == acl::StatusCode::Success);
++    acl::Tensor dst(ctx, dst_info, &err);
++    ARM_COMPUTE_ASSERT(err == acl::StatusCode::Success);
++
++    acl::TensorPack pack(ctx);
++    err = pack.add(src, ACL_SRC);
++    err = pack.add(dst, ACL_DST);
++    ARM_COMPUTE_ASSERT(err == acl::StatusCode::Success);
++
++    // Execute operator
++    err = act.run(queue, pack);
++    ARM_COMPUTE_ASSERT(err == acl::StatusCode::Success);
++}
++
++// *INDENT-OFF*
++// clang-format off
++DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(zip(zip(
++    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching data types
++                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
++                                            TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F32),     // Mismatching shapes
++                                          }),
++    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(27U, 13U, 2U), 1, DataType::F16),
++                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
++                                            TensorInfo(TensorShape(32U, 13U, 2U), 1, DataType::F32),
++                                          })),
++    framework::dataset::make("ActivationInfo", { ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
++                                                 ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
++                                                 ActivationLayerInfo(ActivationLayerInfo::ActivationFunction::RELU),
++                                               })),
++    framework::dataset::make("Expected", { false, true, false})),
++    input_info, output_info, act_info, expected)
++{
++    bool is_valid = bool(op::CpuActivation::validate(&input_info.clone()->set_is_resizable(false), &output_info.clone()->set_is_resizable(false), act_info));
++    ARM_COMPUTE_EXPECT(is_valid == expected, framework::LogLevel::ERRORS);
++}
++// clang-format on
++// *INDENT-ON*
++
++template <typename T>
++using CpuActivationFixture = CpuActivationValidationFixture<Tensor, Accessor, op::CpuActivation, T>;
++
++TEST_SUITE(Float)
++#ifdef __ARM_FEATURE_FP16_VECTOR_ARITHMETIC
++TEST_SUITE(FP16)
++TEST_CASE(SqrtBoundaryValue, framework::DatasetMode::ALL)
++{
++    test_float_sqrt_boundary_value<half>();
++}
++FIXTURE_DATA_TEST_CASE(RunSmall,
++                       CpuActivationFixture<half>,
++                       framework::DatasetMode::ALL,
++                       combine(combine(datasets::SmallShapes(), ActivationDataset),
++                               framework::dataset::make("DataType", DataType::F16)))
++{
++    // Validate output
++    validate(Accessor(_target), _reference, relative_tolerance(_data_type, _function), 0.f,
++             absolute_tolerance(_data_type, _function));
++}
++TEST_SUITE_END() // FP16
++#endif           /* __ARM_FEATURE_FP16_VECTOR_ARITHMETIC */
++
++TEST_SUITE(FP32)
++TEST_CASE(SqrtBoundaryValue, framework::DatasetMode::ALL)
++{
++    test_float_sqrt_boundary_value<float>();
++}
++FIXTURE_DATA_TEST_CASE(RunSmall,
++                       CpuActivationFixture<float>,
++                       framework::DatasetMode::ALL,
++                       combine(combine(datasets::SmallShapes(), ActivationDataset),
++                               framework::dataset::make("DataType", DataType::F32)))
++
++{
++    // Validate output
++    validate(Accessor(_target), _reference, relative_tolerance(_data_type, _function), 0.f,
++             absolute_tolerance(_data_type, _function));
++}
++TEST_SUITE_END() // FP32
++TEST_SUITE_END() // Float
++
++template <typename T>
++using CpuActivationQuantizedFixture = CpuActivationValidationQuantizedFixture<Tensor, Accessor, op::CpuActivation, T>;
++
++/** Input data sets. */
++const auto QuantizedActivationFunctionsDataset =
++    framework::dataset::make("ActivationFunction",
++                             {
++                                 ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU,
++                                 ActivationLayerInfo::ActivationFunction::RELU,
++                                 ActivationLayerInfo::ActivationFunction::BOUNDED_RELU,
++                                 ActivationLayerInfo::ActivationFunction::LOGISTIC,
++                                 ActivationLayerInfo::ActivationFunction::TANH,
++                                 ActivationLayerInfo::ActivationFunction::LEAKY_RELU,
++                             });
++
++const auto QuantizedActivationDataset =
++    combine(combine(framework::dataset::make("InPlace", {false}),
++                    concat(QuantizedActivationFunctionsDataset,
++                           framework::dataset::make("ActivationFunction",
++                                                    ActivationLayerInfo::ActivationFunction::HARD_SWISH))),
++            framework::dataset::make("AlphaBeta", {0.5f, 1.f}));
++
++TEST_SUITE(Quantized)
++TEST_SUITE(QASYMM8)
++FIXTURE_DATA_TEST_CASE(RunSmall,
++                       CpuActivationQuantizedFixture<uint8_t>,
++                       framework::DatasetMode::ALL,
++                       combine(combine(combine(datasets::SmallShapes(), QuantizedActivationDataset),
++                                       framework::dataset::make("DataType", DataType::QASYMM8)),
++                               framework::dataset::make("QuantizationInfo", {QuantizationInfo(0.1f, 128.0f)})))
++{
++    // Validate output
++    validate(Accessor(_target), _reference, tolerance_qasymm8(_function));
++}
++TEST_SUITE_END() // QASYMM8
++
++TEST_SUITE(QASYMM8_SIGNED)
++FIXTURE_DATA_TEST_CASE(RunSmall,
++                       CpuActivationQuantizedFixture<int8_t>,
++                       framework::DatasetMode::ALL,
++                       combine(combine(combine(datasets::SmallShapes(), QuantizedActivationDataset),
++                                       framework::dataset::make("DataType", DataType::QASYMM8_SIGNED)),
++                               framework::dataset::make("QuantizationInfo", {QuantizationInfo(0.5f, 10.0f)})))
++{
++    // Validate output
++    validate(Accessor(_target), _reference, tolerance_qasymm8(_function));
++}
++TEST_SUITE_END() // QASYMM8_SIGNED
++
++/** Input data sets. */
++const auto Int16QuantizedActivationFunctionsDataset =
++    framework::dataset::make("ActivationFunction",
++                             {
++                                 ActivationLayerInfo::ActivationFunction::LOGISTIC,
++                                 ActivationLayerInfo::ActivationFunction::TANH,
++                                 ActivationLayerInfo::ActivationFunction::LU_BOUNDED_RELU,
++                             });
++const auto Int16QuantizedActivationDataset =
++    combine(combine(framework::dataset::make("InPlace", {false}), Int16QuantizedActivationFunctionsDataset),
++            framework::dataset::make("AlphaBeta", {0.5f, 1.f}));
++
++TEST_SUITE(QSYMM16)
++FIXTURE_DATA_TEST_CASE(RunSmall,
++                       CpuActivationQuantizedFixture<int16_t>,
++                       framework::DatasetMode::ALL,
++                       combine(combine(combine(datasets::SmallShapes(), Int16QuantizedActivationDataset),
++                                       framework::dataset::make("DataType", DataType::QSYMM16)),
++                               framework::dataset::make("QuantizationInfo", {QuantizationInfo(1.f / 32768.f, 0.f)})))
++{
++    // Validate output
++    validate(Accessor(_target), _reference, tolerance_qsymm16);
++}
++TEST_SUITE_END() // QSYMM16
++TEST_SUITE_END() // Quantized
++
++TEST_SUITE_END() // ActivationLayer
++TEST_SUITE_END() // Neon
++} // namespace validation
++} // namespace test
++} // namespace arm_compute
+diff --git a/tests/validation/runtime/operators/CpuGemmAssemblyDispatch.cpp b/tests/validation/runtime/operators/CpuGemmAssemblyDispatch.cpp
+new file mode 100644
+index 0000000000..4ddc0ae4a4
+--- /dev/null
++++ b/tests/validation/runtime/operators/CpuGemmAssemblyDispatch.cpp
+@@ -0,0 +1,128 @@
++/*
++ * Copyright (c) 2017-2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++#include "arm_compute/core/Types.h"
++#include "arm_compute/core/utils/StringUtils.h"
++#include "arm_compute/runtime/Tensor.h"
++#include "arm_compute/runtime/TensorAllocator.h"
++#include "src/core/helpers/MemoryHelpers.h"
++#include "arm_compute/runtime/operators/CpuGemmAssemblyDispatch.h"
++
++#include "tests/NEON/Accessor.h"
++#include "tests/NEON/Helper.h"
++#include "tests/PaddingCalculator.h"
++#include "tests/datasets/LargeGEMMDataset.h"
++#include "tests/datasets/SmallGEMMDataset.h"
++#include "tests/datasets/TinyGEMMDataset.h"
++#include "tests/framework/Asserts.h"
++#include "tests/framework/Macros.h"
++#include "tests/framework/datasets/Datasets.h"
++#include "tests/validation/Validation.h"
++#include "tests/validation/fixtures/GEMMFixture.h"
++#include "tests/validation/fixtures/GEMMInterleave4x4Fixture.h"
++#include "tests/validation/fixtures/GEMMTranspose1xWFixture.h"
++
++namespace arm_compute
++{
++namespace test
++{
++namespace validation
++{
++using framework::dataset::make;
++
++namespace
++{
++constexpr AbsoluteTolerance<float> tolerance_f(0.001f); /**< Tolerance value for comparing reference's output against implementation's output for FP32 data types */                                                        /* __ARM_FEATURE_FP16_VECTOR_ARITHMETIC */
++/** CNN data types */
++const auto CNNDataTypes = make("DataType",
++{
++    DataType::F32,
++});
++
++} // namespace
++
++TEST_SUITE(NEON)
++TEST_SUITE(CPUGEMM_ASSEMBLY_DISPATCH)
++
++/** Test case for memory injection in @ref cpu::CpuGemmAssemblyDispatch.
++ *
++ * Configure the operator once and inject memory at run-time in multiple executions.
++ *
++ * Checks performed in order:
++ * - Both runs compute the same output
++ */
++TEST_CASE(MemoryInjection, framework::DatasetMode::ALL)
++{
++    auto       gemm      = std::make_unique<op::CpuGemmAssemblyDispatch>();
++    const auto lhs_info  = TensorInfo(TensorShape(3U, 3U), 1, DataType::F32);
++    const auto rhs_info  = TensorInfo(TensorShape(4U, 3U), 1, DataType::F32);
++    const auto c_info    = TensorInfo(TensorShape(4U, 3U), 1, DataType::F32);
++    auto       dst_info  = TensorInfo(TensorShape(4U, 3U), 1, DataType::F32);
++    const auto gemm_info = GEMMInfo{};
++
++    Status status = gemm->validate(&lhs_info, &rhs_info, &c_info, &dst_info, gemm_info);
++    ARM_COMPUTE_EXPECT((bool(status)), framework::LogLevel::ERRORS);
++
++    gemm->configure(&lhs_info, &rhs_info, &c_info, &dst_info, gemm_info);
++
++    // telhs are newly created every call of this lambda function
++    auto lhs = create_tensor<Tensor>(lhs_info);
++    auto rhs = create_tensor<Tensor>(rhs_info);
++    auto c   = create_tensor<Tensor>(c_info);
++    lhs.allocator()->allocate();
++    rhs.allocator()->allocate();
++    c.allocator()->allocate();
++
++    ITensorPack run_pack{ { TensorType::ACL_SRC_0, &lhs }, { TensorType::ACL_SRC_1, &rhs }, { TensorType::ACL_SRC_2, &c } };
++    ITensorPack prep_pack{ { TensorType::ACL_SRC_1, &rhs }, { TensorType::ACL_SRC_2, &c } };
++
++    auto mg = MemoryGroup{};
++    auto ws = manage_workspace<Tensor>(gemm->workspace(), mg, run_pack, prep_pack);
++
++    auto run_conv = [&]() -> Tensor
++    {
++        auto dst = create_tensor<Tensor>(dst_info);
++        dst.allocator()->allocate();
++        run_pack.add_tensor(TensorType::ACL_DST, &dst);
++
++        library->fill_tensor_value(Accessor(lhs), 1.f);
++        library->fill_tensor_value(Accessor(rhs), 2.f);
++        library->fill_tensor_value(Accessor(c), 3.f);
++        // This operator is configured once and captured by this lambda.
++        gemm->prepare(prep_pack);
++        gemm->run(run_pack);
++        return dst;
++    };
++    auto result_0 = run_conv();
++    auto result_1 = run_conv();
++    for(size_t i = 0; i < result_0.info()->tensor_shape().total_size(); ++i)
++    {
++        ARM_COMPUTE_EXPECT(((float *)result_0.buffer())[i] == ((float *)result_1.buffer())[i], framework::LogLevel::ERRORS);
++    }
++}
++
++TEST_SUITE_END() // CPUGEMM_ASSEMBLY_DISPATCH
++TEST_SUITE_END() // NEON
++} // namespace validation
++} // namespace test
++} // namespace arm_compute
+diff --git a/tests/validation/runtime/operators/CpuTranspose.cpp b/tests/validation/runtime/operators/CpuTranspose.cpp
+new file mode 100644
+index 0000000000..4b0d41e43d
+--- /dev/null
++++ b/tests/validation/runtime/operators/CpuTranspose.cpp
+@@ -0,0 +1,121 @@
++/*
++ * Copyright (c) 2024 Arm Limited.
++ *
++ * SPDX-License-Identifier: MIT
++ *
++ * Permission is hereby granted, free of charge, to any person obtaining a copy
++ * of this software and associated documentation files (the "Software"), to
++ * deal in the Software without restriction, including without limitation the
++ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
++ * sell copies of the Software, and to permit persons to whom the Software is
++ * furnished to do so, subject to the following conditions:
++ *
++ * The above copyright notice and this permission notice shall be included in all
++ * copies or substantial portions of the Software.
++ *
++ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
++ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
++ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
++ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
++ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
++ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
++ * SOFTWARE.
++ */
++#include "arm_compute/runtime/operators/CpuTranspose.h"
++#include "arm_compute/runtime/Tensor.h"
++#include "arm_compute/runtime/TensorAllocator.h"
++#include "tests/NEON/Accessor.h"
++#include "tests/PaddingCalculator.h"
++#include "tests/datasets/ShapeDatasets.h"
++#include "tests/framework/Asserts.h"
++#include "tests/framework/Macros.h"
++#include "tests/framework/datasets/Datasets.h"
++#include "tests/validation/Validation.h"
++#include "tests/validation/fixtures/TransposeFixture.h"
++
++namespace arm_compute
++{
++namespace test
++{
++namespace validation
++{
++TEST_SUITE(OPERATORS)
++TEST_SUITE(Transpose)
++
++// *INDENT-OFF*
++// clang-format off
++DATA_TEST_CASE(Validate, framework::DatasetMode::ALL, zip(zip(
++    framework::dataset::make("InputInfo", { TensorInfo(TensorShape(21U, 13U), 1, DataType::U16), // Invalid shape
++                                            TensorInfo(TensorShape(20U, 13U), 1, DataType::U8),  // Wrong data type
++                                            TensorInfo(TensorShape(20U, 16U), 1, DataType::U16),
++                                            TensorInfo(TensorShape(20U, 16U), 1, DataType::U32),
++                                          }),
++    framework::dataset::make("OutputInfo",{ TensorInfo(TensorShape(21U, 13U), 1, DataType::U16),
++                                            TensorInfo(TensorShape(31U, 20U), 1, DataType::U16),
++                                            TensorInfo(TensorShape(16U, 20U), 1, DataType::U16),
++                                            TensorInfo(TensorShape(16U, 20U), 1, DataType::U32),
++                                           })),
++    framework::dataset::make("Expected", { false, false, true, true })),
++    a_info, output_info, expected)
++{
++    // Lock tensors
++    Status status =  op::CpuTranspose::validate(&a_info.clone()->set_is_resizable(false),
++                                                &output_info.clone()->set_is_resizable(false));
++    ARM_COMPUTE_EXPECT(bool(status) == expected, framework::LogLevel::ERRORS);
++}
++// clang-format on
++// *INDENT-ON*
++
++template <typename T>
++using CpuTransposeFixture = CpuTransposeValidationFixture<Tensor, Accessor, op::CpuTranspose, T>;
++
++TEST_SUITE(U8)
++FIXTURE_DATA_TEST_CASE(RunSmall, CpuTransposeFixture<uint8_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small1DShapes(), datasets::Small2DShapes()),
++                                                                                                          framework::dataset::make("DataType", DataType::U8)))
++{
++    // Validate output
++    validate(Accessor(_target), _reference);
++}
++FIXTURE_DATA_TEST_CASE(RunLarge, CpuTransposeFixture<uint8_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
++                                                                                                        framework::dataset::make("DataType", DataType::U8)))
++{
++    // Validate output
++    validate(Accessor(_target), _reference);
++}
++TEST_SUITE_END()
++
++TEST_SUITE(U16)
++FIXTURE_DATA_TEST_CASE(RunSmall, CpuTransposeFixture<uint16_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small1DShapes(), datasets::Small2DShapes()),
++                                                                                                           framework::dataset::make("DataType", DataType::U16)))
++{
++    // Validate output
++    validate(Accessor(_target), _reference);
++}
++FIXTURE_DATA_TEST_CASE(RunLarge, CpuTransposeFixture<uint16_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
++                                                                                                         framework::dataset::make("DataType", DataType::U16)))
++{
++    // Validate output
++    validate(Accessor(_target), _reference);
++}
++TEST_SUITE_END()
++
++TEST_SUITE(U32)
++FIXTURE_DATA_TEST_CASE(RunSmall, CpuTransposeFixture<uint32_t>, framework::DatasetMode::PRECOMMIT, combine(concat(datasets::Small1DShapes(), datasets::Small2DShapes()),
++                                                                                                           framework::dataset::make("DataType", DataType::U32)))
++{
++    // Validate output
++    validate(Accessor(_target), _reference);
++}
++FIXTURE_DATA_TEST_CASE(RunLarge, CpuTransposeFixture<uint32_t>, framework::DatasetMode::NIGHTLY, combine(concat(datasets::Large1DShapes(), datasets::Large2DShapes()),
++                                                                                                         framework::dataset::make("DataType", DataType::U32)))
++{
++    // Validate output
++    validate(Accessor(_target), _reference);
++}
++TEST_SUITE_END()
++
++TEST_SUITE_END()
++TEST_SUITE_END()
++} // namespace validation
++} // namespace test
++} // namespace arm_compute

--- a/docker/pytorch-aarch64/patches/onednn_stateless_matmul.patch
+++ b/docker/pytorch-aarch64/patches/onednn_stateless_matmul.patch
@@ -1,0 +1,619 @@
+*******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+diff --git a/src/common/memory_tracking.hpp b/src/common/memory_tracking.hpp
+index 9f6b41a001..28b58c6158 100644
+--- a/src/common/memory_tracking.hpp
++++ b/src/common/memory_tracking.hpp
+@@ -241,6 +241,9 @@ enum {
+     key_lnorm_tmp_diff_ss,
+     key_lnorm_reduction,
+     key_matmul_dst_in_acc_dt,
++    key_matmul_src_trans,
++    key_matmul_wei_trans,
++    key_matmul_dst_trans,
+     key_pool_dst_bf16cvt,
+     key_pool_dst_plain2blocked_cvt,
+     key_pool_ind_plain2blocked_cvt,
+diff --git a/src/cpu/aarch64/matmul/acl_matmul.cpp b/src/cpu/aarch64/matmul/acl_matmul.cpp
+index 91f342d44e..06b3ef21b3 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul.cpp
++++ b/src/cpu/aarch64/matmul/acl_matmul.cpp
+@@ -31,70 +31,168 @@ status_t acl_matmul_t::execute_forward(const exec_ctx_t &ctx) const {
+     auto src_base = CTX_IN_MEM(const data_t *, DNNL_ARG_SRC);
+     auto wei_base = CTX_IN_MEM(const data_t *, DNNL_ARG_WEIGHTS);
+ 
+-    bool is_transA = pd()->amp_.is_transA;
+-    bool is_transB = pd()->amp_.is_transB;
+-    bool do_transC = pd()->amp_.do_transC;
+-    bool use_dst_acc_for_sum = pd()->amp_.use_dst_acc_for_sum;
+-
+-    std::lock_guard<std::mutex> _lock {this->mtx};
+-    auto *acl_resource = ctx.get_resource_mapper()->get<acl_resource_t>(this);
+-    acl_matmul_obj_t &acl_obj = acl_resource->get_acl_obj();
++    auto amp = pd()->amp_;
++    bool is_transA = amp.is_transA;
++    bool is_transB = amp.is_transB;
++    bool do_transC = amp.do_transC;
++    bool do_act = amp.do_act;
++    bool use_dst_acc_for_sum = amp.use_dst_acc_for_sum;
+ 
+     const auto scratchpad = ctx.get_scratchpad_grantor();
+ 
++    arm_compute::Tensor src_tensor;
++    arm_compute::Tensor wei_tensor;
++    arm_compute::Tensor bia_tensor = nullptr;
++    arm_compute::Tensor dst_tensor;
++    arm_compute::Tensor dst_acc_tensor;
++    src_tensor.allocator()->init(amp.src_tensor_info);
++    wei_tensor.allocator()->init(amp.wei_tensor_info);
++    dst_tensor.allocator()->init(amp.dst_tensor_info);
++
++    // If we have an unfused sum post op, put the result in a scratchpad tensor.
++    // Result will be summed to the dst during acl_post_ops.execute
++    auto dst_base = use_dst_acc_for_sum ? scratchpad.get<void>(
++                            memory_tracking::names::key_matmul_dst_in_acc_dt)
++                                        : CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
++    dst_tensor.allocator()->import_memory(dst_base);
++
+     // Run transpose kernel
+     if (is_transA && !is_transB) {
+-        acl_obj.src_tensor.allocator()->allocate();
+-        acl_obj.src_acc_tensor.allocator()->import_memory(
++        arm_compute::Tensor src_acc_tensor;
++        src_acc_tensor.allocator()->init(amp.src_acc_info);
++        src_acc_tensor.allocator()->import_memory(
+                 const_cast<data_t *>(src_base));
+-        acl_obj.transA.run();
+-        acl_obj.wei_tensor.allocator()->import_memory(
+-                const_cast<data_t *>(wei_base));
++        auto transA_scratch = scratchpad.get<void>(
++                memory_tracking::names::key_matmul_src_trans);
++        src_tensor.allocator()->import_memory(transA_scratch);
++        arm_compute::ITensorPack transpose_pack;
++        transpose_pack.add_tensor(
++                arm_compute::TensorType::ACL_SRC, &src_acc_tensor);
++        transpose_pack.add_tensor(
++                arm_compute::TensorType::ACL_DST, &src_tensor);
++        acl_obj_->transA.run(transpose_pack);
++        wei_tensor.allocator()->import_memory(const_cast<data_t *>(wei_base));
++        src_acc_tensor.allocator()->free();
+     } else if (is_transB && !is_transA) {
+-        acl_obj.wei_tensor.allocator()->allocate();
+-        acl_obj.wei_acc_tensor.allocator()->import_memory(
++        arm_compute::Tensor wei_acc_tensor;
++        wei_acc_tensor.allocator()->init(amp.wei_acc_info);
++        wei_acc_tensor.allocator()->import_memory(
+                 const_cast<data_t *>(wei_base));
+-        acl_obj.transB.run();
+-        acl_obj.src_tensor.allocator()->import_memory(
+-                const_cast<data_t *>(src_base));
++        auto transB_scratch = scratchpad.get<void>(
++                memory_tracking::names::key_matmul_wei_trans);
++        wei_tensor.allocator()->import_memory(transB_scratch);
++        arm_compute::ITensorPack transpose_pack;
++        transpose_pack.add_tensor(
++                arm_compute::TensorType::ACL_SRC, &wei_acc_tensor);
++        transpose_pack.add_tensor(
++                arm_compute::TensorType::ACL_DST, &wei_tensor);
++        acl_obj_->transB.run(transpose_pack);
++        src_tensor.allocator()->import_memory(const_cast<data_t *>(src_base));
++        wei_acc_tensor.allocator()->free();
+     } else if (is_transA && is_transB && !do_transC) {
+-        acl_obj.src_tensor.allocator()->allocate();
+-        acl_obj.src_acc_tensor.allocator()->import_memory(
++        arm_compute::Tensor src_acc_tensor;
++        arm_compute::Tensor wei_acc_tensor;
++        src_acc_tensor.allocator()->init(amp.src_acc_info);
++        src_acc_tensor.allocator()->import_memory(
+                 const_cast<data_t *>(src_base));
+-        acl_obj.wei_tensor.allocator()->allocate();
+-        acl_obj.wei_acc_tensor.allocator()->import_memory(
++        wei_acc_tensor.allocator()->init(amp.wei_acc_info);
++        wei_acc_tensor.allocator()->import_memory(
+                 const_cast<data_t *>(wei_base));
+-        acl_obj.transA.run();
+-        acl_obj.transB.run();
++        auto transA_scratch = scratchpad.get<void>(
++                memory_tracking::names::key_matmul_src_trans);
++        auto transB_scratch = scratchpad.get<void>(
++                memory_tracking::names::key_matmul_wei_trans);
++        src_tensor.allocator()->import_memory(transA_scratch);
++        wei_tensor.allocator()->import_memory(transB_scratch);
++        arm_compute::ITensorPack transpose_packA;
++        transpose_packA.add_tensor(
++                arm_compute::TensorType::ACL_SRC, &src_acc_tensor);
++        transpose_packA.add_tensor(
++                arm_compute::TensorType::ACL_DST, &src_tensor);
++        arm_compute::ITensorPack transpose_packB;
++        transpose_packB.add_tensor(
++                arm_compute::TensorType::ACL_SRC, &wei_acc_tensor);
++        transpose_packB.add_tensor(
++                arm_compute::TensorType::ACL_DST, &wei_tensor);
++        acl_obj_->transA.run(transpose_packA);
++        acl_obj_->transB.run(transpose_packB);
++        src_acc_tensor.allocator()->free();
++        wei_acc_tensor.allocator()->free();
+     } else {
+-        acl_obj.src_tensor.allocator()->import_memory(
+-                const_cast<data_t *>(src_base));
+-        acl_obj.wei_tensor.allocator()->import_memory(
+-                const_cast<data_t *>(wei_base));
+-        if (do_transC) { acl_obj.dst_acc_tensor.allocator()->allocate(); }
++        src_tensor.allocator()->import_memory(const_cast<data_t *>(src_base));
++        wei_tensor.allocator()->import_memory(const_cast<data_t *>(wei_base));
++        if (do_transC) {
++            auto transC_scratch = scratchpad.get<void>(
++                    memory_tracking::names::key_matmul_dst_trans);
++            dst_acc_tensor.allocator()->init(amp.dst_acc_info);
++            dst_acc_tensor.allocator()->import_memory(transC_scratch);
++        }
+     }
+ 
+-    // If we have an unfused sum post op, put the result in a scratchpad tensor.
+-    // Result will be summed to the dst during acl_post_ops.execute
+-    auto dst_base = use_dst_acc_for_sum ? scratchpad.get<void>(
+-                            memory_tracking::names::key_matmul_dst_in_acc_dt)
+-                                        : CTX_OUT_MEM(data_t *, DNNL_ARG_DST);
+-    acl_obj.dst_tensor.allocator()->import_memory(dst_base);
++    if (do_transC) {
++        acl_obj_->matmul_pack.add_const_tensor(
++                arm_compute::TensorType::ACL_SRC_0, &wei_tensor);
++        acl_obj_->matmul_pack.add_const_tensor(
++                arm_compute::TensorType::ACL_SRC_1, &src_tensor);
++        acl_obj_->matmul_pack.add_tensor(
++                arm_compute::TensorType::ACL_SRC_2, &bia_tensor);
++        acl_obj_->matmul_pack.add_tensor(
++                arm_compute::TensorType::ACL_DST, &dst_acc_tensor);
++    } else {
++        acl_obj_->matmul_pack.add_const_tensor(
++                arm_compute::TensorType::ACL_SRC_0, &src_tensor);
++        acl_obj_->matmul_pack.add_const_tensor(
++                arm_compute::TensorType::ACL_SRC_1, &wei_tensor);
++        acl_obj_->matmul_pack.add_tensor(
++                arm_compute::TensorType::ACL_SRC_2, &bia_tensor);
++        acl_obj_->matmul_pack.add_tensor(
++                arm_compute::TensorType::ACL_DST, &dst_tensor);
++    }
+ 
+-    acl_obj.gemm.run();
++    // Get pointer to scratchpad memory and create a workspace tensor for
++    // CpuGemm. Fixed-format kernel does not need this workspace tensor.
++    arm_compute::Tensor tmp_tensor;
++    if (!IsFixedFormat && acl_obj_->aux_mem_req[0].size != 0) {
++        auto buffer = scratchpad.get<void>(
++                memory_tracking::names::key_gemm_tmp_buffer);
++        tmp_tensor.allocator()->init(
++                amp.tmp_tensor_info, acl_obj_->aux_mem_req[0].alignment);
++        tmp_tensor.allocator()->import_memory(buffer);
++        acl_obj_->matmul_pack.add_tensor(
++                acl_obj_->aux_mem_req[0].slot, &tmp_tensor);
++    }
++    arm_compute::Tensor aux_tensor;
++    if (!IsFixedFormat && acl_obj_->aux_mem_req[2].size != 0) {
++        auto buffer = scratchpad.get<void>(
++                memory_tracking::names::key_gemm_blocked_b);
++        aux_tensor.allocator()->init(
++                amp.aux_tensor_info, acl_obj_->aux_mem_req[2].alignment);
++        aux_tensor.allocator()->import_memory(buffer);
++        acl_obj_->matmul_pack.add_tensor(
++                acl_obj_->aux_mem_req[2].slot, &aux_tensor);
++    }
+ 
+-    if (do_transC) { acl_obj.transC.run(); }
++    acl_obj_->asm_gemm.run(acl_obj_->matmul_pack);
++    if (do_act) {
++        auto dst_to_use = do_transC ? &dst_acc_tensor : &dst_tensor;
++        arm_compute::ITensorPack act_pack;
++        act_pack.add_tensor(arm_compute::TensorType::ACL_SRC, dst_to_use);
++        act_pack.add_tensor(arm_compute::TensorType::ACL_DST, dst_to_use);
++        acl_obj_->act.run(act_pack);
++    }
+ 
+-    acl_obj.src_tensor.allocator()->free();
+-    acl_obj.wei_tensor.allocator()->free();
+-    if (is_transA) acl_obj.src_acc_tensor.allocator()->free();
+-    if (is_transB) acl_obj.wei_acc_tensor.allocator()->free();
++    if (do_transC) {
++        arm_compute::ITensorPack transpose_packC;
++        transpose_packC.add_tensor(
++                arm_compute::TensorType::ACL_SRC, &dst_acc_tensor);
++        transpose_packC.add_tensor(
++                arm_compute::TensorType::ACL_DST, &dst_tensor);
++        acl_obj_->transC.run(transpose_packC);
++    }
+ 
+-    void *dst = acl_obj.dst_tensor.buffer();
++    void *dst = dst_tensor.buffer();
+     pd()->acl_post_ops.execute(ctx, dst);
+ 
+-    acl_obj.dst_tensor.allocator()->free();
+-
+     return status;
+ }
+ 
+diff --git a/src/cpu/aarch64/matmul/acl_matmul.hpp b/src/cpu/aarch64/matmul/acl_matmul.hpp
+index 1427a5bcb8..50426550f7 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul.hpp
++++ b/src/cpu/aarch64/matmul/acl_matmul.hpp
+@@ -27,56 +27,6 @@ namespace cpu {
+ namespace aarch64 {
+ namespace matmul {
+ 
+-struct acl_resource_t : public resource_t {
+-    acl_resource_t() : acl_obj_(utils::make_unique<acl_matmul_obj_t>()) {}
+-
+-    status_t configure(const acl_matmul_conf_t &amp,
+-            const dnnl::impl::format_kind_t weights_format_kind_) {
+-        if (!acl_obj_) return status::out_of_memory;
+-        acl_obj_->src_tensor.allocator()->init(amp.src_tensor_info);
+-        acl_obj_->wei_tensor.allocator()->init(amp.wei_tensor_info);
+-        acl_obj_->dst_tensor.allocator()->init(amp.dst_tensor_info);
+-
+-        // Configure transpose kernel for src, wei, or dst
+-        if (amp.is_transA && !amp.do_transC) {
+-            acl_obj_->src_acc_tensor.allocator()->init(amp.src_acc_info);
+-            acl_obj_->transA.configure(
+-                    &acl_obj_->src_acc_tensor, &acl_obj_->src_tensor);
+-        }
+-
+-        if (amp.is_transB && !amp.do_transC) {
+-            acl_obj_->wei_acc_tensor.allocator()->init(amp.wei_acc_info);
+-            acl_obj_->transB.configure(
+-                    &acl_obj_->wei_acc_tensor, &acl_obj_->wei_tensor);
+-        }
+-
+-        if (amp.do_transC) {
+-            acl_obj_->dst_acc_tensor.allocator()->init(amp.dst_acc_info);
+-            acl_obj_->transC.configure(
+-                    &acl_obj_->dst_acc_tensor, &acl_obj_->dst_tensor);
+-        }
+-
+-        // Configure GEMM
+-        if (amp.do_transC) {
+-            acl_obj_->gemm.configure(&acl_obj_->wei_tensor,
+-                    &acl_obj_->src_tensor, nullptr, &acl_obj_->dst_acc_tensor,
+-                    1.0f, 0.0f, amp.gemm_info);
+-        } else {
+-            acl_obj_->gemm.configure(&acl_obj_->src_tensor,
+-                    &acl_obj_->wei_tensor, nullptr, &acl_obj_->dst_tensor, 1.0f,
+-                    0.0f, amp.gemm_info);
+-        }
+-
+-        return status::success;
+-    }
+-    acl_matmul_obj_t &get_acl_obj() const { return *acl_obj_; }
+-
+-    DNNL_DISALLOW_COPY_AND_ASSIGN(acl_resource_t);
+-
+-private:
+-    std::unique_ptr<acl_matmul_obj_t> acl_obj_;
+-};
+-
+ struct acl_matmul_t : public primitive_t {
+     struct pd_t : public dnnl::impl::cpu::matmul::cpu_matmul_pd_t {
+ 
+@@ -152,25 +102,73 @@ struct acl_matmul_t : public primitive_t {
+                 amp_.gemm_info.set_accumulate(true);
+             }
+ 
++            amp_.do_act = false;
+             arm_compute::ActivationLayerInfo act_info;
+             CHECK(acl_post_ops.init(engine, attr_.post_ops_, dst_md_, act_info,
+-                    amp_.gemm_info.accumulate() ? 1 : 0));
++                    amp_.gemm_info.accumulate()));
++            if (act_info.enabled()
++                    && !arm_compute::op::CpuGemmAssemblyDispatch::
++                               is_activation_supported(act_info)) {
++                auto dst_info_to_use = amp_.do_transC ? &amp_.dst_acc_info
++                                                      : &amp_.dst_tensor_info;
++                ACL_CHECK_VALID(arm_compute::op::CpuActivation::validate(
++                        dst_info_to_use, dst_info_to_use, act_info));
++                amp_.do_act = true;
++            }
+             amp_.gemm_info.set_activation_info(act_info);
+             amp_.use_dst_acc_for_sum = acl_post_ops.has_sum();
+ 
+             // Validate ACL GEMM
+             if (amp_.do_transC) {
+-                ACL_CHECK_VALID(arm_compute::NEGEMM::validate(
+-                        &amp_.wei_tensor_info, &amp_.src_tensor_info, nullptr,
+-                        &amp_.dst_acc_info, 1.0f, 0.0f, amp_.gemm_info));
++                ACL_CHECK_VALID(
++                        arm_compute::op::CpuGemmAssemblyDispatch::validate(
++                                &amp_.wei_tensor_info, &amp_.src_tensor_info,
++                                nullptr, &amp_.dst_acc_info, amp_.gemm_info));
+             } else {
+-                ACL_CHECK_VALID(arm_compute::NEGEMM::validate(
+-                        &amp_.src_tensor_info, &amp_.wei_tensor_info, nullptr,
+-                        &amp_.dst_tensor_info, 1.0f, 0.0f, amp_.gemm_info));
++                ACL_CHECK_VALID(
++                        arm_compute::op::CpuGemmAssemblyDispatch::validate(
++                                &amp_.src_tensor_info, &amp_.wei_tensor_info,
++                                nullptr, &amp_.dst_tensor_info,
++                                amp_.gemm_info));
+             }
+ 
+             auto scratchpad = scratchpad_registry().registrar();
+-            CHECK(acl_matmul_utils::init_scratchpad(scratchpad, amp_, dst_md_));
++            CHECK(acl_matmul_utils::init_scratchpad(
++                    scratchpad, amp_, src_md_, weights_md_, dst_md_));
++
++            // Query buffer memory requirement, if not using fixed-format kernel
++            if (weights_format_kind_ != format_kind::any) {
++                arm_compute::op::CpuGemmAssemblyDispatch asm_gemm;
++                if (amp_.do_transC) {
++                    asm_gemm.configure(&amp_.wei_tensor_info,
++                            &amp_.src_tensor_info, nullptr, &amp_.dst_acc_info,
++                            amp_.gemm_info);
++                } else {
++                    asm_gemm.configure(&amp_.src_tensor_info,
++                            &amp_.wei_tensor_info, nullptr,
++                            &amp_.dst_tensor_info, amp_.gemm_info);
++                }
++                auto aux_mem_req = asm_gemm.workspace();
++
++                if (aux_mem_req[0].size != 0) {
++                    auto scratchpad = scratchpad_registry().registrar();
++                    scratchpad.book(memory_tracking::names::key_gemm_tmp_buffer,
++                            aux_mem_req[0].size, 1, aux_mem_req[0].alignment,
++                            aux_mem_req[0].alignment);
++                    amp_.tmp_tensor_info = arm_compute::TensorInfo(
++                            arm_compute::TensorShape(aux_mem_req[0].size), 1,
++                            arm_compute::DataType::U8);
++                }
++                if (aux_mem_req[2].size != 0) {
++                    auto scratchpad = scratchpad_registry().registrar();
++                    scratchpad.book(memory_tracking::names::key_gemm_blocked_b,
++                            aux_mem_req[2].size, 1, aux_mem_req[2].alignment,
++                            aux_mem_req[2].alignment);
++                    amp_.aux_tensor_info = arm_compute::TensorInfo(
++                            arm_compute::TensorShape(aux_mem_req[2].size), 1,
++                            arm_compute::DataType::U8);
++                }
++            }
+ 
+             return status::success;
+         }
+@@ -186,23 +184,53 @@ struct acl_matmul_t : public primitive_t {
+         }
+     };
+ 
+-    acl_matmul_t(const pd_t *apd) : primitive_t(apd) {}
++    acl_matmul_t(const pd_t *apd)
++        : primitive_t(apd), acl_obj_(std::make_unique<acl_matmul_obj_t>()) {}
+ 
+     status_t create_resource(
+             engine_t *engine, resource_mapper_t &mapper) const override {
+-        if (mapper.has_resource(this)) return status::success;
+-        auto r = utils::make_unique<acl_resource_t>();
+-        if (!r) return status::out_of_memory;
+-
+-        // Configure the resource based on information from primitive descriptor
+-        CHECK(r->configure(pd()->amp_, pd()->weights_format_kind_));
+-        mapper.add(this, std::move(r));
+ 
+         CHECK(pd()->acl_post_ops.create_resource(engine, mapper));
+ 
+         return status::success;
+     }
+ 
++    status_t init(engine_t *engine) override {
++        auto amp_ = pd()->amp_;
++        // Configure transpose kernel for src and wei
++        if (amp_.is_transA && !amp_.do_transC) {
++            acl_obj_->transA.configure(
++                    &amp_.src_acc_info, &amp_.src_tensor_info);
++        }
++        if (amp_.is_transB && !amp_.do_transC) {
++            acl_obj_->transB.configure(
++                    &amp_.wei_acc_info, &amp_.wei_tensor_info);
++        }
++        if (amp_.do_transC) {
++            acl_obj_->transC.configure(
++                    &amp_.dst_acc_info, &amp_.dst_tensor_info);
++        }
++        // Configure GEMM
++        if (amp_.do_transC) {
++            acl_obj_->asm_gemm.configure(&amp_.wei_tensor_info,
++                    &amp_.src_tensor_info, nullptr, &amp_.dst_acc_info,
++                    amp_.gemm_info);
++        } else {
++            acl_obj_->asm_gemm.configure(&amp_.src_tensor_info,
++                    &amp_.wei_tensor_info, nullptr, &amp_.dst_tensor_info,
++                    amp_.gemm_info);
++        }
++        acl_obj_->aux_mem_req = acl_obj_->asm_gemm.workspace();
++        if (amp_.do_act) {
++            auto dst_info_to_use = amp_.do_transC ? &amp_.dst_acc_info
++                                                  : &amp_.dst_tensor_info;
++            acl_obj_->act.configure(dst_info_to_use, dst_info_to_use,
++                    amp_.gemm_info.activation_info());
++        }
++
++        return status::success;
++    }
++
+     typedef typename prec_traits<data_type::f32>::type data_t;
+ 
+     status_t execute(const exec_ctx_t &ctx) const override {
+@@ -214,12 +242,14 @@ struct acl_matmul_t : public primitive_t {
+     }
+ 
+ private:
+-    // To guard the const execute_forward(), the mutex must be 'mutable'
+-    mutable std::mutex mtx;
+     template <bool IsFixedFormat>
+     status_t execute_forward(const exec_ctx_t &ctx) const;
+ 
+-    const pd_t *pd() const { return (const pd_t *)primitive_t::pd().get(); }
++    const pd_t *pd() const {
++        return (const pd_t *)primitive_t::pd().get();
++    }
++
++    std::unique_ptr<acl_matmul_obj_t> acl_obj_;
+ }; // acl_matmul_t
+ 
+ } // namespace matmul
+diff --git a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+index 134ce94c90..0a64e5d8e1 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
++++ b/src/cpu/aarch64/matmul/acl_matmul_utils.cpp
+@@ -104,6 +104,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+                 acl_dst_data_t);
+         amp.src_tensor_info = arm_compute::TensorInfo(
+                 arm_compute::TensorShape(M, K, src_batch), 1, acl_src_data_t);
++        amp.src_tensor_info.set_are_values_constant(false);
+         amp.wei_tensor_info = arm_compute::TensorInfo(
+                 arm_compute::TensorShape(K, N, 1, wei_batch), 1,
+                 acl_wei_data_t);
+@@ -113,6 +114,7 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+                 acl_src_data_t);
+         amp.wei_tensor_info = arm_compute::TensorInfo(
+                 arm_compute::TensorShape(N, K, wei_batch), 1, acl_wei_data_t);
++        amp.wei_tensor_info.set_are_values_constant(false);
+     }
+ 
+     amp.dst_tensor_info = arm_compute::TensorInfo(
+@@ -120,13 +122,13 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+ 
+     // Validate ACL transpose
+     if (amp.is_transA && !amp.do_transC)
+-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
++        ACL_CHECK_VALID(arm_compute::op::CpuTranspose::validate(
+                 &amp.src_acc_info, &amp.src_tensor_info));
+     if (amp.is_transB && !amp.do_transC)
+-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
++        ACL_CHECK_VALID(arm_compute::op::CpuTranspose::validate(
+                 &amp.wei_acc_info, &amp.wei_tensor_info));
+     if (amp.do_transC)
+-        ACL_CHECK_VALID(arm_compute::NETranspose::validate(
++        ACL_CHECK_VALID(arm_compute::op::CpuTranspose::validate(
+                 &amp.dst_acc_info, &amp.dst_tensor_info));
+ 
+     bool is_fastmath_enabled = utils::one_of(
+@@ -143,10 +145,10 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+         // in (if a kernel exists). Note that these are referred to as fixed format
+         // kernels, because they require one specific weights format
+         arm_compute::WeightFormat expected_weight_format;
+-        ACL_CHECK_VALID(
+-                arm_compute::NEGEMM::has_opt_impl(expected_weight_format,
+-                        &amp.src_tensor_info, &amp.wei_tensor_info, nullptr,
+-                        &amp.dst_tensor_info, 1.0f, 0.0f, amp.gemm_info));
++        ACL_CHECK_VALID(arm_compute::op::CpuGemmAssemblyDispatch::has_opt_impl(
++                expected_weight_format, &amp.src_tensor_info,
++                &amp.wei_tensor_info, nullptr, &amp.dst_tensor_info,
++                amp.gemm_info));
+ 
+         // Set gemm weights info to the one returned by has_opt_impl
+         amp.gemm_info.set_weight_format(expected_weight_format);
+@@ -174,12 +176,28 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+ }
+ 
+ status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
+-        acl_matmul_conf_t &amp, memory_desc_t &dst_md) {
++        acl_matmul_conf_t &amp, memory_desc_t &src_md,
++        memory_desc_t &weights_md, memory_desc_t &dst_md) {
+     if (amp.use_dst_acc_for_sum) {
+         const memory_desc_wrapper dst_d(&dst_md);
+         scratchpad.book(memory_tracking::names::key_matmul_dst_in_acc_dt,
+                 dst_d.nelems(), dst_d.data_type_size());
+     }
++    if (amp.is_transA) {
++        const memory_desc_wrapper src_d(&src_md);
++        scratchpad.book(memory_tracking::names::key_matmul_src_trans,
++                src_d.nelems(), src_d.data_type_size());
++    }
++    if (amp.is_transB) {
++        const memory_desc_wrapper wei_d(&weights_md);
++        scratchpad.book(memory_tracking::names::key_matmul_wei_trans,
++                wei_d.nelems(), wei_d.data_type_size());
++    }
++    if (amp.do_transC) {
++        const memory_desc_wrapper dst_d(&dst_md);
++        scratchpad.book(memory_tracking::names::key_matmul_dst_trans,
++                dst_d.nelems(), dst_d.data_type_size());
++    }
+     return status::success;
+ }
+ 
+diff --git a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+index d3fa65d915..6bda7f5cec 100644
+--- a/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
++++ b/src/cpu/aarch64/matmul/acl_matmul_utils.hpp
+@@ -17,9 +17,11 @@
+ #ifndef CPU_AARCH64_ACL_MATMUL_UTILS_HPP
+ #define CPU_AARCH64_ACL_MATMUL_UTILS_HPP
+ 
+-#include "cpu/matmul/cpu_matmul_pd.hpp"
+-
++#include "arm_compute/runtime/operators/CpuActivation.h"
++#include "arm_compute/runtime/operators/CpuTranspose.h"
++#include "arm_compute/runtime/operators/CpuGemmAssemblyDispatch.h"
+ #include "cpu/aarch64/acl_utils.hpp"
++#include "cpu/matmul/cpu_matmul_pd.hpp"
+ 
+ namespace dnnl {
+ namespace impl {
+@@ -27,28 +29,28 @@ namespace cpu {
+ namespace aarch64 {
+ 
+ struct acl_matmul_obj_t {
+-    arm_compute::NEGEMM gemm;
+-    arm_compute::NETranspose transA;
+-    arm_compute::NETranspose transB;
+-    arm_compute::NETranspose transC;
+-    arm_compute::Tensor src_tensor;
+-    arm_compute::Tensor src_acc_tensor;
+-    arm_compute::Tensor wei_acc_tensor;
+-    arm_compute::Tensor dst_acc_tensor;
+-    arm_compute::Tensor wei_tensor;
+-    arm_compute::Tensor dst_tensor;
++    arm_compute::op::CpuGemmAssemblyDispatch asm_gemm;
++    arm_compute::op::CpuActivation act;
++    arm_compute::op::CpuTranspose transA;
++    arm_compute::op::CpuTranspose transB;
++    arm_compute::op::CpuTranspose transC;
++    arm_compute::experimental::MemoryRequirements aux_mem_req;
++    arm_compute::ITensorPack matmul_pack;
+ };
+ 
+ struct acl_matmul_conf_t {
+     bool is_transA;
+     bool is_transB;
+     bool do_transC;
++    bool do_act;
+     // If this is true, the result of the matmul goes into a temporarily
+     // allocated ACL tensor to be accumulated into the oneDNN dst during postops
+     bool use_dst_acc_for_sum;
+     arm_compute::TensorInfo src_tensor_info;
+     arm_compute::TensorInfo wei_tensor_info;
+     arm_compute::TensorInfo dst_tensor_info;
++    arm_compute::TensorInfo tmp_tensor_info;
++    arm_compute::TensorInfo aux_tensor_info;
+     arm_compute::TensorInfo src_acc_info;
+     arm_compute::TensorInfo wei_acc_info;
+     arm_compute::TensorInfo dst_acc_info;
+@@ -63,7 +65,8 @@ status_t init_conf_matmul(acl_matmul_conf_t &amp, memory_desc_t &src_md,
+         const primitive_attr_t &attr);
+ 
+ status_t init_scratchpad(memory_tracking::registrar_t &scratchpad,
+-        acl_matmul_conf_t &amp, memory_desc_t &dst_md);
++        acl_matmul_conf_t &amp, memory_desc_t &src_md,
++        memory_desc_t &weights_md, memory_desc_t &dst_md);
+ 
+ } // namespace acl_matmul_utils
+ 

--- a/docker/pytorch-aarch64/scripts/build-acl.sh
+++ b/docker/pytorch-aarch64/scripts/build-acl.sh
@@ -38,6 +38,7 @@ git checkout $version
 # Patch ACL
 wget -O patch.zip https://eu-gerrit-1.euhpc.arm.com/changes/VisualCompute%2FComputeLibrary~633455/revisions/29/patch?zip && unzip patch.zip && patch -p1 < ./7271dfa.diff
 patch -p1 < ../acl_static_quantization.patch
+patch -p1 < ../acl_stateless_matmul.patch
 
 # Default to v8a if $acl_arch is unset.
 arch=${ACL_ARCH:-"arm64-v8a"}

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -69,11 +69,8 @@ git checkout $ONEDNN_VERSION
 # rename test_api to test_api_dnnl so it does not clash with PyTorch test_api
 patch -p1 < $PACKAGE_DIR/onednn.patch
 patch -p1 < $PACKAGE_DIR/onednn_acl_thread_local_scheduler.patch
-wget -O onednn_enable_indirect_conv.patch https://patch-diff.githubusercontent.com/raw/oneapi-src/oneDNN/pull/1948.patch
-patch -p1 < onednn_enable_indirect_conv.patch
-wget -O onednn_enable_acl_indirect_conv_for_bf16.patch https://patch-diff.githubusercontent.com/raw/oneapi-src/oneDNN/pull/1933.patch
-patch -p1 < onednn_enable_acl_indirect_conv_for_bf16.patch
 patch -p1 < $PACKAGE_DIR/onednn_static_quantization.patch
+patch -p1 < $PACKAGE_DIR/onednn_stateless_matmul.patch
 
 cd $PACKAGE_DIR/$src_repo
 


### PR DESCRIPTION
- Modified oneDNN to v3.5
- Added patch for public API for ACL's stateless matmuls.
- Linked oneDNN with ACL's stateless API for matmuls.