### PR TITLE
update mlcommons rnnt patch with fixes due to librosa version update

### DIFF
--- a/docker/pytorch-aarch64/patches/mlcommons_rnnt.patch
+++ b/docker/pytorch-aarch64/patches/mlcommons_rnnt.patch
@@ -1,5 +1,5 @@
 # *******************************************************************************
-# Copyright 2021-2023 Arm Limited and affiliates.
+# Copyright 2021-2024 Arm Limited and affiliates.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,9 +16,9 @@
 # *******************************************************************************
 #
 # This patch file includes commit 077f823ece09e37d9d40540d8acd504bf138e880
-# from the MLCommons inference repository, and further additions to make
-# the shell scripts suitable for building and running on AArch64 systems
-# without Conda installed.
+# and pull request 1506 from the MLCommons inference repository, and
+# further additions to make the shell scripts suitable for building and running on
+# AArch64 systems without Conda installed.
 #
 # *******************************************************************************
 diff --git a/speech_recognition/rnnt/README.md b/speech_recognition/rnnt/README.md
@@ -65,7 +65,7 @@ index 0000000..8d4ac05
 @@ -0,0 +1,46 @@
 +#!/bin/bash
 +# *******************************************************************************
-+# Copyright 2021 Arm Limited and affiliates.
++# Copyright 2024 Arm Limited and affiliates.
 +# SPDX-License-Identifier: Apache-2.0
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -109,6 +109,58 @@ index 0000000..8d4ac05
 +  --input_dir $librispeech_download_dir/dev-clean \
 +  --dest_dir $local_data_dir/dev-clean-wav \
 +  --output_json $local_data_dir/dev-clean-wav.json
+diff --git a/speech_recognition/rnnt/pytorch/parts/features.py b/speech_recognition/rnnt/pytorch/parts/features.py
+index 0dff7ef..db0e13b 100644
+--- a/speech_recognition/rnnt/pytorch/parts/features.py
++++ b/speech_recognition/rnnt/pytorch/parts/features.py
+@@ -123,7 +123,7 @@ class FilterbankFeatures(nn.Module):
+         window_tensor = window_fn(self.win_length,
+                                   periodic=False) if window_fn else None
+         filterbanks = torch.tensor(
+-            librosa.filters.mel(sample_rate, self.n_fft, n_mels=nfilt, fmin=lowfreq,
++            librosa.filters.mel(sr=sample_rate, n_fft=self.n_fft, n_mels=nfilt, fmin=lowfreq,
+                                 fmax=highfreq), dtype=torch.float).unsqueeze(0)
+         # self.fb = filterbanks
+         # self.window = window_tensor
+@@ -141,9 +141,9 @@ class FilterbankFeatures(nn.Module):
+         seq_len = (seq_len + self.frame_splicing - 1) // self.frame_splicing
+         return seq_len
+ 
+-    @torch.no_grad()
+     def forward(self, inp: Tuple[torch.Tensor, torch.Tensor]) -> torch.Tensor:
+-        x, seq_len = inp
++        with torch.no_grad():
++            x, seq_len = inp
+ 
+         dtype = x.dtype
+ 
+@@ -162,7 +162,8 @@ class FilterbankFeatures(nn.Module):
+         # do stft
+         x = torch.stft(x, n_fft=self.n_fft, hop_length=self.hop_length,
+                        win_length=self.win_length,
+-                       center=True, window=self.window.to(dtype=torch.float))
++                       center=True, window=self.window.to(dtype=torch.float), return_complex = True)
++        x = torch.view_as_real(x)
+ 
+         # get power spectrum
+         x = x.pow(2).sum(-1)
+diff --git a/speech_recognition/rnnt/pytorch/parts/segment.py b/speech_recognition/rnnt/pytorch/parts/segment.py
+index 08aa5c6..0c836ca 100644
+--- a/speech_recognition/rnnt/pytorch/parts/segment.py
++++ b/speech_recognition/rnnt/pytorch/parts/segment.py
+@@ -33,10 +33,10 @@ class AudioSegment(object):
+         """
+         samples = self._convert_samples_to_float32(samples)
+         if target_sr is not None and target_sr != sample_rate:
+-            samples = librosa.core.resample(samples, sample_rate, target_sr)
++            samples = librosa.core.resample(samples, orig_sr=sample_rate, target_sr=target_sr)
+             sample_rate = target_sr
+         if trim:
+-            samples, _ = librosa.effects.trim(samples, trim_db)
++            samples, _ = librosa.effects.trim(samples, top_db=trim_db)
+         self._samples = samples
+         self._sample_rate = sample_rate
+         if self._samples.ndim >= 2:
 diff --git a/speech_recognition/rnnt/run.sh b/speech_recognition/rnnt/run.sh
 index 7538df9..d65a87c 100755
 --- a/speech_recognition/rnnt/run.sh
@@ -118,7 +170,7 @@ index 7538df9..d65a87c 100755
 -
 +#!/bin/bash
 +# *******************************************************************************
-+# Copyright 2021 Arm Limited and affiliates.
++# Copyright 2024 Arm Limited and affiliates.
 +# SPDX-License-Identifier: Apache-2.0
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");
@@ -303,3 +355,16 @@ index 7538df9..d65a87c 100755
 +       ${acc_flag} &
 +done
 +wait
+diff --git a/vision/classification_and_detection/python/coco.py b/vision/classification_and_detection/python/coco.py
+index ef77bf1..169e6bc 100644
+--- a/vision/classification_and_detection/python/coco.py
++++ b/vision/classification_and_detection/python/coco.py
+@@ -112,7 +112,7 @@ class Coco(dataset.Dataset):
+         log.info("loaded {} images, cache={}, took={:.1f}sec".format(
+             len(self.image_list), use_cache, time_taken))
+ 
+-        self.label_list = np.array(self.label_list)
++        self.label_list = np.array(self.label_list, dtype=object)
+ 
+     def get_item(self, nr):
+         """Get image by number in the list."""


### PR DESCRIPTION
- apply patch from https://github.com/mlcommons/inference/pull/1506 which addresses issue in pytorch 2.0.1
- librosa API calls require explicit keyword args