### PR TITLE
Add oneDNN patch to re-enable ACL indirect conv for BF16

### DIFF
--- a/docker/pytorch-aarch64/get-source.sh
+++ b/docker/pytorch-aarch64/get-source.sh
@@ -96,6 +96,8 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
             apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2198 efad4f6582c13823d81c78130ab80db57b1381eb # src: cpu: aarch64: Enable convolution static quantisation.
 
             apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2212 0358abf98dd6c5221a0c40ea47f0a23a1e6cf28e # src: cpu: aarch64: lowp_matmul: Make weights constant
+            apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2218 f913679c5576d4753ea105f44baf4825f202bc8f # src: cpu: aarch64: Re-enable ACL indirect conv for BF16
+
         )
     )
 )


### PR DESCRIPTION
Add oneDNN patch to re-enable ACL indirect conv for BF16
