### PR TITLE
Bump sources, update manylinux, and update patches

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -8,10 +8,26 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [unreleased]
 
 ### Added
+- Adds libtbb to Docker to support parallel sort optimisations.
 
 ### Changed
 - Updates apply-github-patch to make it more tollerant of upstream changes.
 - Removed the dependency on pytorch/builder and use pytorch/.ci scripts for building pytorch.
+- Updates hashes for:
+-- PyTorch, to 8d4926e30a944320adf434016129cb6788eff79b (from viable/strict branch);
+-- iDeep, to e026f3b0318087fe19e2b062e8edf55bfe7a522c (from ideep_pytorch branch);
+-- oneDNN, to 0fd3b73a25d11106e141ddefd19fcacc74f8bbfe (from main branch);
+-- Arm Compute Library, to 6acccf1730b48c9a22155998fc4b2e0752472148 (from main branch).
+- Adds work-in-progress PyTorch PRs:
+-- 142391 8373846f441381a56e7abd905af84102aa52fc7b - parallelize sort;
+-- 139387 e5e5d29d6bab882540e36e44a3a75bd187fcbb62 - Add prepacking for linear weights;
+-- 139387 19423aaa1af154e1d47d8acf1e677dff727da5aa - Add prepacking for linear weights;
+-- 140159 9463c3261f57c42a952f1ba95633833cb1c561fc - cpu: aarch64: enable gemm-bf16f32.
+- Updates PyTorch dependencies:
+-- torchvision updated to 0.22.0.dev20241218;
+-- torchaudio updated to 2.6.0.dev20241218.
+- Updates build environment to manylinux2_28_aarch64.
+  Note: this updates the GCC version from 10 to 11 with performance improvements of 5-10% in many cases.
 
 ### Removed
 

--- a/ML-Frameworks/pytorch-aarch64/Dockerfile
+++ b/ML-Frameworks/pytorch-aarch64/Dockerfile
@@ -75,9 +75,9 @@ COPY $TORCH_WHEEL /home/$DOCKER_USER/
 # to match the git commit date, so that it is compatibile with the other built
 # torch* nightly builds
 RUN pip install "$(basename "$TORCH_WHEEL")" \
-    torchaudio==2.5.0.dev20241104 \
+    torchaudio==2.6.0.dev20241218 \
     torchdata~=0.7.1 \
-    torchvision==0.20.0.dev20241104 \
+    torchvision==0.22.0.dev20241218 \
     --extra-index-url https://download.pytorch.org/whl/nightly/cpu \
     && rm "$(basename "$TORCH_WHEEL")"
 

--- a/ML-Frameworks/pytorch-aarch64/build-wheel.sh
+++ b/ML-Frameworks/pytorch-aarch64/build-wheel.sh
@@ -26,7 +26,7 @@ PYTHON_VERSION="3.10"
 
 # Transition to pytorch/manylinux2_28_aarch64-builder once
 # https://github.com/pytorch/pytorch/pull/137696 goes in
-IMAGE_NAME="pytorch/manylinuxaarch64-builder:cpu-aarch64-3a2ab9584f6ce69bf9730c822fd08375c592bf38"
+IMAGE_NAME="pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-a040006da76a51c4f660331e9abd3affe5a4bd81"
 TORCH_BUILD_CONTAINER_ID_FILE="${PWD}/.torch_build_container_id"
 
 # Output dir for PyTorch wheel and other artifacts
@@ -74,6 +74,7 @@ if ! docker container inspect $TORCH_BUILD_CONTAINER >/dev/null 2>&1 ; then
     docker exec -t $TORCH_BUILD_CONTAINER bash -c "$PYTORCH_ROOT/.ci/aarch64_linux/aarch64_ci_setup.sh"
     docker exec -t $TORCH_BUILD_CONTAINER bash -c "python${PYTHON_VERSION} -m venv $TEST_VENV"
     docker exec -t $TORCH_BUILD_CONTAINER bash -c "source $TEST_VENV/bin/activate && pip install -r $PYTORCH_ROOT/.ci/docker/requirements-ci.txt && pip install ninja==1.10.0.post1"
+    docker exec -t $TORCH_BUILD_CONTAINER bash -c "yum install -y tbb tbb-devel"
 
     docker exec -t $TORCH_BUILD_CONTAINER bash /pytorch/.ci/docker/common/install_openblas.sh
 

--- a/ML-Frameworks/pytorch-aarch64/get-source.sh
+++ b/ML-Frameworks/pytorch-aarch64/get-source.sh
@@ -19,10 +19,10 @@
 
 set -eux -o pipefail
 
