### PR TITLE
Remove ACL from oneDNN/PyTorch build

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -24,6 +24,8 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [r26.06] 2026-06-19
 
 ### Added
+ - Adds PyTorch [PR #184372](https://github.com/pytorch/pytorch/pull/184372).
+ - Adds oneDNN [PR #5156](https://github.com/uxlfoundation/oneDNN/pull/5156).
  - TorchAO installation via nightly AArch64 wheel (0.18.0.dev20260528) in Dockerfile
  - Adds a `--source-variant {upstream,pinned,patched}` option to `build.sh` and
    `get-source.sh` to select PyTorch's upstream submodule hashes, repo-pinned
@@ -48,6 +50,9 @@ where `YY` is the year, and `MM` the month of the increment.
  - Updates `torchvision` from 0.26.0.dev20260329 to 0.28.0.dev20260527.
 
 ### Removed
+ - Disables PyTorch [PR #182655](https://github.com/pytorch/pytorch/pull/182655), to update the PyTorch CI build scripts.
+ - Disables PyTorch [PR #170600](https://github.com/pytorch/pytorch/pull/170600), to gate deletion of clean-up steps in build_common.sh.
+ - Disables PyTorch [PR #167328](https://github.com/pytorch/pytorch/pull/167328), to build cpuinfo into c10 shared library.
  - Removes the `scripts/` directory containing retired helper scripts.
  - Removes TorchAO wheel build from source.
  - Removes PRs that have already been merged.

--- a/ML-Frameworks/pytorch-aarch64/get-source.sh
+++ b/ML-Frameworks/pytorch-aarch64/get-source.sh
@@ -56,16 +56,21 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
         git add .ci/docker/manywheel/build.sh
         git-with-credentials commit -m "Disable sudo commands in manywheel build"
 
-        # https://github.com/pytorch/pytorch/pull/182655 - Update ACL/OpenBLAS/manywheel build scripts and add ccache support
-        apply-github-patch pytorch/pytorch 159406ab7f210bacadb757fabef28ac9ddacb706
+        # # https://github.com/pytorch/pytorch/pull/182655 - Update ACL/OpenBLAS/manywheel build scripts and add ccache support
+        # apply-github-patch pytorch/pytorch 159406ab7f210bacadb757fabef28ac9ddacb706
 
-        # https://github.com/pytorch/pytorch/pull/170600 - Gate deletion of clean-up steps in build_common.sh
-        apply-github-patch pytorch/pytorch e368ec2693b8b2b8ba35d0913f1d663ba2fdc804
+        # # https://github.com/pytorch/pytorch/pull/170600 - Gate deletion of clean-up steps in build_common.sh
+        # apply-github-patch pytorch/pytorch e368ec2693b8b2b8ba35d0913f1d663ba2fdc804
 
-        # https://github.com/pytorch/pytorch/pull/167328 - Build cpuinfo into c10 shared library
-        apply-github-patch pytorch/pytorch 7c053dd1582b778c81101dd452708c4ec6e58233
-        apply-github-patch pytorch/pytorch b1782bbe0eda5957870e2f6e95b8f167e04843cb
-        apply-github-patch pytorch/pytorch 337925aed2babb3ef7808f78536bbbc9df346a4f
+        # # https://github.com/pytorch/pytorch/pull/167328 - Build cpuinfo into c10 shared library
+        # apply-github-patch pytorch/pytorch 7c053dd1582b778c81101dd452708c4ec6e58233
+        # apply-github-patch pytorch/pytorch b1782bbe0eda5957870e2f6e95b8f167e04843cb
+        # apply-github-patch pytorch/pytorch 337925aed2babb3ef7808f78536bbbc9df346a4f
+
+        # https://github.com/pytorch/pytorch/pull/184372 - [Draft] Remove ACL
+        apply-github-patch pytorch/pytorch 0b0d4ac70463892391dcacde63d087e8fa1c980d
+        apply-github-patch pytorch/pytorch 30788230c5dcdd2a2a716c7cf4aa7530615ffe89
+        apply-github-patch pytorch/pytorch 129cc717fa87f733aa41b4807bac399c94c2057c
     fi
 
     # Remove deps that we don't need for manylinux AArch64 CPU builds before fetching.
@@ -116,7 +121,11 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
                 if [[ "$source_variant" != patched ]]; then
                     echo "Not applying extra patches to oneDNN build for source variant '$source_variant'"
                 else
-                    echo "No oneDNN patches to apply"
+                    # https://github.com/uxlfoundation/oneDNN/pull/5156 - cpu: aarch64: replace acl with kleidiai
+                    apply-github-patch uxlfoundation/oneDNN 9d2436344f2cecb2ac2f879a2ffbbcc27cbe2aaf
+                    apply-github-patch uxlfoundation/oneDNN 685713adc27e3a34d6265f9e4cfd2eb3541ed6be
+                    apply-github-patch uxlfoundation/oneDNN c0dec6ea825430977b23773547a62310ab806cea
+                    git submodule update --init third_party/kleidiai
                 fi
             )
         )


### PR DESCRIPTION
## Summary

This pulls in https://github.com/pytorch/pytorch/pull/184372 and https://github.com/uxlfoundation/oneDNN/pull/5156.

### Todo

- [x] Wait for Jon to rebase the oneDNN PR on `ONEDNN_HASH=3004f0a1d9cf92c06eaaca57840aaa2149ebba85`, from main, May 27th, 2026.

### Notes

- I've converted it to draft as there's going to be a lot of fiddling as we try and get the PyTorch patch to strip out ACL working; I don't want the PR accidentally merged before then.
- Rebased on https://github.com/ARM-software/Tool-Solutions/pull/461 to pull in PyTorch unit test fix.