### PR TITLE
Prune setuptools from PyTorch Docker image.

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/Dockerfile
+++ b/ML-Frameworks/pytorch-aarch64/Dockerfile
@@ -64,15 +64,28 @@ RUN echo 'export PATH="$HOME/.local/bin:$PATH"' >>  /etc/bash.bashrc
 # Grab the SECURITY.md from the root directory
 COPY --from=rootdir SECURITY.md /home/$DOCKER_USER/
 
+# Update to newer pip/setuptools/wheel (setuptools >= 70.0.0 due to CVE-2024-6345
+# and CVE-2025-47273, wheel >= 0.38.0 due to CVE-2022-40898) and delete old system
+# version (we essentially use apt:python3-pip to bootstrap pip)
+RUN pip install --upgrade pip~=25.2 setuptools~=78.1.1 wheel~=0.45.1
+
+# Remove system Python stuff. Should be safe to wipe after the line above, because
+# python3 -m pip now uses the /usr/local install
+RUN apt-get update && apt-get purge -y \
+      python3-pip \
+      python3-setuptools \
+      python3-pkg-resources \
+      python3-wheel \
+      python3-distutils \
+      python3-lib2to3 \
+      python3-dev \
+      python3.10-dev \
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/*
+
 # Move to userland
 WORKDIR /home/$DOCKER_USER
 USER $DOCKER_USER
-
-# Update to newer pip/setuptools/wheel (setuptools>= 70.0.0 due to CVE-2024-6345
-# and CVE-2025-47273, wheel >= 0.38.0 due to CVE-2022-40898) and delete old system
-# version (we essentially use apt:python3-pip to bootstrap pip)
-RUN pip install --upgrade pip~=25.2 setuptools~=78.1.1 wheel~=0.45.1 \
-    && sudo rm -r /usr/lib/python3/dist-packages/
 
 # Base requirements for examples, excluding torch and torch*
 COPY requirements.txt ./


### PR DESCRIPTION
The SBOM currently contains a reference to the Debian `setuptools` package. We want to get rid of it since we'll have our own up to date version installed. @jondea did the heavy lifting trying to remove this junk but Xray wasn't happy. I think it's because `dpkg`'s registry wasn't updated to reflect the deleted files (with `sudo rm -r /usr/lib/python3/dist-packages/`).

### Before the change:

```bash
# Ask dpkg whether it has the setuptools package
aarch64_pytorch ~> dpkg -L python3-setuptools
...
/usr/lib/python3/dist-packages/setuptools
...
/usr/lib/python3/dist-packages/setuptools/command/__init__.py
...
/usr/share/doc/python3-setuptools/changelog.Debian.gz
```

(So `dpkg` still thinks it has this package.) Admittedly, after the manual wipe, we still have some files left over:

```bash 
aarch64_pytorch ~> dpkg -L python3-setuptools | xargs -r ls -1d 2>&1 | grep -v "No such file or directory"
/.
/usr
/usr/lib
/usr/lib/python3
/usr/share
/usr/share/doc
/usr/share/doc/python3-setuptools
/usr/share/doc/python3-setuptools/changelog.Debian.gz
/usr/share/doc/python3-setuptools/copyright
```

### After the change:

```bash
aarch64_pytorch ~> dpkg -L python3-setuptools
dpkg-query: package 'python3-setuptools' is not installed
Use dpkg --contents (= dpkg-deb --contents) to list archive files contents.
```

I've also requested to wipe a number of other system Python packages too.

### Do the tests still pass?

I ran `./test-examples.sh` `./run_unit_tests.sh` afterwards and they still worked. (The precommit CI should attest to that.)