### PR TITLE
Update ComputeLibrary info in `get-source.sh`

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -10,8 +10,10 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 
 ### Changed
+- Updates ACL URL from [ML Platform](https://review.mlplatform.org/ml/ComputeLibrary) to [GitHub](https://github.com/ARM-software/ComputeLibrary.git).
 
 ### Removed
+- Removes WIP ComputeLibrary patch https://review.mlplatform.org/c/ml/ComputeLibrary/+/12818/1.
 
 ### Fixed
 

--- a/ML-Frameworks/pytorch-aarch64/get-source.sh
+++ b/ML-Frameworks/pytorch-aarch64/get-source.sh
@@ -94,11 +94,6 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
 
 )
 
-git-shallow-clone https://review.mlplatform.org/ml/ComputeLibrary $ACL_HASH
-(
-    cd ComputeLibrary
-    # Improve gemm_interleaved 2D vs 1D blocking heuristic
-    apply-gerrit-patch https://review.mlplatform.org/c/ml/ComputeLibrary/+/12818/1
-)
+git-shallow-clone https://github.com/ARM-software/ComputeLibrary.git $ACL_HASH
 
 git-shallow-clone https://github.com/pytorch/ao.git $TORCH_AO_HASH

--- a/ML-Frameworks/utils/git-utils.sh
+++ b/ML-Frameworks/utils/git-utils.sh
@@ -65,16 +65,6 @@ function apply-github-patch {
     return 0
 }
 
-function apply-gerrit-patch {
-    # $1 must be the url to a specific patch set
-    # We get the repo by removing /c and chopping off the change number
-    # e.g. https://review.mlplatform.org/c/ml/ComputeLibrary/+/12818/1 -> https://review.mlplatform.org/ml/ComputeLibrary/
-    local repo_url=$(echo "$1" | sed 's#/c/#/#' | cut -d'+' -f1)
-    # e.g. refs/changes/18/12818/1 Note that where the middle number is the last 2 digits of the patch number
-    local refname=$(echo "$1" | awk -F'/' '{print "refs/changes/" substr($(NF-1),length($(NF-1))-1,2) "/" $(NF-1) "/" $(NF)}')
-    git fetch $repo_url $refname && git cherry-pick --no-commit FETCH_HEAD
-}
-
 function setup_submodule() {
     local original_dir=$(pwd)
     rm -rf "$2"


### PR DESCRIPTION
- Switched from ML Platform to GitHub
- Remove Fadi's patch; had confirmation that it can be dropped