### PR TITLE
Refactor GitHub workflows + add c6g testing support

### DIFF
--- a/.github/workflows/_pytorch-single-platform.yml
+++ b/.github/workflows/_pytorch-single-platform.yml
@@ -1,0 +1,111 @@
+# SPDX-FileCopyrightText: Copyright 2026 Arm Limited and affiliates.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: "PyTorch single platform build-and-test"
+
+on:
+  workflow_call:
+    inputs:
+      target_name:
+        required: true
+        type: string
+      runner_label:
+        required: true
+        type: string
+      onednn_fpmath_modes_json:
+        required: true
+        type: string
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  build-image:
+    runs-on: ${{ inputs.runner_label }}
+    env:
+      TARGET_NAME: ${{ inputs.target_name }}
+      CCACHE_LOCAL_DIR: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64/.ccache
+      TORCH_BUILD_CONTAINER_ID_FILE: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64/.torch_build_container_id
+    steps:
+      - name: Checkout Tool-Solutions
+        uses: actions/checkout@v6.0.2
+        with:
+          path: Tool-Solutions
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5.0.0
+
+      - name: Create unique cache key from the year and week (YYYY-WW)
+        id: cache_suffix
+        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
+
+      # Restore cache if available. GitHub automatically evicts cache entries that have not been
+      # accessed for over 7 days. We rotate the cache key weekly; if no cache exists for the
+      # current week, a cache from a previous week (via the prefix restore key) will be restored
+      # and then saved under the current week's key at the end of the job. This effectively limits
+      # the cache to at most two weeks of cache data.
+      - name: Restore ccache cache
+        uses: actions/cache@v5.0.3
+        with:
+          path: ${{ env.CCACHE_LOCAL_DIR }}
+          key: ccache-${{ env.TARGET_NAME }}-${{ steps.cache_suffix.outputs.week }}
+          restore-keys: |
+            ccache-${{ env.TARGET_NAME }}-
+
+      - name: Build Tool-Solutions PyTorch
+        working-directory: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64
+        run: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64/build.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CCACHE_LOCAL_DIR: ${{ env.CCACHE_LOCAL_DIR }}
+          CCACHE_MAXSIZE: 2G
+
+      - name: Print ccache disk usage
+        run: du -sh "${{ env.CCACHE_LOCAL_DIR }}" || true
+
+      - name: Report final ccache build stats
+        run: docker exec "$(cat ${{ env.TORCH_BUILD_CONTAINER_ID_FILE }})" ccache -s || true
+
+      - name: Save image as an artifact
+        run: docker save toolsolutions-pytorch:latest -o toolsolutions-pytorch-image-${{ env.TARGET_NAME }}.tar
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7.0.0
+        with:
+          name: toolsolutions-pytorch-image-${{ env.TARGET_NAME }}
+          path: toolsolutions-pytorch-image-${{ env.TARGET_NAME }}.tar
+          compression-level: 9
+          retention-days: 1
+
+  test:
+    needs: build-image
+    strategy:
+      fail-fast: false
+      matrix:
+        onednn_fpmath_mode: ${{ fromJSON(inputs.onednn_fpmath_modes_json) }}
+    runs-on: ${{ inputs.runner_label }}
+    steps:
+      - name: Download image artifact
+        uses: actions/download-artifact@v8.0.0
+        with:
+          name: toolsolutions-pytorch-image-${{ inputs.target_name }}
+          path: .
+
+      - name: Set up Docker
+        uses: docker/setup-docker-action@v5.0.0
+
+      - name: Load Docker image
+        run: docker load -i toolsolutions-pytorch-image-${{ inputs.target_name }}.tar
+
+      - name: Run smoke tests
+        run: |
+          docker run --rm \
+            -e ONEDNN_DEFAULT_FPMATH_MODE=${{ matrix.onednn_fpmath_mode }} \
+            toolsolutions-pytorch:latest ./test-examples.sh
+
+      - name: Run unit tests
+        run: |
+          docker run --rm \
+            -e ONEDNN_DEFAULT_FPMATH_MODE=${{ matrix.onednn_fpmath_mode }} \
+            toolsolutions-pytorch:latest ./run_unit_tests.sh

--- a/.github/workflows/pytorch.yml
+++ b/.github/workflows/pytorch.yml
@@ -45,102 +45,29 @@ concurrency:
 permissions: read-all
 
 jobs:
-  build-image:
-    strategy:
-      matrix:
-        config:
-          [
-            { name: c7g, label: ah-ubuntu_24_04-c7g_8x-100 },
-            { name: c8g, label: ah-ubuntu_24_04-c8g_8x }
-           ]
-    runs-on: ${{ matrix.config.label }}
-    env:
-      CCACHE_LOCAL_DIR: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64/.ccache
-      TORCH_BUILD_CONTAINER_ID_FILE: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64/.torch_build_container_id
-    steps:
-      - name: Checkout Tool-Solutions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          path: Tool-Solutions
+  run-c6g:
+    name: "c6g - build & test"
+    uses: ./.github/workflows/_pytorch-single-platform.yml
+    with:
+      target_name: c6g
+      runner_label: ah-ubuntu_22_04-c6g_8x-100
+      onednn_fpmath_modes_json: '["FP32"]'
+    secrets: inherit
 
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+  run-c7g:
+    name: "c7g - build & test"
+    uses: ./.github/workflows/_pytorch-single-platform.yml
+    with:
+      target_name: c7g
+      runner_label: ah-ubuntu_24_04-c7g_8x-100
+      onednn_fpmath_modes_json: '["FP32","BF16"]'
+    secrets: inherit
 
