### PR TITLE
Update CHANGELOGs for 25.06 release.

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -15,7 +15,27 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Fixed
 
-### [r25.04] 2025-05-16
+## [r25.06] 2025-06-20
+https://github.com/ARM-software/Tool-Solutions/tree/r25.06
+
+### Added
+ - Adds WIP patch to update the OpenBLAS commit - https://github.com/pytorch/pytorch/pull/151547.
+   - Speedups across most of the HF models via significant boost to SDPA layers.
+   - Overall torchbench pass-rate increased.
+ - Adds support in `github-apply-patch` for local caching of patches.
+
+### Changed
+ - Updates protobuf from 5.29.2 to 5.29.5 in response to CVE-2025-4565.
+ - Updates hashes for:
+   - PyTorch to 3040ca6d0f8558e39919b14eebeacc34ddf980f5 2.8.0.dev20250611 from viable/strict.
+   - ideep to 2ef932a861439e4cc9bb8baee8424b57573de023 from ideep_pytorch, June 10.
+   - oneDNN to 106a7b41bc4156297b8a88cd1951304b739cc427 from main, June 10th.
+   - Compute Library to 6bc1c7b8d0756272e2a97a7489e13de90f864326 from main, June 9th.
+
+### Removed
+ - Removes patches which are no longer required.
+
+## [r25.05] 2025-05-16
 https://github.com/ARM-software/Tool-Solutions/tree/r25.05
 
 ### Added

--- a/ML-Frameworks/pytorch-aarch64/get-source.sh
+++ b/ML-Frameworks/pytorch-aarch64/get-source.sh
@@ -20,10 +20,10 @@
 source ../utils/git-utils.sh
 
 set -eux -o pipefail
-PYTORCH_HASH=3040ca6d0f8558e39919b14eebeacc34ddf980f5   # main June 10th
-IDEEP_HASH=2ef932a861439e4cc9bb8baee8424b57573de023     # main June 10th
-ONEDNN_HASH=106a7b41bc4156297b8a88cd1951304b739cc427    # main June 10th
-ACL_HASH=6bc1c7b8d0756272e2a97a7489e13de90f864326       # main June 9th
+PYTORCH_HASH=3040ca6d0f8558e39919b14eebeacc34ddf980f5   # 2.8.0.dev20250611 from viable/strict
+IDEEP_HASH=2ef932a861439e4cc9bb8baee8424b57573de023     # from ideep_pytorch, June 10th
+ONEDNN_HASH=106a7b41bc4156297b8a88cd1951304b739cc427    # from main, June 10th
+ACL_HASH=6bc1c7b8d0756272e2a97a7489e13de90f864326       # from main, June 9th
 TORCH_AO_HASH=e1cb44ab84eee0a3573bb161d65c18661dc4a307 # From main
 
 git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH

--- a/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
@@ -15,7 +15,19 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Fixed
 
-#### [r25.04] 2025-05-16
+## [r25.06] 2025-06-20
+https://github.com/ARM-software/Tool-Solutions/tree/r25.06
+
+### Added
+ - Adds support in `github-apply-patch` for local caching of patches.
+ - Adds WIP patch: https://github.com/tensorflow/tensorflow/pull/93951
+   to update to oneDNN-3.7 + ACL-24.12, and address unit test failures
+
+### Changed
+ - Updates TensorFlow hash to 65781570c55d2338106767de200323f123c3f91f
+   tensorflow-2.20.0.dev0 from main
+
+## [r25.05] 2025-05-16
 https://github.com/ARM-software/Tool-Solutions/tree/r25.05
 
 ### Added

--- a/ML-Frameworks/tensorflow-aarch64/get-source.sh
+++ b/ML-Frameworks/tensorflow-aarch64/get-source.sh
@@ -23,14 +23,6 @@ set -eux -o pipefail
 
 TENSORFLOW_HASH=65781570c55d2338106767de200323f123c3f91f
 
-# The next oneDNN commits relocate xbyak_aarch64 as a third_party module,
-# but this is not picked up by TF Bazel build.
-ONEDNN_HASH=ad06da68524b2b5e63fc1d7a7a749d555394a0a7       # main Jan 03, 2025
- 
-# The next ACL commit introduces KleidiAI as a third-party module,
-# but this is not picked up by TF Bazel build.
-ACL_HASH=0038c52d6c79b76755c087cda1be4bbf752e272c          # main Jan 6, 2025
-
 git-shallow-clone https://github.com/tensorflow/tensorflow.git $TENSORFLOW_HASH
 
 (
@@ -38,6 +30,7 @@ git-shallow-clone https://github.com/tensorflow/tensorflow.git $TENSORFLOW_HASH
 
     # Apply TensorFlow WIP patches here
 
-    apply-github-patch tensorflow/tensorflow 6eb08485a6312a02636f79d8eddf00a549e32aca # build(aarch64): Update to oneDNN-3.7 + ACL-24.12 (fix)
+    # https://github.com/tensorflow/tensorflow/pull/93951 - build(aarch64): Update to oneDNN-3.7 + ACL-24.12 (fix)
+    apply-github-patch tensorflow/tensorflow 6eb08485a6312a02636f79d8eddf00a549e32aca
 
 )


### PR DESCRIPTION
Also tidies up some comments in get-source.sh files and removes superfluous lines.