### PR TITLE
Fix static quantization broken links and example

### DIFF
--- a/docker/pytorch-aarch64/examples/static_quantize_conv.py
+++ b/docker/pytorch-aarch64/examples/static_quantize_conv.py
@@ -46,7 +46,7 @@ weighted_int8_dtype_config = DTypeConfig(
     input_dtype=torch.qint8,
     output_dtype=torch.qint8,
     weight_dtype=torch.qint8,
-    bias_dtype=torch.qint32)
+    bias_dtype=torch.float32)
 
 # For quantizing convolution
 conv2d_config = BackendPatternConfig(torch.nn.Conv2d) \

--- a/docker/pytorch-aarch64/get-source.sh
+++ b/docker/pytorch-aarch64/get-source.sh
@@ -92,8 +92,8 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
             git fetch origin $ONEDNN_HASH && git clean -f && git checkout -f FETCH_HEAD
             apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2194 c22f4ae50002ef0a93bfe1895684f36abd92517d # src: cpu: aarch64: lowp_matmul: Make weights constant
             # Two commits from one PR
-            apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2198 6a77e84feb442964c91a0101d58fe1473566b185 # src: cpu: aarch64: Enable matmul static quantisation.
-            apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2198 efad4f6582c13823d81c78130ab80db57b1381eb # src: cpu: aarch64: Enable convolution static quantisation.
+            apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2212 6a77e84feb442964c91a0101d58fe1473566b185 # src: cpu: aarch64: Enable matmul static quantisation.
+            apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2212 efad4f6582c13823d81c78130ab80db57b1381eb # src: cpu: aarch64: Enable convolution static quantisation.
 
             apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2212 0358abf98dd6c5221a0c40ea47f0a23a1e6cf28e # src: cpu: aarch64: lowp_matmul: Make weights constant
             apply-github-patch https://github.com/oneapi-src/oneDNN/pull/2218 f913679c5576d4753ea105f44baf4825f202bc8f # src: cpu: aarch64: Re-enable ACL indirect conv for BF16


### PR DESCRIPTION
This PR fix:

 1. Broken links for OneDNN commits in `docker/pytorch-aarch64/get-source.sh`.
 2. Update example `static_quantize_conv.py`.