### PR TITLE
Add Docker-layer caching for the PyTorch build + bump PyTorch versions/clean up PRs

### DIFF
--- a/.github/workflows/_pytorch-single-platform.yml
+++ b/.github/workflows/_pytorch-single-platform.yml
@@ -26,7 +26,7 @@ jobs:
     env:
       TARGET_NAME: ${{ inputs.target_name }}
       CCACHE_LOCAL_DIR: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64/.ccache
-      TORCH_BUILD_CONTAINER_ID_FILE: ${{ github.workspace }}/Tool-Solutions/ML-Frameworks/pytorch-aarch64/.torch_build_container_id
+      BUILDER_IMAGE_NAME: local/pytorch-manylinux2_28_aarch64-builder:cpu-aarch64
     steps:
       - name: Checkout Tool-Solutions
         uses: actions/checkout@v6.0.2
@@ -65,7 +65,12 @@ jobs:
         run: du -sh "${{ env.CCACHE_LOCAL_DIR }}" || true
 
       - name: Report final ccache build stats
-        run: docker exec "$(cat ${{ env.TORCH_BUILD_CONTAINER_ID_FILE }})" ccache -s || true
+        run: |
+          docker run --rm \
+            -e CCACHE_DIR=/.ccache \
+            -v "${CCACHE_LOCAL_DIR}:/.ccache" \
+            "${BUILDER_IMAGE_NAME}" \
+            ccache -s || true
 
       - name: Save image as an artifact
         run: docker save toolsolutions-pytorch:latest -o toolsolutions-pytorch-image-${{ env.TARGET_NAME }}.tar

--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -14,7 +14,7 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [unreleased]
 
 ### Added
- - TorchAO installation via nightly AArch64 wheel in Dockerfile
+ - TorchAO installation via nightly AArch64 wheel (0.18.0.dev20260505) in Dockerfile
 
 ### Changed
  - Updates `filelock` from 3.16.1 to 3.20.3.
@@ -23,9 +23,18 @@ where `YY` is the year, and `MM` the month of the increment.
  - Updates `pytest` from 8.4.2 to 9.0.3.
  - Updates `requests` from 2.32.3 to 2.33.0.
  - Updates `urllib3` from 2.2.3 to 2.6.3.
+ - Updates the build to use Docker layer caching for PyTorch builder image.
+ - Updates hashes for:
+   - `PYTORCH_HASH=004acb4e35805062a643ee1588cdae584b2b2957`, 2.13.0.dev20260504 from viable/strict, May 4th, 2026.
+   - `IDEEP_HASH=6469a610baaa94ba15de1902fd1afb25316171d2`, from ideep_pytorch, Apr 23rd, 2026.
+   - `ONEDNN_HASH=8fa20dc93a75c094f618f3f8c206775731d63301`, from main, May 5th, 2026.
+   - `KLEIDIAI_HASH=7a7da265d21f42053d453ef664814c5b5cad8cd3`, v1.24.0 from main, May 4th, 2026.
+ - Updates `OPENBLAS_VERSION` from `d26960a21ec5da7f77377f28bd6e230060841ae0` to v0.3.33, from main, Apr 23rd.
+ - Updates `torchvision` from 0.26.0.dev20260329 to 0.27.0.dev20260505.
 
 ### Removed
- - TorchAO wheel build from source
+ - Removes TorchAO wheel build from source.
+ - Removes PRs that have already been merged.
 
 ### Fixed
 

--- a/ML-Frameworks/pytorch-aarch64/build-wheel.sh
+++ b/ML-Frameworks/pytorch-aarch64/build-wheel.sh
@@ -4,9 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Note that this script intentionally has no options. It builds *the* PyTorch
-# Tool-Solutions, of which there is only one type
-
 # The logic in this script should mirror the upstream build pipelines as closely
 # as possible, along with Tool-Solutions specific changes we want to test (e.g.
 # installing tbb) or improving local development in a way that doesn't affect
@@ -23,14 +20,20 @@ docker_exec() {
     docker exec "$TORCH_BUILD_CONTAINER" "$@"
 }
 
+cleanup() {
+    local return_code=$?
+
+    if [ -n "${TORCH_BUILD_CONTAINER:-}" ] && docker container inspect "$TORCH_BUILD_CONTAINER" >/dev/null 2>&1; then
+        docker_exec chown -R "$(id -u)":"$(id -g)" "${OWNERSHIP_PATHS[@]}" || true
+        docker rm -f "$TORCH_BUILD_CONTAINER" >/dev/null 2>&1 || true
+    fi
+
+    exit "$return_code"
+}
+
 PYTHON_VERSION="3.12"
 