-PYTORCH_HASH=fda43c98d1bc82eeb493f6e79a1fd5f1636474a5 # From viable/strict
-IDEEP_HASH=77d4b35c685eecfc8f32ced5381052483bdc3b1d   # From ideep_pytorch
-ONEDNN_HASH=316287183e2503a9db2d975dd04359728aabceb2 # From main
-ACL_HASH=6acccf1730b48c9a22155998fc4b2e0752472148     # From main
+PYTORCH_HASH=8d4926e30a944320adf434016129cb6788eff79b  # From viable/strict
+IDEEP_HASH=e026f3b0318087fe19e2b062e8edf55bfe7a522c    # From ideep_pytorch
+ONEDNN_HASH=0fd3b73a25d11106e141ddefd19fcacc74f8bbfe   # From main
+ACL_HASH=6acccf1730b48c9a22155998fc4b2e0752472148      # From main
 
 function git-shallow-clone {
     (
@@ -53,7 +53,7 @@ function apply-github-patch {
     # Look in the full repo instead.
     # If it can't be found, this time curl will error
     if [[ ! -s $3.patch ]]; then
-       >&2 echo "Commit $2 not found in PR $1. Checking the full repository..."
+       >&2 echo "Commit $3 not found in $1/pull/$2. Checking the full repository..."
        curl --silent --fail -L $1/commit/$3.patch -o $3.patch
     fi
 
@@ -79,12 +79,18 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
     # Bump OpenBLAS version. Note that install_openblas.sh has to be rerun in the PyTorch builder Docker container
     sed -i -e 's/v0.3.25/v0.3.28/g' .ci/docker/common/install_openblas.sh
 
+    apply-github-patch https://github.com/pytorch/pytorch 143190 bdb74e24bfc70240fd2260dd7613246d7972fac1 # Enable AArch64 CI scripts to be used for local dev
+
     apply-github-patch https://github.com/pytorch/pytorch 139887 eff3c11b1a31f725b50020ce32f6eddba17b5a94 # Use s8s8s8 for qlinear on aarch64 instead of u8s8u8 with mkl-dnn
     apply-github-patch https://github.com/pytorch/pytorch 139753 16d397416abc44005fc66e377d4d15a0d6131a32 # Add SVE implementation for 8 bit quantized embedding bag on aarch64
     apply-github-patch https://github.com/pytorch/pytorch 136850 6d5aaff8434203f870d76d840158d6989ddd61d0 # Enable XNNPACK for quantized add
     apply-github-patch https://github.com/pytorch/pytorch 140233 6d0b4448bfe3771e076e5c7758333f98810605c4 # Enables static quantization for aarch64
     apply-github-patch https://github.com/pytorch/pytorch 135058 511af4efb5c008a75a196c525a7ad546a9915fd0 # Pass ideep:lowp_kind to matmul_forward::compute on cache misses
-    apply-github-patch https://github.com/pytorch/pytorch 143190 bdb74e24bfc70240fd2260dd7613246d7972fac1 # Enable AArch64 CI scripts to be used for local dev
+    apply-github-patch https://github.com/pytorch/pytorch 142391 8373846f441381a56e7abd905af84102aa52fc7b # parallelize sort
+    apply-github-patch https://github.com/pytorch/pytorch 139387 e5e5d29d6bab882540e36e44a3a75bd187fcbb62 # Add prepacking for linear weights
+    apply-github-patch https://github.com/pytorch/pytorch 139387 19423aaa1af154e1d47d8acf1e677dff727da5aa # Add prepacking for linear weights
+    apply-github-patch https://github.com/pytorch/pytorch 140159 9463c3261f57c42a952f1ba95633833cb1c561fc # cpu: aarch64: enable gemm-bf16f32
+
     git submodule sync
     git submodule update --init --checkout --force --recursive --jobs=$(nproc)
     (
@@ -96,7 +102,7 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
             cd mkl-dnn
             git fetch origin $ONEDNN_HASH && git clean -f && git checkout -f FETCH_HEAD
             apply-github-patch https://github.com/oneapi-src/oneDNN 2194 c22f4ae50002ef0a93bfe1895684f36abd92517d # src: cpu: aarch64: lowp_matmul: Make weights constant
-            # Two commits from one PR
+            # Multiple commits from one PR
             apply-github-patch https://github.com/oneapi-src/oneDNN 2212 6a77e84feb442964c91a0101d58fe1473566b185 # src: cpu: aarch64: Enable matmul static quantisation.
             apply-github-patch https://github.com/oneapi-src/oneDNN 2212 efad4f6582c13823d81c78130ab80db57b1381eb # src: cpu: aarch64: Enable convolution static quantisation.
             apply-github-patch https://github.com/oneapi-src/oneDNN 2212 0358abf98dd6c5221a0c40ea47f0a23a1e6cf28e # src: cpu: aarch64: lowp_matmul: Make weights constant


### PR DESCRIPTION
- Adds libtbb to Docker to support parallel sort optimisations.
- Updates apply-github-patch to make it more tollerant of upstream changes.
- Removes PyTorch/builder dependency as it is deprecated.
- Updates hashes for: -- PyTorch, to 8d4926e30a944320adf434016129cb6788eff79b (from viable/strict branch);
-- iDeep, to e026f3b0318087fe19e2b062e8edf55bfe7a522c (from ideep_pytorch branch);
-- oneDNN, to 0fd3b73a25d11106e141ddefd19fcacc74f8bbfe (from main branch);
-- Arm Compute Library, to 6acccf1730b48c9a22155998fc4b2e0752472148 (from main branch).
- Adds work-in-progress PyTorch PRs: -- 142391 8373846f441381a56e7abd905af84102aa52fc7b - parallelize sort; -- 139387 e5e5d29d6bab882540e36e44a3a75bd187fcbb62 - Add prepacking for linear weights;
-- 139387 19423aaa1af154e1d47d8acf1e677dff727da5aa - Add prepacking for linear weights;
-- 140159 9463c3261f57c42a952f1ba95633833cb1c561fc - cpu: aarch64: enable gemm-bf16f32.
- Updates PyTorch dependencies: -- torchvision updated to 0.22.0.dev20241218;
-- torchaudio updated to 2.6.0.dev20241218.
- Updates build environment to manylinux2_28_aarch64.