### PR TITLE
Relaxed precision float32 matmul fixes

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -289,9 +289,11 @@ COPY patches/torchvision.patch $PACKAGE_DIR/.
 COPY patches/ideep_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/ideep_static_quantization.patch $PACKAGE_DIR/.
 COPY patches/ideep_remove_matmul_primitive_caching.patch $PACKAGE_DIR/.
+COPY patches/ideep_pd_cache_modes.patch $PACKAGE_DIR/.
 COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_static_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_gelu.patch $PACKAGE_DIR/.
+COPY patches/pytorch_bf32_matmul.patch $PACKAGE_DIR/.
 
 COPY patches/onednn_stateless_matmul.patch $PACKAGE_DIR/.
 

--- a/docker/pytorch-aarch64/patches/ideep_pd_cache_modes.patch
+++ b/docker/pytorch-aarch64/patches/ideep_pd_cache_modes.patch
@@ -1,0 +1,34 @@
+*******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/include/ideep/attributes.hpp b/include/ideep/attributes.hpp
+index 133bb1c..255b387 100644
+--- a/include/ideep/attributes.hpp
++++ b/include/ideep/attributes.hpp
+@@ -480,6 +480,12 @@
+       }
+     }
+ 
++    // encode computation modes
++    utils::to_bytes(bytes, get_fpmath_mode()); // fpmath mode
++    utils::to_bytes(bytes, get_scratchpad_mode()); // scratchpad mode
++    utils::to_bytes(bytes, get_accumulation_mode()); // accumulation mode
++    utils::to_bytes(bytes, get_deterministic()); // deterministic mode
++
+     // Note: depthwise/binary post op, zero points, scales, rnn params are
+     // not encoded so far. PD cache is supposed to use in convolution only
+     // as a temporary workaround for gemm-based conv pd overhead

--- a/docker/pytorch-aarch64/patches/pytorch_bf32_matmul.patch
+++ b/docker/pytorch-aarch64/patches/pytorch_bf32_matmul.patch
@@ -1,0 +1,39 @@
+ *******************************************************************************
+ Copyright 2023 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/aten/src/ATen/native/mkldnn/Matmul.cpp b/aten/src/ATen/native/mkldnn/Matmul.cpp
+index db02e5f..4b927eb 100644
+--- a/aten/src/ATen/native/mkldnn/Matmul.cpp
++++ b/aten/src/ATen/native/mkldnn/Matmul.cpp
+@@ -136,7 +136,7 @@
+   if (beta != 0.0f) {
+     op_attr = ideep::attr_t::fuse_sum();
+   }
+-  if (std::is_same_v<scalar_t, float>) op_attr.set_fpmath_mode(dnnl_fpmath_mode_bf16); // bf32 path
++  if (bf32_usable) op_attr.set_fpmath_mode(dnnl_fpmath_mode_bf16); // bf32 path
+ 
+   // NOTE: View as c-contiguous to avoid extra reordering in mkldnn
+   // Use identity: C = AB <=> C^T = B^T A^T
+@@ -276,7 +276,7 @@
+   // but mkldnn matmul primitive only support bias be 1-D tensors
+   // to address their differences, we use mkldnn post ops to perform a fused "add" after matrix multiplication is over
+   if (beta != 0.0f) op_attr = ideep::attr_t::fuse_sum();
+-  if (mat1.scalar_type() == at::kFloat) op_attr.set_fpmath_mode(dnnl_fpmath_mode_bf16); // bf32 path
++  if (mat1.scalar_type() == at::kFloat && use_mkldnn_bf32_matmul()) op_attr.set_fpmath_mode(dnnl_fpmath_mode_bf16); // bf32 path
+   // If alpha = 0, dose not need actually do gemm computation
+   if (alpha == 0)
+     return;

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -50,6 +50,7 @@ fi
 patch -p1 < $PACKAGE_DIR/pytorch_dynamic_quantization.patch
 patch --ignore-whitespace -p1 < $PACKAGE_DIR/pytorch_static_quantization.patch
 patch -p1 < $PACKAGE_DIR/pytorch_gelu.patch
+patch -p1 < $PACKAGE_DIR/pytorch_bf32_matmul.patch
 
 # Apply https://github.com/pytorch/pytorch/pull/122616 to make torch 2.3.0 backwards
 # compatible with torchdata
@@ -61,6 +62,7 @@ git checkout 55ca0191687aaf19aca5cdb7881c791e3bea442b
 patch -p1 < $PACKAGE_DIR/ideep_dynamic_quantization.patch
 patch -p1 < $PACKAGE_DIR/ideep_static_quantization.patch
 patch -p1 < $PACKAGE_DIR/ideep_remove_matmul_primitive_caching.patch
+patch -p1 < $PACKAGE_DIR/ideep_pd_cache_modes.patch
 
 # Update the oneDNN tag in third_party/ideep
 cd mkl-dnn


### PR DESCRIPTION
- Patch which correctly applies BF16 downconversion when float32 matmul precision is set to "medium'
- Add patch to ideep which includes computation modes as part of the PD cache key.