-# Specify DOCKER_IMAGE_MIRROR if you want to use a mirror of hub.docker.com
-IMAGE_NAME="${DOCKER_IMAGE_MIRROR:-}pytorch/manylinux2_28_aarch64-builder:cpu-aarch64-69d4c1f80b5e7da224d4f9c2170ef100e75dfe03"
-TORCH_BUILD_CONTAINER_ID_FILE="${PWD}/.torch_build_container_id"
-
-PYTHON_TAG="cp$(echo "$PYTHON_VERSION" | tr -d .)-cp$(echo "$PYTHON_VERSION" | tr -d .)"
-PYTHON_CONTAINER_BIN="/opt/python/${PYTHON_TAG}/bin"
+BUILDER_IMAGE_NAME="${BUILDER_IMAGE_NAME:-local/pytorch-manylinux2_28_aarch64-builder:cpu-aarch64}"
 
 # Output dir for PyTorch wheel and other artifacts. Rename with the "_LOCAL_DIR"
 # suffix for consistency with other variables
@@ -55,11 +58,13 @@ CCACHE_LOCAL_DIR="${CCACHE_LOCAL_DIR:-"${PWD}/.ccache"}"
 CCACHE_CONTAINER_DIR=/.ccache
 CCACHE_MAXSIZE=${CCACHE_MAXSIZE:-}
 
-# If the user wants to use ccache for build caching
+# If the user wants to use ccache for build caching.
 ccache_args=()
 if [[ "$*" == *--disable-ccache* ]]; then
+    USE_CCACHE=0
     ccache_args+=(-e USE_CCACHE=0)
 else
