### PR TITLE
Add SECURITY.md to image

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -8,6 +8,7 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [unreleased]
 
 ### Added
+- Adds `SECURITY.md` to built image.
 
 ### Changed
 - Updates ACL URL from [ML Platform](https://review.mlplatform.org/ml/ComputeLibrary) to [GitHub](https://github.com/ARM-software/ComputeLibrary.git).
@@ -18,9 +19,10 @@ where `YY` is the year, and `MM` the month of the increment.
   - ACL_HASH to 531a4968cecb7b4fc0a3b65482e2c524289e087e, from main, September 23rd.
   - TORCH_AO_HASH to 8e2ca35ea603349e71c2467e10fd371e34bf52bc, from main, September 23rd.
   - KLEIDIAI_HASH to bd2e6ae060014035e25bf4986be682762c446c2d, v1.14 from main.
-- Update torchvision from 0.23.0 to a nightly build, 0.25.0.dev20250923
+- Update torchvision from 0.23.0 to a nightly build, 0.25.0.dev20250923.
 - Change of flag name in `./build.sh` from `--force` to `--fresh`
 - Add `intx_packing_format="opaque_aten_kleidiai"` to `Int8DynamicActivationIntxWeightConfig` due to torchao API change
+- Updates `dockerize.sh` build to use BuildKit (to add extra build contexts).
 
 ### Removed
 - Removes WIP ComputeLibrary patch https://review.mlplatform.org/c/ml/ComputeLibrary/+/12818/1.

--- a/ML-Frameworks/pytorch-aarch64/Dockerfile
+++ b/ML-Frameworks/pytorch-aarch64/Dockerfile
@@ -57,9 +57,12 @@ COPY bash_profile /home/$DOCKER_USER/.bash_profile
 RUN chown $DOCKER_USER:$DOCKER_USER /home/$DOCKER_USER/.bash_profile
 
 # Add welcome message to warn about dev quality
-COPY welcome.txt /home/$DOCKER_USER/.
+COPY welcome.txt /home/$DOCKER_USER/
 RUN echo '[ ! -z "$TERM" -a -r /home/$DOCKER_USER/welcome.txt ] && cat /home/$DOCKER_USER/welcome.txt' >> /etc/bash.bashrc
 RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >>  /etc/bash.bashrc
+
+# Grab the SECURITY.md from the root directory
+COPY --from=rootdir SECURITY.md /home/$DOCKER_USER/
 
 # Move to userland
 WORKDIR /home/$DOCKER_USER

--- a/ML-Frameworks/pytorch-aarch64/dockerize.sh
+++ b/ML-Frameworks/pytorch-aarch64/dockerize.sh
@@ -35,9 +35,12 @@ if ! [ -e "$1" ] || ! [ -e "$2" ]; then
     exit 1
 fi
 
-docker build -t toolsolutions-pytorch:latest  \
-    --build-arg TORCH_WHEEL=$1 \
+docker buildx \
+    build --load \
+    -t toolsolutions-pytorch:latest  \
+    --build-context rootdir=../.. \
     --build-arg DOCKER_IMAGE_MIRROR \
+    --build-arg TORCH_WHEEL=$1 \
     --build-arg TORCH_AO_WHEEL=$2 \
     --build-arg USERNAME=ubuntu \
     .

--- a/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
@@ -9,9 +9,11 @@ where `YY` is the year, and `MM` the month of the increment.
 
 ### Added
  - Adds WIP patch to upgrade Compute Library to 52.4.0
+ - Adds `SECURITY.md` to built image
 
 ### Changed
  - Updates TensorFLow hash to 6aa8fd07270293b918255af5988aef45b844c5b4 # from nightly, September 22nd
+ - Updates `dockerize.sh` build to use BuildKit (to add extra build contexts)
 
 ### Removed
  - Removed previous patch updating oneDNN and Compute Library that has been merged upstream

--- a/ML-Frameworks/tensorflow-aarch64/Dockerfile
+++ b/ML-Frameworks/tensorflow-aarch64/Dockerfile
@@ -57,6 +57,9 @@ COPY welcome.txt /home/$DOCKER_USER/.
 RUN echo '[ ! -z "$TERM" -a -r /home/$DOCKER_USER/welcome.txt ] && cat /home/$DOCKER_USER/welcome.txt' >> /etc/bash.bashrc
 RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >>  /etc/bash.bashrc
 
+# Grab the SECURITY.md from the root directory
+COPY --from=rootdir SECURITY.md /home/$DOCKER_USER/
+
 # Move to userland
 WORKDIR /home/$DOCKER_USER
 USER $DOCKER_USER

--- a/ML-Frameworks/tensorflow-aarch64/dockerize.sh
+++ b/ML-Frameworks/tensorflow-aarch64/dockerize.sh
@@ -32,7 +32,12 @@ if ! [ -e "$1" ]; then
     exit 1
 fi
 
-docker build -t toolsolutions-tensorflow:latest  \
+docker buildx \
+    build --load \
+    -t toolsolutions-tensorflow:latest  \
+    --build-context rootdir=../.. \
     --build-arg TENSORFLOW_WHEEL=$1 \
     .
+
+[[ $* == *--build-only* ]] && exit 0
 docker run --rm -it toolsolutions-tensorflow:latest


### PR DESCRIPTION
Same as https://github.com/ARM-software/Tool-Solutions/pull/371 (other was accidentally closed by a branch name change).

Changed approach to use BuildKit (built into Docker since v23.0 in 2023; GitHub CI uses v28 for reference) with [`docker buildx`](https://docs.docker.com/reference/cli/docker/buildx/) which allows us to add another [build context](https://docs.docker.com/reference/cli/docker/buildx/build/#build-context) (i.e. the root directory) to grab the `SECURITY.md` from. 

**Notes:** 
- `docker buildx build --load` relies on the output being a single-platform image
- `--load` will automatically load the single-platform build result to `docker images`