### PR TITLE
Revert "Removes compile option from genai PyTorch examples"

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/examples/README.md
+++ b/ML-Frameworks/pytorch-aarch64/examples/README.md
@@ -201,7 +201,7 @@ The script [torchchat_llm_text_gen.py](torchchat_llm_text_gen.py) demonstrates h
 To run infernece using torchchat call:
 
 ```
-LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libtcmalloc.so.4  TORCHINDUCTOR_CPP_WRAPPER=1  TORCHINDUCTOR_FREEZING=1  OMP_NUM_THREADS=16 python torchchat_llm_text_gen.py
+LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libtcmalloc.so.4  TORCHINDUCTOR_CPP_WRAPPER=1  TORCHINDUCTOR_FREEZING=1  OMP_NUM_THREADS=16 python torchchat_llm_text_gen.py --compile
 ```
 
 #### Command-Line Options
@@ -211,6 +211,9 @@ LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libtcmalloc.so.4  TORCHINDUCTOR_CPP_WRAPPE
 
 `--max-new-tokens`
   Description: Max new tokens to generate.
+
+`--compile`
+  Description: Whether to compile the model (default: `False`).
 
 `--model`
   Description: Model alias. (Default: `"llama2"`  )
@@ -224,7 +227,7 @@ The script [transformers_llm_text_gen.py](transformers_llm_text_gen.py) demonstr
 To run infernece using torchchat call:
 
 ```
-LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libtcmalloc.so.4  TORCHINDUCTOR_CPP_WRAPPER=1  TORCHINDUCTOR_FREEZING=1  OMP_NUM_THREADS=16 python transformers_llm_text_gen.py
+LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libtcmalloc.so.4  TORCHINDUCTOR_CPP_WRAPPER=1  TORCHINDUCTOR_FREEZING=1  OMP_NUM_THREADS=16 python transformers_llm_text_gen.py --compile
 ```
 
 #### Command-Line Options
@@ -234,6 +237,9 @@ LD_PRELOAD=/usr/lib/aarch64-linux-gnu/libtcmalloc.so.4  TORCHINDUCTOR_CPP_WRAPPE
 
 `--max-new-tokens`
   Description: Max new tokens to generate.
+
+`--compile`
+  Description: Whether to compile the model (default: `False`).
 
 `--model`
   Description: Local Path to model repo or huggingface model id. (Default: `"meta-llama/Llama-2-7b-hf"`  )

--- a/ML-Frameworks/pytorch-aarch64/examples/torchchat_llm_text_gen.py
+++ b/ML-Frameworks/pytorch-aarch64/examples/torchchat_llm_text_gen.py
@@ -31,6 +31,8 @@ def main(args):
         "python3", torchchat_path, "generate", args.model,
         "--quantize", str(args.quant_config),
         "--prompt", prompt,
+        "--compile" if args.compile else "",
+        "--compile-prefill" if args.compile else "",
         "--max-autotune", "--max-new-tokens", str(args.max_new_tokens)
     ]
     command = [arg for arg in command if arg]
@@ -45,6 +47,8 @@ if __name__ == '__main__':
                         help='Path to json file for quantization config')
     parser.add_argument('--max-new-tokens', type=int,
                         default=64, help='New tokens to generate at decode.')
+    parser.add_argument('--compile', action='store_true',
+                        help='Whether to compile the model.')
     parser.add_argument('--model', type=str, default="llama2",
                         help='Torchchat supported model alias')
     parser.add_argument('--prompt', type=str, default="In a distant world where magic and technology coexist, "


### PR DESCRIPTION
This reverts commit 65dbd3bea401fc6cb170a937581427eaee3be086. The issue has been fixed upstream and is no longer present in the bumped version