### PR TITLE
Make `build.sh` wipe old artefacts with `--fresh`

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -19,6 +19,7 @@ where `YY` is the year, and `MM` the month of the increment.
   - TORCH_AO_HASH to 8e2ca35ea603349e71c2467e10fd371e34bf52bc, from main, September 23rd.
   - KLEIDIAI_HASH to bd2e6ae060014035e25bf4986be682762c446c2d, v1.14 from main.
 - Update torchvision from 0.23.0 to a nightly build, 0.25.0.dev20250923
+- Change of flag name in `./build.sh` from `--force` to `--fresh`
 
 ### Removed
 - Removes WIP ComputeLibrary patch https://review.mlplatform.org/c/ml/ComputeLibrary/+/12818/1.

--- a/ML-Frameworks/pytorch-aarch64/build.sh
+++ b/ML-Frameworks/pytorch-aarch64/build.sh
@@ -24,13 +24,32 @@ build_log=build-$(git rev-parse --short=7 HEAD)-$(date '+%Y-%m-%dT%H-%M-%S').log
 exec &> >(tee -a $build_log)
 
 # Bail out if sources are already there
-if [ -d pytorch ] || [ -d builder ] || [ -d ComputeLibrary ] ; then
-    echo "You appear to have sources already (pytorch/builder/ComputeLibrary)" \
+if [ -f .torch_build_container_id ] || [ -f .torch_ao_build_container_id ] || \
+    [ -d ao ] || [ -d ComputeLibrary ] || [ -d pytorch ]; then
+    printf "\n\n%s\n%s\n%s\n%s\n%s\n%s\n%s\n\n\n" \
+        "You appear to have artefacts from a previous build lying around." \
+        "Check for any of the following:" \
+        "  - .torch_build_container_id" \
+        "  - .torch_ao_build_container_id" \
+        "  - ao" \
+        "  - ComputeLibrary" \
+        "  - pytorch"
 
-    if ! ([[ $* == *--force* ]] || [[ $* == *--use-existing-sources* ]]) ; then
-        >&2 echo "rerun with --force to overwrite sources or with" \
-                 "--use-existing-sources to build your existing sources."
+    if [[ "$*" != *--fresh* ]] && [[ "$*" != *--use-existing-sources* ]]; then
+        >&2 printf "\n\n%s\n%s\n%s\n\n\n" \
+            "Rerun with one of the following options:" \
+            "  - '--fresh': wipe the pre-existing sources and do a fresh build" \
+            "  - '--use-existing-sources': reuse the sources as is"
         exit 1
+    fi
+
+    # Wipe old build artefacts
+    if [[ $* == *--fresh* ]]; then
+        if [ -f .torch_build_container_id ]; then rm -f .torch_build_container_id; fi
+        if [ -f .torch_ao_build_container_id ]; then rm -f .torch_ao_build_container_id; fi
+        if [ -d ao ]; then rm -rf ao; fi
+        if [ -d ComputeLibrary ]; then rm -rf ComputeLibrary; fi
+        if [ -d pytorch ]; then rm -rf pytorch; fi
     fi
 fi
 


### PR DESCRIPTION
If `--force` is used, it may not overwrite the sources. With this change, we'll clean up before getting the sources again and rebuilding afresh (hence the flag name change `--force` --> `--fresh`). 

We could use `git clean -xdff .` to avoid hardcoding specific files/directories but it might wipe scripts that the user has been developing. It's therefore safer to use this approach.