### PR TITLE
Freeze `pytest<9` to address failing PyTorch unit tests

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -20,7 +20,6 @@ where `YY` is the year, and `MM` the month of the increment.
  - Updates `filelock` from 3.16.1 to 3.20.3.
  - Updates `pillow` from 12.1.1 to 12.2.0.
  - Updates `protobuf` from 5.29.5 to 5.29.6.
- - Updates `pytest` from 8.4.2 to 9.0.3.
  - Updates `requests` from 2.32.3 to 2.33.0.
  - Updates `urllib3` from 2.2.3 to 2.6.3.
  - Updates the build to use Docker layer caching for PyTorch builder image.
@@ -37,6 +36,7 @@ where `YY` is the year, and `MM` the month of the increment.
  - Removes PRs that have already been merged.
 
 ### Fixed
+ - Constrains `pytest` to the 8.4 series to keep PyTorch's copied unit tests compatible with pytest hook deprecation handling.
 
 ## [r26.04] 2026-04-10
 

--- a/ML-Frameworks/pytorch-aarch64/requirements.txt
+++ b/ML-Frameworks/pytorch-aarch64/requirements.txt
@@ -26,7 +26,9 @@ pyaml~=24.9.0
 python-dateutil~=2.9.0.post0
 pytz==2024.2
 PyYAML~=6.0.2
-pytest~=9.0.3
+# PyTorch's copied test suite still uses pytest hook signatures that are
+# incompatible with pytest 9 warnings-as-errors handling.
+pytest~=8.4.2
 regex==2024.9.11
 requests~=2.33.0
 safetensors~=0.4.5


### PR DESCRIPTION
Separating this out from #456 to get it in ASAP and fix the failing CI as the other changes in that PR are blocking this fix.