+    USE_CCACHE=1
     ccache_args+=(-e USE_CCACHE=1)
     mkdir -p "${CCACHE_LOCAL_DIR}"
     ccache_args+=(
@@ -75,77 +80,64 @@ GPU_ARCH_TYPE=cpu-aarch64
 # Affects the number of jobs used in install_acl.sh and install_openblas.sh
 MAX_JOBS=${MAX_JOBS:-$(nproc --ignore=2)}
 
-if [ -f "$TORCH_BUILD_CONTAINER_ID_FILE" ]; then
-    TORCH_BUILD_CONTAINER=$(cat "$TORCH_BUILD_CONTAINER_ID_FILE")
-    echo "Found an existing torch build container id: $TORCH_BUILD_CONTAINER"
-else
-    TORCH_BUILD_CONTAINER=""
-    echo "Did not find torch build container id in $(readlink -f $TORCH_BUILD_CONTAINER_ID_FILE), we will create one later"
+OWNERSHIP_PATHS=(
+    "${PYTORCH_CONTAINER_DIR}"
+    "${PYTORCH_FINAL_PACKAGE_CONTAINER_DIR}"
+)
+if [[ "$*" != *--disable-ccache* ]]; then
+    OWNERSHIP_PATHS+=("${CCACHE_CONTAINER_DIR}")
 fi
 
-if ! docker container inspect "$TORCH_BUILD_CONTAINER" >/dev/null 2>&1 ; then
-    # Based on environment used in pytorch/.github/workflows/_binary-build-linux.yml
-    # and pytorch/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
-    TORCH_BUILD_CONTAINER=$(docker run -t -d \
-        -e MAX_JOBS=${MAX_JOBS} \
-        -e OPENBLAS_VERSION=${OPENBLAS_VERSION} \
-        -e ACL_VERSION=${ACL_VERSION} \
-        -e BINARY_ENV_FILE=/tmp/env \
-        -e BUILD_ENVIRONMENT=linux-aarch64-binary-manywheel \
-        -e DESIRED_CUDA=${DESIRED_CUDA} \
-        -e DESIRED_PYTHON=${PYTHON_VERSION} \
-        -e GITHUB_ACTIONS=0 \
-        -e GPU_ARCH_TYPE=${GPU_ARCH_TYPE} \
-        -e PACKAGE_TYPE=manywheel \
-        -e PYTORCH_FINAL_PACKAGE_DIR="${PYTORCH_FINAL_PACKAGE_CONTAINER_DIR}" \
-        -e PYTORCH_ROOT="${PYTORCH_CONTAINER_DIR}" \
-        -e SKIP_ALL_TESTS=1 \
-        -e OPENSSL_ROOT_DIR="${OPENSSL_CONTAINER_DIR}" \
-        -e CMAKE_INCLUDE_PATH="${OPENSSL_CONTAINER_DIR}/include" \
-        "${ccache_args[@]}" \
-        -v "${PYTORCH_LOCAL_DIR}:${PYTORCH_CONTAINER_DIR}" \
-        -v "${PYTORCH_FINAL_PACKAGE_LOCAL_DIR}:${PYTORCH_FINAL_PACKAGE_CONTAINER_DIR}" \
-        -w / \
-        "${IMAGE_NAME}")
+mkdir -p "${OUTPUT_LOCAL_DIR}"
 
-    # Provide ccache support
-    if [[ "$*" != *--disable-ccache* ]]; then
-        docker_exec yum install -y ccache || true
-        if [ -n "${CCACHE_MAXSIZE}" ]; then
-            docker_exec ccache --max-size="$CCACHE_MAXSIZE" || true
-        fi
-        docker_exec ccache -z || true
-        docker_exec ccache -o compression=true || true
-        docker_exec ccache -o compression_level=6 || true
-        docker_exec ccache -s || true
+trap cleanup EXIT
+
+echo "Building local manywheel builder image with ACL_VERSION=${ACL_VERSION} and OPENBLAS_VERSION=${OPENBLAS_VERSION}"
+(
+    cd "${PYTORCH_LOCAL_DIR}"
+    ACL_VERSION="${ACL_VERSION}" \
+    OPENBLAS_VERSION="${OPENBLAS_VERSION}" \
+    MAX_JOBS="${MAX_JOBS}" \
+    USE_CCACHE="${USE_CCACHE}" \
+    ./.ci/docker/manywheel/build.sh \
+        manylinux2_28_aarch64-builder:cpu-aarch64 \
+        --progress=plain \
+        -t "${BUILDER_IMAGE_NAME}"
+)
+
+# Based on environment used in pytorch/.github/workflows/_binary-build-linux.yml
+# and pytorch/.github/workflows/generated-linux-aarch64-binary-manywheel-nightly.yml
+TORCH_BUILD_CONTAINER=$(docker run -t -d \
+    -e MAX_JOBS="${MAX_JOBS}" \
+    -e BINARY_ENV_FILE=/tmp/env \
+    -e BUILD_ENVIRONMENT=linux-aarch64-binary-manywheel \
+    -e DESIRED_CUDA="${DESIRED_CUDA}" \
+    -e DESIRED_PYTHON="${PYTHON_VERSION}" \
+    -e GITHUB_ACTIONS=0 \
+    -e GPU_ARCH_TYPE="${GPU_ARCH_TYPE}" \
+    -e PACKAGE_TYPE=manywheel \
+    -e PYTORCH_FINAL_PACKAGE_DIR="${PYTORCH_FINAL_PACKAGE_CONTAINER_DIR}" \
+    -e PYTORCH_ROOT="${PYTORCH_CONTAINER_DIR}" \
+    -e SKIP_ALL_TESTS=1 \
+    -e OPENSSL_ROOT_DIR="${OPENSSL_CONTAINER_DIR}" \
+    -e CMAKE_INCLUDE_PATH="${OPENSSL_CONTAINER_DIR}/include" \
+    "${ccache_args[@]}" \
+    -v "${PYTORCH_LOCAL_DIR}:${PYTORCH_CONTAINER_DIR}" \
+    -v "${PYTORCH_FINAL_PACKAGE_LOCAL_DIR}:${PYTORCH_FINAL_PACKAGE_CONTAINER_DIR}" \
+    -w / \
+    "${BUILDER_IMAGE_NAME}")
+
+if [[ "$*" != *--disable-ccache* ]]; then
+    if [ -n "${CCACHE_MAXSIZE}" ]; then
+        docker_exec ccache --max-size="$CCACHE_MAXSIZE" || true
     fi
-
-    # Currently changes in these scripts will not be applied without a clean
-    # build, which is not ideal for dev work. But we have to balance this with
-    # extra time/network traffic when rebuilding many times.
-    docker_exec bash "${PYTORCH_CONTAINER_DIR}/.ci/pytorch/binary_populate_env.sh"
-
-    # Install scons for the Compute Library (ACL) build
-    docker_exec ${PYTHON_CONTAINER_BIN}/python3 -m pip install scons==4.7.0
-    docker_exec ln -sf "${PYTHON_CONTAINER_BIN}/scons" /usr/local/bin
-
-    # The Docker image comes with a pre-built version of ACL, but we
-    # want to build our own so we remove the provided version here
-    docker_exec rm -rf /acl
-
-    # Affected by ACL_VERSION set as an environment variable above
-    echo "Overriding Arm Compute Library version: ${ACL_VERSION}"
-    docker_exec "${PYTORCH_CONTAINER_DIR}/.ci/docker/common/install_acl.sh"
-
-    # Affected by OPENBLAS_VERSION set as an environment variable above
-    echo "Installing OpenBLAS version: ${OPENBLAS_VERSION}"
-    docker_exec "${PYTORCH_CONTAINER_DIR}/.ci/docker/common/install_openblas.sh"
-
-    echo "Storing torch build container ID in ${TORCH_BUILD_CONTAINER_ID_FILE} for reuse: ${TORCH_BUILD_CONTAINER}"
-    echo "$TORCH_BUILD_CONTAINER" > "${TORCH_BUILD_CONTAINER_ID_FILE}"
-else
-    docker restart "$TORCH_BUILD_CONTAINER"
+    docker_exec ccache -z || true
+    docker_exec ccache -o compression=true || true
+    docker_exec ccache -o compression_level=6 || true
+    docker_exec ccache -s || true
 fi
+
+docker_exec bash "${PYTORCH_CONTAINER_DIR}/.ci/pytorch/binary_populate_env.sh"
 
 # If there are multiple wheels in the dist directory, an old wheel can be
 # erroneously copied to results, so we clear the directory to be sure
@@ -156,7 +148,7 @@ docker_exec rm -rf "${PYTORCH_CONTAINER_DIR}/dist"
 # the Dockerfile. This is what PyTorch does in its nightly pipeline, see
 # pytorch/.ci/aarch64_linux/aarch64_wheel_ci_build.py for this logic.
 build_date=$(cd "$PYTORCH_LOCAL_DIR" && git show -s --format=%cs "${PYTORCH_HASH}" | tr -d '-')
-version=$(cat "$PYTORCH_LOCAL_DIR/version.txt" | tr -d "[:space:]")
+version=$(tr -d "[:space:]" < "${PYTORCH_LOCAL_DIR}/version.txt")
 OVERRIDE_PACKAGE_VERSION="${version%??}.dev${build_date}${TORCH_RELEASE_ID:+"+$TORCH_RELEASE_ID"}"
 
 # Build the wheel!
@@ -168,9 +160,3 @@ docker_exec bash -lc "
   OVERRIDE_PACKAGE_VERSION=$OVERRIDE_PACKAGE_VERSION \
   bash ${PYTORCH_CONTAINER_DIR}/.ci/manywheel/build.sh
 "
-
-# Directories generated by the docker container are owned by root, so transfer ownership to user
-docker_exec chown -R "$(id -u)":"$(id -g)" \
-    "${PYTORCH_CONTAINER_DIR}" \
-    "${PYTORCH_FINAL_PACKAGE_CONTAINER_DIR}" \
-    "${CCACHE_CONTAINER_DIR}"

--- a/ML-Frameworks/pytorch-aarch64/build-wheel.sh
+++ b/ML-Frameworks/pytorch-aarch64/build-wheel.sh
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# This script builds *the* PyTorch Tool-Solutions, of which there is only one type
+
 # The logic in this script should mirror the upstream build pipelines as closely
 # as possible, along with Tool-Solutions specific changes we want to test (e.g.
 # installing tbb) or improving local development in a way that doesn't affect

--- a/ML-Frameworks/pytorch-aarch64/build.sh
+++ b/ML-Frameworks/pytorch-aarch64/build.sh
@@ -11,11 +11,10 @@ build_log=build-$(git rev-parse --short=7 HEAD)-$(date '+%Y-%m-%dT%H-%M-%S').log
 exec &> >(tee -a "$build_log")
 
 # Bail out if sources are already there
-if [ -f .torch_build_container_id ] || [ -d pytorch ]; then
-    printf "\n\n%s\n%s\n%s\n%s\n\n\n" \
+if [ -d pytorch ]; then
+    printf "\n\n%s\n%s\n%s\n\n\n" \
         "You appear to have artefacts from a previous build lying around." \
         "Check for any of the following:" \
-        "  - .torch_build_container_id" \
         "  - pytorch"
 
     if [[ "$*" != *--fresh* ]] && [[ "$*" != *--use-existing-sources* ]]; then
@@ -28,24 +27,14 @@ if [ -f .torch_build_container_id ] || [ -d pytorch ]; then
 
     # Wipe old build artefacts
     if [[ $* == *--fresh* ]]; then
-        # Make sure we can wipe directories created with root privileges in Docker
-        if [ -f .torch_build_container_id ]; then
-            TORCH_BUILD_CONTAINER=$(cat .torch_build_container_id)
-            if [ ! -z "$(docker ps -a --no-trunc | grep $TORCH_BUILD_CONTAINER)" ]; then
-                # Change permissions from root
-                docker exec $TORCH_BUILD_CONTAINER chown -R $(id -u):$(id -g) /artifacts 2>/dev/null || true
-                docker exec $TORCH_BUILD_CONTAINER chown -R $(id -u):$(id -g) /pytorch 2>/dev/null || true
-
-                # Wipe old container
-                docker rm -f $TORCH_BUILD_CONTAINER 2>/dev/null || true
-            fi
-            rm -f .torch_build_container_id
-        fi
-
         # Wipe the other directories; we should have the privileges now
         if [ -d pytorch ]; then rm -rf pytorch; fi
     fi
 fi
+
+# Older builds wrote this file for persistent builder-container reuse. The
+# current flow uses Docker image layers and fresh containers instead.
+rm -f .torch_build_container_id
 
 if ! [[ $* == *--use-existing-sources* ]]; then
     ./get-source.sh

--- a/ML-Frameworks/pytorch-aarch64/build.sh
+++ b/ML-Frameworks/pytorch-aarch64/build.sh
@@ -12,10 +12,8 @@ exec &> >(tee -a "$build_log")
 
 # Bail out if sources are already there
 if [ -d pytorch ]; then
-    printf "\n\n%s\n%s\n%s\n\n\n" \
-        "You appear to have artefacts from a previous build lying around." \
-        "Check for any of the following:" \
-        "  - pytorch"
+    printf "\n\n%s\n\n\n" \
+        "You appear to have the 'pytorch/' folder lying around from a previous build."
 
     if [[ "$*" != *--fresh* ]] && [[ "$*" != *--use-existing-sources* ]]; then
         >&2 printf "\n\n%s\n%s\n%s\n\n\n" \
@@ -25,9 +23,7 @@ if [ -d pytorch ]; then
         exit 1
     fi
 
-    # Wipe old build artefacts
     if [[ $* == *--fresh* ]]; then
-        # Wipe the other directories; we should have the privileges now
         if [ -d pytorch ]; then rm -rf pytorch; fi
     fi
 fi

--- a/ML-Frameworks/pytorch-aarch64/get-source.sh
+++ b/ML-Frameworks/pytorch-aarch64/get-source.sh
@@ -14,12 +14,8 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
     # Apply patches to PyTorch build
     cd pytorch
 
-    # https://github.com/pytorch/pytorch/pull/167829 - Refactor ACL and OpenBLAS install scripts on AArch64
-    apply-github-patch pytorch/pytorch f5e7b3ab44b14902f1e44ac138006b04bd9b7728
-
-    # https://github.com/pytorch/pytorch/pull/170062 - Add ccache support to ACL/OpenBLAS and manywheel
-    # build script.
-    apply-github-patch pytorch/pytorch 327b118078869b85d979d9f7eb1038b8a53c8a49
+    # https://github.com/pytorch/pytorch/pull/182655 - Update ACL/OpenBLAS/manywheel build scripts and add ccache support
+    apply-github-patch pytorch/pytorch 159406ab7f210bacadb757fabef28ac9ddacb706
 
     # https://github.com/pytorch/pytorch/pull/170600 - Gate deletion of clean-up steps in build_common.sh
     apply-github-patch pytorch/pytorch e368ec2693b8b2b8ba35d0913f1d663ba2fdc804
@@ -29,9 +25,10 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
     apply-github-patch pytorch/pytorch b1782bbe0eda5957870e2f6e95b8f167e04843cb
     apply-github-patch pytorch/pytorch 337925aed2babb3ef7808f78536bbbc9df346a4f
 
-    # https://github.com/pytorch/pytorch/pull/177009 - Accelerate SDPA on Arm CPUs: Unroll exp_sum and max_mul kernels
-    apply-github-patch pytorch/pytorch f6a6cc94e92636902acbbe443d00cec4a8efa12d
-    apply-github-patch pytorch/pytorch 253a1ea6db210c01178dd365922eb49fe4892fe7
+    # https://github.com/pytorch/pytorch/pull/177867 - Add ASIMD_BF16 Vectorized class specialisation
+    apply-github-patch pytorch/pytorch 6cbed7b8e0d5985569b4cc36931afc717930fe00
+    apply-github-patch pytorch/pytorch 6e6878ec8869fd8f7d9314571a3e84933f149ef5
+    apply-github-patch pytorch/pytorch e14a2184c44c96e433f468ba12e104dc6be85886
 
     # Remove deps that we don't need for manylinux AArch64 CPU builds before fetching.
     # Only used when jni.h is present (see .ci/pytorch/build.sh:116), which is not the case for manylinux
@@ -73,9 +70,6 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
         (
             cd mkl-dnn
             git fetch origin $ONEDNN_HASH && git clean -f && git checkout -f FETCH_HEAD
-
-            # https://github.com/uxlfoundation/oneDNN/pull/4911 - cpu: aarch64: add LUT-based gelu_erf JIT implementations #4911
-            apply-github-patch uxlfoundation/oneDNN 86661869d4267b49db667ed7946eefba4e44d2c0
         )
     )
     (

--- a/ML-Frameworks/pytorch-aarch64/versions.sh
+++ b/ML-Frameworks/pytorch-aarch64/versions.sh
@@ -9,15 +9,15 @@
 # For information on how to update the versions below, read the README.md.
 
 # get-source.sh deps
-PYTORCH_HASH=fb69aa6b76c7ddbcac13ac3dd8b14625f4352ffd   # 2.12.0.dev20260328 from viable/strict, Mar 28th
-IDEEP_HASH=cbbfd4ad7c5ac6d7683af571055e95c948d8cf54     # From ideep_pytorch, Mar 17th
-ONEDNN_HASH=abc14842394f985313191bc1e3c69bb7f8cecd23    # From main, Mar 27th
-KLEIDIAI_HASH=6c544373d1731d2b74435fc02f8bad5f4631b0b1  # v1.23.0 from main, Mar 25th
+PYTORCH_HASH=004acb4e35805062a643ee1588cdae584b2b2957   # 2.13.0.dev20260504 from viable/strict, May 4th, 2026
+IDEEP_HASH=6469a610baaa94ba15de1902fd1afb25316171d2     # From ideep_pytorch, Apr 23rd, 2026
+ONEDNN_HASH=8fa20dc93a75c094f618f3f8c206775731d63301    # From main, May 5th, 2026
+KLEIDIAI_HASH=7a7da265d21f42053d453ef664814c5b5cad8cd3  # v1.24.0 from main, May 4th, 2026
 
 # build-wheel.sh deps
-ACL_VERSION="v52.8.0"   # Jan 23rd
-OPENBLAS_VERSION="d26960a21ec5da7f77377f28bd6e230060841ae0"  # Mar 27th
+ACL_VERSION="v53.0.0"   # Apr 10th
+OPENBLAS_VERSION="v0.3.33"  # Apr 23rd
 
 # Dockerfile deps
-TORCHVISION_NIGHTLY="0.26.0.dev20260329"
-TORCHAO_NIGHTLY="0.18.0.dev20260424"
+TORCHVISION_NIGHTLY="0.27.0.dev20260505"
+TORCHAO_NIGHTLY="0.18.0.dev20260505"


### PR DESCRIPTION
This PR will rely on the [`Dockerfile_2_28_aarch64`](https://github.com/pytorch/pytorch/blob/main/.ci/docker/manywheel/Dockerfile_2_28_aarch64) to handle caching of OpenBLAS and ACL inside the builder image. We build this image and it sits around as a tagged image until the user prunes it. So even if the user wipes the final `toolsolutions-pytorch:latest` image, they can just restart from the previous complete builder image (i.e. `BUILDER_IMAGE_NAME`). Note that the `trap` can remove the running build container but it will not wipe `BUILDER_IMAGE_NAME`. 

The caveat here is that it makes `ccache` support more difficult for the ACL and OpenBLAS build. The changes I've made in my PyTorch PR don't actually allow this to work (as I don't pass the local mounted directory and it's difficult to do with the `docker build`), so there's no actual `ccache` support for that. However, assuming the user doesn't wipe `BUILDER_IMAGE_NAME`, the user just pays a one-off cost and then only needs to rely on `ccache` for new builds of PyTorch itself. I think it's a reasonable loss for a big win.

I can (and will) therefore remove all `ccache` changes from [pytorch #182655](https://github.com/pytorch/pytorch/pull/182655/changes#diff-015deef3b315c3f8c3fbd5b26cfdc991a0650ed1180899487a662c5c9a5f84a7) to support this new direction.