### PR TITLE
fix: append to build log rather than overwriting

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/.dockerignore
+++ b/ML-Frameworks/pytorch-aarch64/.dockerignore
@@ -1,4 +1,4 @@
 ComputeLibrary/
 pytorch/
-*.whl
+*.log
 .*_build_container_id


### PR DESCRIPTION
Previously, tee was overwriting the logs for every invocation inside build.sh, so we couldn't see the logs for the torch build. Use exec at the start of the script to redirect output so that all the output from the script goes to the log. This means we no longer need a tee on each command, and we are less likely to miss it off future additions.

Also
- Change the date format to be more filename friendly (no spaces and no colons)
- Remove *.whl from .dockerignore, because they are used in the docker build
- Add *.log to .dockerignore