### PR TITLE
Add weights_only=False in model.load to fix example

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/examples/executor/model.py
+++ b/ML-Frameworks/pytorch-aarch64/examples/executor/model.py
@@ -164,7 +164,7 @@ class Model:
             )
             # the script for preparing files to run
             runpy.run_path(script_path, run_name="__main__")
-            self._model = torch.load(model_name, map_location="cpu")
+            self._model = torch.load(model_name, map_location="cpu", weights_only=False)
 
         else:
             assert (


### PR DESCRIPTION
weights_only now defaults to True, but we need to load the model as well as weights.