### PR TITLE
Refactor common `urllib` usage into `utils/common.py`

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/examples/executor/model.py
+++ b/ML-Frameworks/pytorch-aarch64/examples/executor/model.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2021-2025 Arm Limited and affiliates.
+# SPDX-FileCopyrightText: Copyright 2021-2026 Arm Limited and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -10,7 +10,6 @@ import runpy
 import time
 import sys
 from urllib.parse import urlparse
-import urllib.request
 import warnings
 import zipfile
 
@@ -19,6 +18,8 @@ from tqdm import tqdm
 
 import torch
 import torchvision.models as torch_models
+
+from utils import common
 
 
 def _zip_file(zip_file, model_name, extract):
@@ -101,10 +102,10 @@ class Model:
                 return model_name
 
         # Download the model
-        urllib.request.urlretrieve(
+        common.download_url(
             model_url,
             model_name,
-            DownloadProgressBar("Downloading: " + model_name + "..."),
+            reporthook=DownloadProgressBar("Downloading: " + model_name + "..."),
         )
 
         # once it is downloaded and if it is archive then

--- a/ML-Frameworks/pytorch-aarch64/examples/ssd_resnet34.py
+++ b/ML-Frameworks/pytorch-aarch64/examples/ssd_resnet34.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2021, 2025 Arm Limited and affiliates.
+# SPDX-FileCopyrightText: Copyright 2021, 2025, 2026 Arm Limited and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -10,7 +10,7 @@ import datetime
 import os
 import sys
 
-import urllib.request
+from utils import common
 
 # List of files that need downloading
 REPO = "https://raw.githubusercontent.com/mlcommons/inference"
@@ -44,7 +44,7 @@ def main():
         basename = python_file.split("/")[-1]
         dest = os.path.join(folder, basename)
         url = os.path.join(REPO, COMMIT, python_file)
-        urllib.request.urlretrieve(url, dest)
+        common.download_url(url, dest)
 
         # Check whether downloaded file needs to be patched
         if basename in PATCH:

--- a/ML-Frameworks/pytorch-aarch64/examples/utils/common.py
+++ b/ML-Frameworks/pytorch-aarch64/examples/utils/common.py
@@ -1,9 +1,12 @@
-# SPDX-FileCopyrightText: Copyright 2021, 2023, 2025 Arm Limited and affiliates.
+# SPDX-FileCopyrightText: Copyright 2021, 2023, 2025, 2026 Arm Limited and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
 Helper methods that are common between utility functions
 """
+
+from pathlib import Path
+import urllib.request
 
 import yaml
 
@@ -11,6 +14,41 @@ import yaml
 RESNET50_NAME = "resnet50_v1.pth"
 RETINANET_NAME = "retinanet_model_10.pth"
 SSD_RESNET34_NAME = "resnet34-ssd1200.pytorch"
+USER_AGENT = (
+    "Tool-Solutions/1.0 (https://github.com/ARM-software/Tool-Solutions)"
+)
+
+
+def download_url(url, dest, *, reporthook=None, timeout=60):
+    """
+    Downloads a URL to a local file if needed.
+    :param url: URL to download
+    :param dest: Local output path
+    :param reporthook: Optional urllib.urlretrieve-style progress hook
+    :param timeout: Network timeout in seconds
+    :returns: Local output path
+    """
+    dest = Path(dest)
+    if dest.is_file():
+        return dest
+
+    request = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        total_size = int(response.headers.get("Content-Length", -1))
+        block_size = 8192
+        block_num = 0
+        with dest.open("wb") as dest_file:
+            while True:
+                block = response.read(block_size)
+                if not block:
+                    break
+                dest_file.write(block)
+                block_num += 1
+                if reporthook:
+                    reporthook(block_num, block_size, total_size)
+
+    return dest
 
 
 def parse_model_file(model_file):

--- a/ML-Frameworks/pytorch-aarch64/examples/utils/image.py
+++ b/ML-Frameworks/pytorch-aarch64/examples/utils/image.py
@@ -1,11 +1,10 @@
-# SPDX-FileCopyrightText: Copyright 2021-2025 Arm Limited and affiliates.
+# SPDX-FileCopyrightText: Copyright 2021-2026 Arm Limited and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
 Helper methods for pre- and post-processing of images
 """
 
-import urllib.request
 import os
 import sys
 
@@ -19,16 +18,6 @@ from torchvision import transforms
 import cv2
 
 from . import common
-
-# Install user agent to comply with Wikipedia policy
-opener = urllib.request.build_opener()
-opener.addheaders = [
-    (
-        "User-agent",
-        "Tool-Solutions/1.0 (https://github.com/ARM-software/Tool-Solutions)",
-    )
-]
-urllib.request.install_opener(opener)
 
 
 def download_image(image_loc):
@@ -44,7 +33,7 @@ def download_image(image_loc):
 
         if not os.path.isfile(image_file):
             # download the image if required
-            urllib.request.urlretrieve(image_loc, image_file)
+            common.download_url(image_loc, image_file)
 
     if not os.path.isfile(image_file):
         sys.exit("Image %s does not exist!" % image_file)

--- a/ML-Frameworks/pytorch-aarch64/examples/utils/label.py
+++ b/ML-Frameworks/pytorch-aarch64/examples/utils/label.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright 2021-2023, 2025 Arm Limited and affiliates.
+# SPDX-FileCopyrightText: Copyright 2021-2023, 2025, 2026 Arm Limited and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 """
@@ -7,7 +7,6 @@ Utility functions to label predictions
 
 import os
 import sys
-import urllib.request
 import json
 
 import numpy as np
@@ -30,7 +29,7 @@ def _get_labels_file(labels_loc):
 
         if not os.path.isfile(labels_file):
             # Download the labels if required
-            urllib.request.urlretrieve(labels_loc, labels_file)
+            common.download_url(labels_loc, labels_file)
 
     if not os.path.isfile(labels_file):
         sys.exit("Labels file %s does not exist!" % labels_file)

--- a/ML-Frameworks/pytorch-aarch64/examples/utils/nlp.py
+++ b/ML-Frameworks/pytorch-aarch64/examples/utils/nlp.py
@@ -1,12 +1,14 @@
-# SPDX-FileCopyrightText: Copyright 2021, 2022, 2025 Arm Limited and affiliates.
+# SPDX-FileCopyrightText: Copyright 2021, 2022, 2025, 2026 Arm Limited and affiliates.
 #
 # SPDX-License-Identifier: Apache-2.0
 
 import sys
-import os
 import json
-import urllib.request
+from pathlib import Path
+
 import pandas
+
+from . import common
 
 
 def clean(question):
@@ -27,14 +29,13 @@ def import_squad_data():
     squad_url = (
         "https://rajpurkar.github.io/SQuAD-explorer/dataset/dev-v2.0.json"
     )
-    squad_file = squad_url.split("/")[-1]  # last part of URL
+    squad_file = Path(squad_url.rsplit("/", maxsplit=1)[-1])
+    common.download_url(squad_url, squad_file)
 
-    urllib.request.urlretrieve(squad_url, squad_file)
-
-    if not os.path.isfile(squad_file):
+    if not squad_file.is_file():
         sys.exit("Dataset %s does not exist!" % squad_file)
 
-    with open(squad_file) as squad_file_handle:
+    with squad_file.open() as squad_file_handle:
         squad_data = json.load(squad_file_handle)["data"]
 
         title_list = []


### PR DESCRIPTION
A number of the tests appear to be hanging for 6h and that appears to be from `urllib` requests not being safely wrapped. This PR provides a timeout and common header usage and ensures the PyTorch examples all use the same functionality. 