### PR TITLE
Fix broken links and incorrect docs

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/README.md
+++ b/ML-Frameworks/pytorch-aarch64/README.md
@@ -11,7 +11,7 @@
 > Release versions of PyTorch are available from: https://pypi.org/project/torch/
 
 ## Getting started
-This [component](https://github.com/ARM-software/Tool-Solutions/tree/master/docker/pytorch-aarch64) of [ARM-Software's](https://github.com/ARM-software) [Tool Solutions](https://github.com/ARM-software/Tool-Solutions) repository provides scripts to build a wheel and a Docker image containing [PyTorch](https://www.pytorch.org/) and dependencies for the [Armv8-A architecture](https://developer.arm.com/architectures/cpu-architecture/a-profile), as well as a selection of [examples and benchmarks](./examples/README.md).
+This [component](https://github.com/ARM-software/Tool-Solutions/tree/main/ML-Frameworks/pytorch-aarch64) of [ARM-Software's](https://github.com/ARM-software) [Tool Solutions](https://github.com/ARM-software/Tool-Solutions) repository provides scripts to build a wheel and a Docker image containing [PyTorch](https://www.pytorch.org/) and dependencies for the [Armv8-A architecture](https://developer.arm.com/architectures/cpu-architecture/a-profile), as well as a selection of [examples and benchmarks](./examples/README.md).
 
 Use the `./build.sh` script to build the wheel, which will be placed in the `results/` directory.
 

--- a/ML-Frameworks/tensorflow-aarch64/README.md
+++ b/ML-Frameworks/tensorflow-aarch64/README.md
@@ -75,8 +75,8 @@ That means we use commits off the following branches:
 - TensorFlow: nightly, which is the most recent main that passes the
   nightlies. We don't use main because there's no point us having to deal with
   already known issues.
-- oneDNN: 3.7-rc.
-- ComputeLibrary: 24.12.
+- oneDNN: 3.2.1.
+- ComputeLibrary: 23.05.1.
 
 Each commit of `tensorflow-aarch64` is a fixed reference point, both for
 benchmarking and bug fixes.

--- a/ML-Frameworks/tensorflow-aarch64/examples/README.md
+++ b/ML-Frameworks/tensorflow-aarch64/examples/README.md
@@ -30,7 +30,7 @@ By default, the model will be optimized for inference before the classification 
 
 ### Object Detection
 
-The script [detect_objects.py](detect_object.py) demonstrates how to run inference using SSD-ResNet-34 model trained from the Common Object in Context (COCO) image dataset. This is a multiscale SSD (Single Shot Detection) model based on the ResNet-34 backbone network that performs object detection.
+The script [detect_objects.py](detect_objects.py) demonstrates how to run inference using SSD-ResNet-34 model trained from the Common Object in Context (COCO) image dataset. This is a multiscale SSD (Single Shot Detection) model based on the ResNet-34 backbone network that performs object detection.
 
 To run inference on example image call:
 


### PR DESCRIPTION
Fix broken links and incorrect versions for ACL and oneDNN for TensorFlow in README.