### PR TITLE
fix: allow DOCKER_IMAGE_MIRROR to be unset

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/build-torch-ao-wheel.sh
+++ b/ML-Frameworks/pytorch-aarch64/build-torch-ao-wheel.sh
@@ -25,7 +25,7 @@ set -eux -o pipefail
 PYTHON_VERSION="3.10"
 
 # Specify DOCKER_IMAGE_MIRROR if you want to use a mirror of hub.docker.com
-IMAGE_NAME="${DOCKER_IMAGE_MIRROR}pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-a040006da76a51c4f660331e9abd3affe5a4bd81"
+IMAGE_NAME="${DOCKER_IMAGE_MIRROR:-}pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-a040006da76a51c4f660331e9abd3affe5a4bd81"
 TORCH_BUILD_CONTAINER_ID_FILE="${PWD}/.torch_ao_build_container_id"
 
 TEST_VENV=aarch64_env_test_torch_ao

--- a/ML-Frameworks/pytorch-aarch64/build-wheel.sh
+++ b/ML-Frameworks/pytorch-aarch64/build-wheel.sh
@@ -32,7 +32,7 @@ set -eux -o pipefail
 PYTHON_VERSION="3.10"
 
 # Specify DOCKER_IMAGE_MIRROR if you want to use a mirror of hub.docker.com
-IMAGE_NAME="${DOCKER_IMAGE_MIRROR}pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-a040006da76a51c4f660331e9abd3affe5a4bd81"
+IMAGE_NAME="${DOCKER_IMAGE_MIRROR:-}pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-a040006da76a51c4f660331e9abd3affe5a4bd81"
 TORCH_BUILD_CONTAINER_ID_FILE="${PWD}/.torch_build_container_id"
 
 # Output dir for PyTorch wheel and other artifacts


### PR DESCRIPTION
Fix error:
```
./build-wheel.sh: line 35: DOCKER_IMAGE_MIRROR: unbound variable
```
by explicitly providing blank default