### PR TITLE
Add proof of concept for SVE embedding_lookup_idx

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -295,7 +295,7 @@ COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_static_quantization.patch $PACKAGE_DIR/.
 COPY patches/pytorch_gelu.patch $PACKAGE_DIR/.
 COPY patches/pytorch_bf32_matmul.patch $PACKAGE_DIR/.
-
+COPY patches/pytorch_embedding_lookup_sve_concept.patch $PACKAGE_DIR/.
 COPY patches/onednn_stateless_matmul.patch $PACKAGE_DIR/.
 
 COPY scripts/build-torchvision.sh $PACKAGE_DIR/.

--- a/docker/pytorch-aarch64/patches/pytorch_embedding_lookup_sve_concept.patch
+++ b/docker/pytorch-aarch64/patches/pytorch_embedding_lookup_sve_concept.patch
@@ -1,0 +1,655 @@
+ *******************************************************************************
+ Copyright 2024 Arm Limited and affiliates.
+ SPDX-License-Identifier: Apache-2.0
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ *******************************************************************************
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index b74bf4536f4..4e095388a75 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -232,7 +232,7 @@ option(USE_MAGMA "Use MAGMA" ON)
+ option(USE_METAL "Use Metal for Caffe2 iOS build" ON)
+ option(USE_PYTORCH_METAL "Use Metal for PyTorch iOS build" OFF)
+ option(USE_PYTORCH_METAL_EXPORT "Export Metal models on MacOSX desktop" OFF)
+-option(USE_NATIVE_ARCH "Use -march=native" OFF)
++option(USE_NATIVE_ARCH "Use -march=native" ON)
+ cmake_dependent_option(
+     USE_MPS "Use MPS for macOS build" ON
+     "MPS_FOUND" OFF)
+diff --git a/caffe2/perfkernels/embedding_lookup_idx.cc b/caffe2/perfkernels/embedding_lookup_idx.cc
+index 48c869ee703..a3752ac62e4 100644
+--- a/caffe2/perfkernels/embedding_lookup_idx.cc
++++ b/caffe2/perfkernels/embedding_lookup_idx.cc
+@@ -7,6 +7,10 @@
+ #include "caffe2/core/logging.h"
+ #include "caffe2/perfkernels/common.h"
+ 
++#ifdef __ARM_FEATURE_SVE
++#include <arm_sve.h>
++#endif //__ARM_FEATURE_SVE
++
+ namespace caffe2 {
+ 
+ /**
+@@ -76,6 +80,495 @@ static bool EmbeddingLookupGenericSlowIdx(
+   return current == index_size;
+ }
+ 
++#ifdef __ARM_FEATURE_SVE
++template <typename IndexType, bool IS_WEIGHT_POSITIONAL = false>
++static bool EmbeddingLookupIdx_sve(
++    const int64_t block_size,
++    const int64_t output_size,
++    const int64_t index_size,
++    const int64_t data_size,
++    const float* input,
++    const IndexType* indices,
++    const IndexType* offsets,
++    const float* weights, // optional, can be null for sum reducer
++    const float* scale_bias, // optional scale & bias params for uint8 input
++    bool normalize_by_lengths,
++    float* out) {
++  const svbool_t svAll = svptrue_b32();
++  const uint64_t vLen = svcntw();
++
++  int64_t pos = 0;
++  if (block_size == static_cast<int64_t>(16 * vLen)) {
++    for (int64_t i = 0; i < output_size; ++i) {
++      float* const outPtr = &out[i * block_size];
++      memset(outPtr, 0, sizeof(float) * block_size);
++      if (pos != offsets[i] - offsets[0]) {
++        return false;
++      }
++
++      svfloat32_t vsum0 = svdup_n_f32(0);
++      svfloat32_t vsum1 = svdup_n_f32(0);
++      svfloat32_t vsum2 = svdup_n_f32(0);
++      svfloat32_t vsum3 = svdup_n_f32(0);
++      svfloat32_t vsum4 = svdup_n_f32(0);
++      svfloat32_t vsum5 = svdup_n_f32(0);
++      svfloat32_t vsum6 = svdup_n_f32(0);
++      svfloat32_t vsum7 = svdup_n_f32(0);
++      svfloat32_t vsum8 = svdup_n_f32(0);
++      svfloat32_t vsum9 = svdup_n_f32(0);
++      svfloat32_t vsum10 = svdup_n_f32(0);
++      svfloat32_t vsum11 = svdup_n_f32(0);
++      svfloat32_t vsum12 = svdup_n_f32(0);
++      svfloat32_t vsum13 = svdup_n_f32(0);
++      svfloat32_t vsum14 = svdup_n_f32(0);
++      svfloat32_t vsum15 = svdup_n_f32(0);
++
++      int64_t start_offset = offsets[i];
++      int64_t end_offset = offsets[i + 1];
++
++      for (int64_t j = start_offset; j < end_offset; ++j) {
++        const IndexType idx = indices[pos];
++        if (idx < 0 || idx >= data_size) {
++          return false;
++        }
++
++        // Get weights
++        float wgt = 1.f;
++        if (weights) {
++          wgt = weights[IS_WEIGHT_POSITIONAL ? (j - start_offset) : pos];
++        }
++        const svfloat32_t vwgt = svdup_n_f32(wgt);
++
++        // Scaling
++        const float* const inPtr = &input[idx * block_size];
++        // w * input + output
++        vsum0 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[0 * vLen]), vsum0);
++
++        vsum1 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[1 * vLen]), vsum1);
++
++        vsum2 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[2 * vLen]), vsum2);
++
++        vsum3 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[3 * vLen]), vsum3);
++
++        vsum4 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[4 * vLen]), vsum4);
++
++        vsum5 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[5 * vLen]), vsum5);
++
++        vsum6 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[6 * vLen]), vsum6);
++
++        vsum7 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[7 * vLen]), vsum7);
++
++        vsum8 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[8 * vLen]), vsum8);
++
++        vsum9 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[9 * vLen]), vsum9);
++
++        vsum10 = svmad_f32_x(
++            svAll, vwgt, svld1_f32(svAll, &inPtr[10 * vLen]), vsum10);
++
++        vsum11 = svmad_f32_x(
++            svAll, vwgt, svld1_f32(svAll, &inPtr[11 * vLen]), vsum11);
++
++        vsum12 = svmad_f32_x(
++            svAll, vwgt, svld1_f32(svAll, &inPtr[12 * vLen]), vsum12);
++
++        vsum13 = svmad_f32_x(
++            svAll, vwgt, svld1_f32(svAll, &inPtr[13 * vLen]), vsum13);
++
++        vsum14 = svmad_f32_x(
++            svAll, vwgt, svld1_f32(svAll, &inPtr[14 * vLen]), vsum14);
++
++        vsum15 = svmad_f32_x(
++            svAll, vwgt, svld1_f32(svAll, &inPtr[15 * vLen]), vsum15);
++
++        ++pos;
++      }
++
++      // Normalisation
++      const int64_t length = end_offset - start_offset;
++
++      if (normalize_by_lengths && (length != 0)) {
++        const float len_inv = 1.0f / length;
++        svfloat32_t vlen_inv = svdup_n_f32(len_inv);
++
++        svst1_f32(
++            svAll, &outPtr[0 * vLen], svmul_f32_x(svAll, vsum0, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[1 * vLen], svmul_f32_x(svAll, vsum1, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[2 * vLen], svmul_f32_x(svAll, vsum2, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[3 * vLen], svmul_f32_x(svAll, vsum3, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[4 * vLen], svmul_f32_x(svAll, vsum4, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[5 * vLen], svmul_f32_x(svAll, vsum5, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[6 * vLen], svmul_f32_x(svAll, vsum6, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[7 * vLen], svmul_f32_x(svAll, vsum7, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[8 * vLen], svmul_f32_x(svAll, vsum8, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[9 * vLen], svmul_f32_x(svAll, vsum9, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[10 * vLen], svmul_f32_x(svAll, vsum10, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[11 * vLen], svmul_f32_x(svAll, vsum11, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[12 * vLen], svmul_f32_x(svAll, vsum12, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[13 * vLen], svmul_f32_x(svAll, vsum13, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[14 * vLen], svmul_f32_x(svAll, vsum14, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[15 * vLen], svmul_f32_x(svAll, vsum15, vlen_inv));
++      } else {
++        svst1_f32(svAll, &outPtr[0 * vLen], vsum0);
++        svst1_f32(svAll, &outPtr[1 * vLen], vsum1);
++        svst1_f32(svAll, &outPtr[2 * vLen], vsum2);
++        svst1_f32(svAll, &outPtr[3 * vLen], vsum3);
++        svst1_f32(svAll, &outPtr[4 * vLen], vsum4);
++        svst1_f32(svAll, &outPtr[5 * vLen], vsum5);
++        svst1_f32(svAll, &outPtr[6 * vLen], vsum6);
++        svst1_f32(svAll, &outPtr[7 * vLen], vsum7);
++        svst1_f32(svAll, &outPtr[8 * vLen], vsum8);
++        svst1_f32(svAll, &outPtr[9 * vLen], vsum9);
++        svst1_f32(svAll, &outPtr[10 * vLen], vsum10);
++        svst1_f32(svAll, &outPtr[11 * vLen], vsum11);
++        svst1_f32(svAll, &outPtr[12 * vLen], vsum12);
++        svst1_f32(svAll, &outPtr[13 * vLen], vsum13);
++        svst1_f32(svAll, &outPtr[14 * vLen], vsum14);
++        svst1_f32(svAll, &outPtr[15 * vLen], vsum15);
++      }
++    }
++  } else if (block_size == static_cast<int64_t>(8 * vLen)) {
++    for (int64_t i = 0; i < output_size; ++i) {
++      float* const outPtr = &out[i * block_size];
++      memset(outPtr, 0, sizeof(float) * block_size);
++      if (pos != offsets[i] - offsets[0]) {
++        return false;
++      }
++
++      svfloat32_t vsum0 = svdup_n_f32(0);
++      svfloat32_t vsum1 = svdup_n_f32(0);
++      svfloat32_t vsum2 = svdup_n_f32(0);
++      svfloat32_t vsum3 = svdup_n_f32(0);
++      svfloat32_t vsum4 = svdup_n_f32(0);
++      svfloat32_t vsum5 = svdup_n_f32(0);
++      svfloat32_t vsum6 = svdup_n_f32(0);
++      svfloat32_t vsum7 = svdup_n_f32(0);
++
++      int64_t start_offset = offsets[i];
++      int64_t end_offset = offsets[i + 1];
++
++      for (int64_t j = start_offset; j < end_offset; ++j) {
++        const IndexType idx = indices[pos];
++        if (idx < 0 || idx >= data_size) {
++          return false;
++        }
++
++        // Get weights
++        float wgt = 1.f;
++        if (weights) {
++          wgt = weights[IS_WEIGHT_POSITIONAL ? (j - start_offset) : pos];
++        }
++        const svfloat32_t vwgt = svdup_n_f32(wgt);
++
++        // Scaling
++        const float* const inPtr = &input[idx * block_size];
++        // w * input + output
++        vsum0 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[0 * vLen]), vsum0);
++
++        vsum1 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[1 * vLen]), vsum1);
++
++        vsum2 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[2 * vLen]), vsum2);
++
++        vsum3 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[3 * vLen]), vsum3);
++
++        vsum4 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[4 * vLen]), vsum4);
++
++        vsum5 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[5 * vLen]), vsum5);
++
++        vsum6 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[6 * vLen]), vsum6);
++
++        vsum7 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[7 * vLen]), vsum7);
++
++        ++pos;
++      }
++
++      // Normalisation
++      const int64_t length = end_offset - start_offset;
++
++      if (normalize_by_lengths && (length != 0)) {
++        const float len_inv = 1.0f / length;
++        svfloat32_t vlen_inv = svdup_n_f32(len_inv);
++
++        svst1_f32(
++            svAll, &outPtr[0 * vLen], svmul_f32_x(svAll, vsum0, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[1 * vLen], svmul_f32_x(svAll, vsum1, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[2 * vLen], svmul_f32_x(svAll, vsum2, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[3 * vLen], svmul_f32_x(svAll, vsum3, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[4 * vLen], svmul_f32_x(svAll, vsum4, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[5 * vLen], svmul_f32_x(svAll, vsum5, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[6 * vLen], svmul_f32_x(svAll, vsum6, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[7 * vLen], svmul_f32_x(svAll, vsum7, vlen_inv));
++      } else {
++        svst1_f32(svAll, &outPtr[0 * vLen], vsum0);
++        svst1_f32(svAll, &outPtr[1 * vLen], vsum1);
++        svst1_f32(svAll, &outPtr[2 * vLen], vsum2);
++        svst1_f32(svAll, &outPtr[3 * vLen], vsum3);
++        svst1_f32(svAll, &outPtr[4 * vLen], vsum4);
++        svst1_f32(svAll, &outPtr[5 * vLen], vsum5);
++        svst1_f32(svAll, &outPtr[6 * vLen], vsum6);
++        svst1_f32(svAll, &outPtr[7 * vLen], vsum7);
++      }
++    }
++  } else if (block_size == static_cast<int64_t>(4 * vLen)) {
++    for (int64_t i = 0; i < output_size; ++i) {
++      float* const outPtr = &out[i * block_size];
++      memset(outPtr, 0, sizeof(float) * block_size);
++      if (pos != offsets[i] - offsets[0]) {
++        return false;
++      }
++
++      svfloat32_t vsum0 = svdup_n_f32(0);
++      svfloat32_t vsum1 = svdup_n_f32(0);
++      svfloat32_t vsum2 = svdup_n_f32(0);
++      svfloat32_t vsum3 = svdup_n_f32(0);
++
++      int64_t start_offset = offsets[i];
++      int64_t end_offset = offsets[i + 1];
++
++      for (int64_t j = start_offset; j < end_offset; ++j) {
++        const IndexType idx = indices[pos];
++        if (idx < 0 || idx >= data_size) {
++          return false;
++        }
++
++        // Get weights
++        float wgt = 1.f;
++        if (weights) {
++          wgt = weights[IS_WEIGHT_POSITIONAL ? (j - start_offset) : pos];
++        }
++        const svfloat32_t vwgt = svdup_n_f32(wgt);
++
++        // Scaling
++        const float* const inPtr = &input[idx * block_size];
++        // w * input + output
++        vsum0 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[0 * vLen]), vsum0);
++
++        vsum1 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[1 * vLen]), vsum1);
++
++        vsum2 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[2 * vLen]), vsum2);
++
++        vsum3 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[3 * vLen]), vsum3);
++
++        ++pos;
++      }
++
++      // Normalisation
++      const int64_t length = end_offset - start_offset;
++
++      if (normalize_by_lengths && (length != 0)) {
++        const float len_inv = 1.0f / length;
++        svfloat32_t vlen_inv = svdup_n_f32(len_inv);
++
++        svst1_f32(
++            svAll, &outPtr[0 * vLen], svmul_f32_x(svAll, vsum0, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[1 * vLen], svmul_f32_x(svAll, vsum1, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[2 * vLen], svmul_f32_x(svAll, vsum2, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[3 * vLen], svmul_f32_x(svAll, vsum3, vlen_inv));
++
++      } else {
++        svst1_f32(svAll, &outPtr[0 * vLen], vsum0);
++        svst1_f32(svAll, &outPtr[1 * vLen], vsum1);
++        svst1_f32(svAll, &outPtr[2 * vLen], vsum2);
++        svst1_f32(svAll, &outPtr[3 * vLen], vsum3);
++      }
++    }
++  } else if (block_size == static_cast<int64_t>(2 * vLen)) {
++    for (int64_t i = 0; i < output_size; ++i) {
++      float* const outPtr = &out[i * block_size];
++      memset(outPtr, 0, sizeof(float) * block_size);
++      if (pos != offsets[i] - offsets[0]) {
++        return false;
++      }
++
++      svfloat32_t vsum0 = svdup_n_f32(0);
++      svfloat32_t vsum1 = svdup_n_f32(0);
++
++      int64_t start_offset = offsets[i];
++      int64_t end_offset = offsets[i + 1];
++
++      for (int64_t j = start_offset; j < end_offset; ++j) {
++        const IndexType idx = indices[pos];
++        if (idx < 0 || idx >= data_size) {
++          return false;
++        }
++
++        // Get weights
++        float wgt = 1.f;
++        if (weights) {
++          wgt = weights[IS_WEIGHT_POSITIONAL ? (j - start_offset) : pos];
++        }
++        const svfloat32_t vwgt = svdup_n_f32(wgt);
++
++        // Scaling
++        const float* const inPtr = &input[idx * block_size];
++        // w * input + output
++        vsum0 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[0 * vLen]), vsum0);
++
++        vsum1 =
++            svmad_f32_x(svAll, vwgt, svld1_f32(svAll, &inPtr[1 * vLen]), vsum1);
++
++        ++pos;
++      }
++
++      // Normalisation
++      const int64_t length = end_offset - start_offset;
++
++      if (normalize_by_lengths && (length != 0)) {
++        const float len_inv = 1.0f / length;
++        svfloat32_t vlen_inv = svdup_n_f32(len_inv);
++
++        svst1_f32(
++            svAll, &outPtr[0 * vLen], svmul_f32_x(svAll, vsum0, vlen_inv));
++
++        svst1_f32(
++            svAll, &outPtr[1 * vLen], svmul_f32_x(svAll, vsum1, vlen_inv));
++
++      } else {
++        svst1_f32(svAll, &outPtr[0 * vLen], vsum0);
++        svst1_f32(svAll, &outPtr[1 * vLen], vsum1);
++      }
++    }
++  } else {
++    for (int64_t i = 0; i < output_size; ++i) {
++      float* const outPtr = &out[i * block_size];
++      memset(outPtr, 0, sizeof(float) * block_size);
++
++      if (pos != offsets[i] - offsets[0]) {
++        return false;
++      }
++
++      int64_t start_offset = offsets[i];
++      int64_t end_offset = offsets[i + 1];
++
++      for (int64_t j = start_offset; j < end_offset; ++j) {
++        const IndexType idx = indices[pos];
++        if (idx < 0 || idx >= data_size) {
++          return false;
++        }
++
++        // Get weights
++        float wgt = 1.f;
++        if (weights) {
++          wgt = weights[IS_WEIGHT_POSITIONAL ? (j - start_offset) : pos];
++        }
++        const svfloat32_t vwgt = svdup_n_f32(wgt);
++
++        // Scaling
++        const float* const inPtr = &input[idx * block_size];
++        // w * input + output
++        svbool_t pg;
++        for (int64_t k = 0;
++             svptest_first(svAll, pg = svwhilelt_b32_s64(k, block_size));
++             k += vLen) {
++          svst1_f32(
++              pg,
++              &outPtr[k],
++              svmad_f32_x(
++                  pg,
++                  vwgt,
++                  svld1_f32(pg, &inPtr[k]),
++                  svld1_f32(pg, &outPtr[k])));
++        }
++
++        ++pos;
++      }
++
++      // Normalisation
++      const int64_t length = end_offset - start_offset;
++
++      if (normalize_by_lengths && (length != 0)) {
++        const float len_inv = 1.0f / length;
++        svfloat32_t vlen_inv = svdup_n_f32(len_inv);
++        svbool_t pg;
++
++        for (int64_t k = 0;
++             svptest_first(svAll, pg = svwhilelt_b32_s64(k, block_size));
++             k += vLen) {
++          svst1_f32(
++              pg,
++              &outPtr[k],
++              svmul_f32_x(pg, svld1_f32(pg, &outPtr[k]), vlen_inv));
++        }
++      }
++    }
++  }
++
++  return pos == index_size;
++}
++#endif
++
+ // clang-format off
+ // Proxy back to generic implementation
+ #define EMBEDDING_IDX_SPECIALIZATION(                                                                 \
+@@ -211,8 +704,113 @@ static bool EmbeddingLookupGenericSlowIdx(
+   }
+ // clang-format on
+ 
++#ifdef __ARM_FEATURE_SVE
++template <>
++void EmbeddingLookupIdx<int32_t, float, float, false>(
++    const int64_t block_size,
++    const int64_t output_size,
++    const int64_t index_size,
++    const int64_t data_size,
++    const float* input,
++    const int* indices,
++    const int* offsets,
++    const float* weights,
++    const float* scale_bias,
++    bool normalize_by_lengths,
++    float* out) {
++  bool success = EmbeddingLookupIdx_sve<int32_t, false>(
++      block_size,
++      output_size,
++      index_size,
++      data_size,
++      input,
++      indices,
++      offsets,
++      weights,
++      scale_bias,
++      normalize_by_lengths,
++      out);
++  if (success) {
++    return;
++  }
++  int64_t current = 0;
++  for (int m = 0; m < output_size; ++m) {
++    for (int64_t i = offsets[m]; i < offsets[m + 1]; ++i) {
++      CAFFE_ENFORCE_LT(current, index_size);
++      int idx = indices[current];
++      CAFFE_ENFORCE(
++          0 <= idx && idx < data_size,
++          "Index ",
++          current,
++          " is out of bounds: ",
++          idx,
++          ", range 0 to ",
++          data_size);
++      ++current;
++    }
++  }
++  CAFFE_ENFORCE_EQ(
++      current,
++      index_size,
++      "Your input seems to be incorrect: the sum of lengths values should be "
++      "the size of the indices tensor, but it appears not.");
++}
++
++template <>
++void EmbeddingLookupIdx<int64_t, float, float, false>(
++    const int64_t block_size,
++    const int64_t output_size,
++    const int64_t index_size,
++    const int64_t data_size,
++    const float* input,
++    const int64_t* indices,
++    const int64_t* offsets,
++    const float* weights,
++    const float* scale_bias,
++    bool normalize_by_lengths,
++    float* out) {
++  bool success = EmbeddingLookupIdx_sve<int64_t, false>(
++      block_size,
++      output_size,
++      index_size,
++      data_size,
++      input,
++      indices,
++      offsets,
++      weights,
++      scale_bias,
++      normalize_by_lengths,
++      out);
++  if (success) {
++    return;
++  }
++  int64_t current = 0;
++  for (int m = 0; m < output_size; ++m) {
++    for (int64_t i = offsets[m]; i < offsets[m + 1]; ++i) {
++      CAFFE_ENFORCE_LT(current, index_size);
++      int idx = indices[current];
++      CAFFE_ENFORCE(
++          0 <= idx && idx < data_size,
++          "Index ",
++          current,
++          " is out of bounds: ",
++          idx,
++          ", range 0 to ",
++          data_size);
++      ++current;
++    }
++  }
++  CAFFE_ENFORCE_EQ(
++      current,
++      index_size,
++      "Your input seems to be incorrect: the sum of lengths values should be "
++      "the size of the indices tensor, but it appears not.");
++}
++#else
+ EMBEDDING_IDX_SPECIALIZATION(int32_t, float, float, float, false);
+ EMBEDDING_IDX_SPECIALIZATION(int64_t, float, float, float, false);
++#endif //__ARM_FEATURE_SVE
++
+ EMBEDDING_IDX_SPECIALIZATION(int32_t, half, at::Half, float, false);
+ EMBEDDING_IDX_SPECIALIZATION(int64_t, half, at::Half, float, false);
+ EMBEDDING_IDX_SPECIALIZATION(int32_t, bfloat16, at::BFloat16, float, false);

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -47,6 +47,7 @@ if [[ $ONEDNN_BUILD ]]; then
   esac
 fi
 
+patch -p1 < $PACKAGE_DIR/pytorch_embedding_lookup_sve_concept.patch
 patch -p1 < $PACKAGE_DIR/pytorch_dynamic_quantization.patch
 patch --ignore-whitespace -p1 < $PACKAGE_DIR/pytorch_static_quantization.patch
 patch -p1 < $PACKAGE_DIR/pytorch_gelu.patch


### PR DESCRIPTION
This PR adds a proof-of-concept, SVE-vectorised version of the [embedding lookup from PyTorch](https://github.com/pytorch/pytorch/blob/main/caffe2/perfkernels/embedding_lookup_idx.cc). On my Neoverse V1 machine this gives a roughly 3.85x speedup.

This proof-of-concept is for FP32, but can be fleshed out for the remaining data types in a similar fashion.

It requires native builds to be enabled for the PyTorch build which is enabled here as a patch.