### PR TITLE
Add patch cache to github-apply-patch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ __pycache__/
 build*.log
 *.pb
 *.zip
+
+patch_cache/

--- a/ML-Frameworks/pytorch-aarch64/README.md
+++ b/ML-Frameworks/pytorch-aarch64/README.md
@@ -58,6 +58,12 @@ Note: if the environment variable `GITHUB_TOKEN` is set then the build will
 attemmpt to use `GITHUB_TOKEN` for authenticated access when downloading WIP patches.
 This can avoid issues with rate-limiting on annonymous access.
 
+Note: GitHub patches are cached in `utils/patch_cache` to save network
+traffic. This also allows you to use local patches that are not yet upstream by
+adding your patch to `utils/patch_cache` with the name
+`<your commit hash>.patch`. Then use `github-apply-patch` as usual in
+`get-source.sh`.
+
 ### Flags useful for development
 - `--use-existing-sources` skips `get-source.sh` and just builds
 - `--force` overwrites sources

--- a/ML-Frameworks/tensorflow-aarch64/README.md
+++ b/ML-Frameworks/tensorflow-aarch64/README.md
@@ -58,6 +58,12 @@ Note: if the environment variable `GITHUB_TOKEN` is set then the build will
 attemmpt to use `GITHUB_TOKEN` for authenticated access when downloading WIP patches.
 This can avoid issues with rate-limiting on annonymous access.
 
+Note: GitHub patches are cached in `utils/patch_cache` to save network
+traffic. This also allows you to use local patches that are not yet upstream by
+adding your patch to `utils/patch_cache` with the name
+`<your commit hash>.patch`. Then use `github-apply-patch` as usual in
+`get-source.sh`.
+
 ## Motivation
 TensorFlow + oneDNN + ComputeLibrary is a deep stack. The purpose of
 `tensorflow-aarch64` is to let us see the future of that stack, so that we can:


### PR DESCRIPTION
GitHub patches are cached in `utils/patch_cache` to save network traffic. This also allows you to use local patches that are not yet upstream by adding your patch to `utils/patch_cache` with the name `<your commit hash>.patch`. Then use `github-apply-patch` as usual in `get-source.sh`.