### PR TITLE
Cache reorders in ideep

### DIFF
--- a/docker/pytorch-aarch64/Dockerfile
+++ b/docker/pytorch-aarch64/Dockerfile
@@ -284,6 +284,7 @@ COPY patches/onednn.patch $PACKAGE_DIR/.
 COPY patches/onednn_acl_thread_local_scheduler.patch $PACKAGE_DIR/.
 COPY patches/torchvision.patch $PACKAGE_DIR/.
 COPY patches/ideep_dynamic_quantization.patch $PACKAGE_DIR/.
+COPY patches/ideep_cache_reorders.patch $PACKAGE_DIR/.
 COPY patches/pytorch_dynamic_quantization.patch $PACKAGE_DIR/.
 
 COPY scripts/build-torchvision.sh $PACKAGE_DIR/.

--- a/docker/pytorch-aarch64/README.md
+++ b/docker/pytorch-aarch64/README.md
@@ -174,3 +174,12 @@ It is possible to choose a specific build target using the `--build-target` flag
   * custom       - apply a custom set of architecture and tuning flags, as defined in [cpu_info.sh](cpu_info.sh).
 
 In addition to the Dockerfile, please refer to the files in the `scripts/` and `patches/` directories to see how the software is built.
+
+# General optimization guidelines
+
+## PyTorch runtime flags
+
+We recommend running with the following run time flags and using tcmalloc to handle memory allocations in PyTorch for better performance.
+
+* IDEEP_CACHE_MATMUL_REORDERS=1   - Caches reordered weight tensors. This increases performance but also increases memory usage. LRU_CACHE_CAPACITY should be set to a meaningful amount for this cache to be effective.
+* LRU_CACHE_CAPACITY=<cache size> - Number of objects to cache in the LRU cache

--- a/docker/pytorch-aarch64/patches/ideep_cache_reorders.patch
+++ b/docker/pytorch-aarch64/patches/ideep_cache_reorders.patch
@@ -1,0 +1,64 @@
+diff --git a/include/ideep/operators/matmul.hpp b/include/ideep/operators/matmul.hpp
+index c0f7bcd..9141644 100644
+--- a/include/ideep/operators/matmul.hpp
++++ b/include/ideep/operators/matmul.hpp
+@@ -3,6 +3,16 @@
+ 
+ namespace ideep {
+ 
++#ifdef __aarch64__
++struct reorder_cache : utils::computation_cache<ideep::tensor> {
++  ideep::tensor reordered;
++
++  reorder_cache () {}
++
++  reorder_cache(ideep::tensor reordered_) : reordered(std::move(reordered_)) {}
++};
++#endif
++
+ // Parameters for dynamic quantization
+ struct matmul_forward_dyn_quant_params {
+   tensor::desc src_desc; // to create src tensor
+@@ -47,6 +57,14 @@ struct matmul_forward_params {
+   }
+ };
+ 
++#ifdef __aarch64__
++  static inline bool get_ideep_cache_matmul_reorders() {
++    static const char* ptr = std::getenv("IDEEP_CACHE_MATMUL_REORDERS");
++    static const bool value = ptr ? bool(std::atoi(ptr)) : false;
++    return value;
++  }
++#endif
++
+ struct matmul_forward : public dnnl::matmul,
+                         utils::computation_cache<dnnl::matmul::primitive_desc> {
+   using super = dnnl::matmul;
+@@ -1245,9 +1263,27 @@ struct matmul_forward : public dnnl::matmul,
+     auto& expected_src = reorder_src ?
+                          src.reorder_if_differ_in(expected_src_desc, src_attr) :
+                          src;
++#ifdef __aarch64__
++    tensor expected_weights = weights;
++    if(reorder_weight) {
++      bool cache_reorders = get_ideep_cache_matmul_reorders();
++      if(cache_reorders) {
++        // Key for reorder cache
++        auto key = utils::create_key(
++          expected_weights.get_hash()
++        );
++        expected_weights = reorder_cache::fetch_or_create(key, [&]() {
++          return weights.reorder_if_differ_in(expected_wei_desc, weights_attr);
++        });
++      } else {
++        expected_weights = weights.reorder_if_differ_in(expected_wei_desc, weights_attr);
++      }
++    }
++#else
+     auto& expected_weights = reorder_weight ?
+                              weights.reorder_if_differ_in(expected_wei_desc, weights_attr) :
+                              weights;
++#endif
+     tensor scratchpad(pd.scratchpad_desc());
+ 
+     exec_args args;

--- a/docker/pytorch-aarch64/scripts/build-pytorch.sh
+++ b/docker/pytorch-aarch64/scripts/build-pytorch.sh
@@ -57,6 +57,7 @@ patch -p1 < torch2.3_bc_torchdata.patch
 cd third_party/ideep
 git checkout 55ca0191687aaf19aca5cdb7881c791e3bea442b
 patch -p1 < $PACKAGE_DIR/ideep_dynamic_quantization.patch
+patch -p1 < $PACKAGE_DIR/ideep_cache_reorders.patch
 
 # Update the oneDNN tag in third_party/ideep
 cd mkl-dnn


### PR DESCRIPTION
Add functionality to cache the reordered weights in ideep. Enabled by the environment variables `IDEEP_CACHE_MATMUL_REORDERS` and `LRU_CACHE_CAPACITY`