### PR TITLE
Remove bumping of oneDNN and ACL

### DIFF
--- a/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
@@ -8,20 +8,15 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [Unreleased]
 
 ### Added
-- TensorFlow patch bumping to ComputeLibrary 24.12 and oneDNN 3.7-rc
 
 ### Changed
-- Updated ComputeLibrary to 0038c52 (Jan 6, 2025)
-- Updated oneDNN to d4b61e9 (Jan 14, 2025)
 - Updated TensorFlow to 2.20.dev-6506da6
 
 ### Removed
 - Removed MLCommons examples and patches
 - Removed cpp examples
 - Removed all inline patches, work in progress features should now be applied
-  from PRs using wget. Removed patches have been merged upstream (and now picked
-  up by new versions of software components) or are now included via wget in
-  `./get-source.sh`
+  from PRs using wget in `./get-source.sh`.
 
 ### Fixed
 

--- a/ML-Frameworks/tensorflow-aarch64/get-source.sh
+++ b/ML-Frameworks/tensorflow-aarch64/get-source.sh
@@ -22,52 +22,54 @@ source ../utils/git-utils.sh
 set -eux -o pipefail
 
 TENSORFLOW_HASH=6506da61ed123658ddca003774a5f2eb430c3cad   # Nightly Feb 11, 2025
-ONEDNN_HASH=d4b61e983b456f69cced71d8296bd2b2de5fabf4    # main Jan 14, 2025
-ACL_HASH=0038c52d6c79b76755c087cda1be4bbf752e272c       # main Jan 6, 2025 (Commit after introduces KleidiAI as third-party module in Bazel build, dependency missing in TensorFlow)
+# ONEDNN_HASH=
+# ACL_HASH=
 
 git-shallow-clone https://github.com/tensorflow/tensorflow.git $TENSORFLOW_HASH
-(
-    cd tensorflow
 
-    # TensorFlow patches
-    apply-github-patch https://github.com/tensorflow/tensorflow 84975 01c30f3277c2b943ebc61a0b23ab402d48b3e1d2 # build(aarch64): Update to oneDNN-3.7 + ACL-24.12
+# Below code is used to build with customized commits of oneDNN and ACL with WIP patches applied,
+# please set ONEDNN_HASH and ACL_HASH above when uncommenting.
+# (
+#     cd tensorflow
 
-    cd tensorflow
+#     # Apply TensorFlow WIP patches here
 
-    # Set up workspace to point to local versions of Compute Library and oneDNN
-    # Rename existing tf_http_archives
-    sed -i -e 's/\"mkl_dnn_acl_compatible\"/\"mkl_dnn_acl_compatible_backup\"/g' workspace2.bzl
-    sed -i -e 's/\"compute_library\"/\"compute_library_backup\"/g' workspace2.bzl
-    # Insert a new_local_repository for oneDNN and ACL in place of the http_archives
-    csplit -f workspace2.bzl. -n 1 workspace2.bzl /'def _tf_repositories():'/+2 '{0}'
-    onednn_acl_local_repositories=$'
-    native.new_local_repository(
-        name = "mkl_dnn_acl_compatible",
-        build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
-        path = \'./third_party/mkl_dnn/oneDNN\'
-    )
-    native.local_repository(
-        name = "compute_library",
-        path = \'./third_party/compute_library/ComputeLibrary\'
-    )'
-    echo "$onednn_acl_local_repositories" > tensorflow_local-repositories.txt
-    cat workspace2.bzl.0 tensorflow_local-repositories.txt workspace2.bzl.1 > workspace2.bzl
-    cd ..
+#     cd tensorflow
 
-    # oneDNN patches
-    (
-        cd third_party/mkl_dnn
-        git-shallow-clone https://github.com/oneapi-src/oneDNN.git $ONEDNN_HASH
+#     # Set up workspace to point to local versions of Compute Library and oneDNN
+#     # Rename existing tf_http_archives
+#     sed -i -e 's/\"mkl_dnn_acl_compatible\"/\"mkl_dnn_acl_compatible_backup\"/g' workspace2.bzl
+#     sed -i -e 's/\"compute_library\"/\"compute_library_backup\"/g' workspace2.bzl
+#     # Insert a new_local_repository for oneDNN and ACL in place of the http_archives
+#     csplit -f workspace2.bzl. -n 1 workspace2.bzl /'def _tf_repositories():'/+2 '{0}'
+#     onednn_acl_local_repositories=$'
+#     native.new_local_repository(
+#         name = "mkl_dnn_acl_compatible",
+#         build_file = "//third_party/mkl_dnn:mkldnn_acl.BUILD",
+#         path = \'./third_party/mkl_dnn/oneDNN\'
+#     )
+#     native.local_repository(
+#         name = "compute_library",
+#         path = \'./third_party/compute_library/ComputeLibrary\'
+#     )'
+#     echo "$onednn_acl_local_repositories" > tensorflow_local-repositories.txt
+#     cat workspace2.bzl.0 tensorflow_local-repositories.txt workspace2.bzl.1 > workspace2.bzl
+#     cd ..
 
-        # Apply WIP patches
-    )
+#     # oneDNN patches
+#     (
+#         cd third_party/mkl_dnn
+#         git-shallow-clone https://github.com/oneapi-src/oneDNN.git $ONEDNN_HASH
 
-    # ACL patches
-    (
-        cd third_party/compute_library
-        git-shallow-clone https://review.mlplatform.org/ml/ComputeLibrary $ACL_HASH
+#         # Apply WIP patches here
+#     )
 
-        # Apply WIP patches
-    )
+#     # ACL patches
+#     (
+#         cd third_party/compute_library
+#         git-shallow-clone https://review.mlplatform.org/ml/ComputeLibrary $ACL_HASH
 
-)
+#         # Apply WIP patches here
+#     )
+
+# )


### PR DESCRIPTION
Bumping to oneDNN 3.7 and ACL 24.12 currently causes issues in examples when running with bf16. Revert to building Tensorflow with same versions as upstream, applying in-tree patches.