### PR TITLE
fix: typo in stdout to stderr redirection

### DIFF
--- a/ML-Frameworks/tensorflow-aarch64/build.sh
+++ b/ML-Frameworks/tensorflow-aarch64/build.sh
@@ -28,8 +28,8 @@ if [ -d tensorflow ] ; then
     echo "You appear to have sources already" \
 
     if ! ([[ $* == *--force* ]] || [[ $* == *--use-existing-sources* ]]) ; then
-        >2& echo "rerun with --force to overwrite sources or with" \
-                 "--use-existing-sources to build your existing sources."
+        echo "rerun with --force to overwrite sources or with" \
+                 "--use-existing-sources to build your existing sources." 1>&2
         exit 1
     fi
 fi


### PR DESCRIPTION
Fixes a typo. Right now we create an empty file called `2` instead of redirecting `echo` to `stderr`.