### PR TITLE
Updates for r25.03

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -8,14 +8,23 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [unreleased]
 
 ### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+## [r25.03] 2025-03-14
+https://github.com/ARM-software/Tool-Solutions/tree/r25.03
+
+### Added
 - Adds work-in-progress PyTorch PRs:
   - https://github.com/pytorch/pytorch/pull/148542 - Enables direct use Compute Library in ATen
   - https://github.com/pytorch/pytorch/pull/147337 - Enables a fast path for static qlinear via Compute Library directly
   - https://github.com/pytorch/pytorch/pull/146620 - Enables qint8 and quint8 add via Compute Library directly. Speedup for OMP_NUM_THREADS=1 is ~15x, and ~5.4x for 32 threads.
   - https://github.com/pytorch/pytorch/pull/148197 - Enables oneDNN dispatch for GEMM bf16bf16->bf16
   - https://github.com/pytorch/pytorch/pull/140159 - Enables gemm-bf16f32
-- Adds work-in-progress OpenBLAS PRs:
-  - https://github.com/OpenMathLib/OpenBLAS/pull/5157 - adds optimized gemv_n_sve kernel.
 
 ### Changed
 - Updates hashes for:
@@ -23,11 +32,12 @@ where `YY` is the year, and `MM` the month of the increment.
   - ideep to 719d8e6  from ideep_pytorch branch.
   - oneDNN to 321c452 from main branch.
   - Compute Library to v25.02.1.
-  - OpenBLAS to e4630ed from main.
+  - OpenBLAS to ef9e3f7 from main.
 - Updates work-in-progress PyTorch PRs.
 - Updates torchaudio to 2.6.0.dev20250305.
 - Updates torchvision to 0.22.0.dev20250305.
 - Dockerfile now upgrades pip before installing Python packages.
+- git-shallow-clone function now supports cloning by tag as well as hash.
 
 ### Removed
 - Removes patches which have now been merged into the upstream branches.

--- a/ML-Frameworks/pytorch-aarch64/utils/build_openblas.sh
+++ b/ML-Frameworks/pytorch-aarch64/utils/build_openblas.sh
@@ -25,13 +25,11 @@
 source /common_utils/git-utils.sh
 
 set -ex
-OPENBLAS_HASH="e4630ed15a8c52f780d9b3f9fb4ac2168c60f830"
+OPENBLAS_HASH="ef9e3f71595edfc69aadeb34d99a96d5f72a29a2"
 OPENBLAS_CHECKOUT_DIR="OpenBLAS"
 
 cd /
 git-shallow-clone https://github.com/OpenMathLib/OpenBLAS.git $OPENBLAS_HASH
-
-apply-github-patch https://github.com/OpenMathLib/OpenBLAS/ 5157 5c4e38ab17eb530e950e68e1d45ea7a2fcd25cea # Optimize gemv_n_sve kernel
 
 OPENBLAS_BUILD_FLAGS="
 NUM_THREADS=128

--- a/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
@@ -5,7 +5,18 @@ docker/tensorflow-aarch64 will be noted in this log.
 Monthly increments are tagged `tensorflow-pytorch-aarch64--rYY.MM`,
 where `YY` is the year, and `MM` the month of the increment.
 
-## [Unreleased]
+## [unreleased]
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+
+## [r25.03] 2025-03-14
+https://github.com/ARM-software/Tool-Solutions/tree/r25.03
 
 ### Added
 

--- a/ML-Frameworks/utils/git-utils.sh
+++ b/ML-Frameworks/utils/git-utils.sh
@@ -27,7 +27,7 @@ function git-shallow-clone {
             git init
             git remote add origin $1
         fi
-        git fetch --recurse-submodules=no origin $2
+        git fetch --tags --recurse-submodules=no origin $2
         # We do a force checkout + clean to overwrite previous patches
         git checkout -f $2
         git clean -fd


### PR DESCRIPTION
- Updates CHANGELOG.mds.
- Rolls back OpenBLAS version and adds support for cloning tags. Build failures in bgemv_t_bfdot observed with GCC11. OpenBLAS hash rolled back to before bgemv_t_bfdot was added.
- Adds `--tags` flag to shallow clone function.