-      - name: Create unique cache key from the year and week (YYYY-WW)
-        id: cache_suffix
-        run: echo "week=$(date -u +%G-%V)" >> "$GITHUB_OUTPUT"
-
-      # Restore cache if available. GitHub automatically evicts cache entries that have not been
-      # accessed for over 7 days. We rotate the cache key weekly; if no cache exists for the
-      # current week, a cache from a previous week (via the prefix restore key) will be restored
-      # and then saved under the current week's key at the end of the job. This effectively limits
-      # the cache to at most two weeks of cache data.
-      - name: Restore ccache cache
-        uses: actions/cache@v5
-        with:
-          path: ${{ env.CCACHE_LOCAL_DIR }}
-          key: ccache-${{ matrix.config.name }}-${{ steps.cache_suffix.outputs.week }}
-          restore-keys: |
-            ccache-${{ matrix.config.name }}-
-
-      - name: Build Tool-Solutions PyTorch
-        working-directory: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64
-        run: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64/build.sh
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CCACHE_LOCAL_DIR: ${{ env.CCACHE_LOCAL_DIR }}
-          CCACHE_MAXSIZE: 2G
-
-      - name: Print ccache disk usage
-        run: du -sh "${{ env.CCACHE_LOCAL_DIR }}" || true
-
-      - name: Report final ccache build stats
-        run: docker exec "$(cat ${{ env.TORCH_BUILD_CONTAINER_ID_FILE }})" ccache -s || true
-
-      - name: Save image as an artifact
-        run: docker save toolsolutions-pytorch:latest -o toolsolutions-pytorch-image-${{ matrix.config.name }}.tar
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v5
-        with:
-          name: toolsolutions-pytorch-image-${{ matrix.config.name }}
-          path: toolsolutions-pytorch-image-${{ matrix.config.name }}.tar
-          compression-level: 9
-          retention-days: 1
-
-  test:
-    needs: build-image
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          [
-            { name: c7g, label: ah-ubuntu_24_04-c7g_8x-100 },
-            { name: c8g, label: ah-ubuntu_24_04-c8g_8x }
-           ]
-        onednn_fpmath_mode: [FP32, BF16]
-    runs-on: ${{ matrix.config.label }}
-    steps:
-      - name: Download image artifact
-        uses: actions/download-artifact@v5
-        with:
-          name: toolsolutions-pytorch-image-${{ matrix.config.name }}
-          path: .
-
-      - name: Set up Docker
-        uses: docker/setup-docker-action@v4
-
-      - name: Load Docker image
-        run: docker load -i toolsolutions-pytorch-image-${{ matrix.config.name }}.tar
-
-      - name: Run smoke tests
-        run: |
-          docker run --rm \
-            -e ONEDNN_DEFAULT_FPMATH_MODE=${{ matrix.onednn_fpmath_mode }} \
-            toolsolutions-pytorch:latest ./test-examples.sh
-
-      - name: Run unit tests
-        run: |
-          docker run --rm \
-            -e ONEDNN_DEFAULT_FPMATH_MODE=${{ matrix.onednn_fpmath_mode }} \
-            toolsolutions-pytorch:latest ./run_unit_tests.sh
+  run-c8g:
+    name: "c8g - build & test"
+    uses: ./.github/workflows/_pytorch-single-platform.yml
+    with:
+      target_name: c8g
+      runner_label: ah-ubuntu_24_04-c8g_8x
+      onednn_fpmath_modes_json: '["FP32","BF16"]'
+    secrets: inherit

--- a/.github/workflows/tensorflow.yml
+++ b/.github/workflows/tensorflow.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2025 Arm Limited and affiliates.
+# SPDX-FileCopyrightText: Copyright 2025, 2026 Arm Limited and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -55,12 +55,12 @@ jobs:
     runs-on: ${{ matrix.config.label }}
     steps:
       - name: Checkout Tool-Solutions
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@v6.0.2
         with:
           path: Tool-Solutions
 
       - name: Set up Docker
-        uses: docker/setup-docker-action@v4
+        uses: docker/setup-docker-action@v5.0.0
 
       - name: Build Tool-Solutions Tensorflow
         working-directory: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/tensorflow-aarch64


### PR DESCRIPTION
- Updated versions of actions we're using (e.g. upload, checkout)
- Added c6g testing for the pytorch build
- Refactored the pytorch CI so that:
   1. we can run just c6g fp32 fast math test
   2. tests can run as soon as the relevant platform build is done (e.g. c7g tests should be able to run as soon as the c7g build step is done; we don't have to wait for the build on every platform to be done first)

The refactored pipeline view should also make it much nicer to view from the Actions tab.

<div align="center">
  <img width="653" height="548" alt="github-action-display"
       src="https://github.com/user-attachments/assets/5e6a3afc-42d7-44c3-8de4-00ab2abd25fc"/>
</div>
