### PR TITLE
Remove `sudo` commands from PyTorch build script

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -40,6 +40,7 @@ where `YY` is the year, and `MM` the month of the increment.
  - Removes PRs that have already been merged.
 
 ### Fixed
+ - Disables `sudo` commands in PyTorch scripts used to build wheel.
  - Constrains `pytest` to the 8.4 series to keep PyTorch's copied unit tests compatible with pytest hook deprecation handling.
 
 ## [r26.04] 2026-04-10

--- a/ML-Frameworks/pytorch-aarch64/get-source.sh
+++ b/ML-Frameworks/pytorch-aarch64/get-source.sh
@@ -49,6 +49,13 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
     if [[ "$source_variant" != patched ]]; then
         echo "Not applying extra patches to PyTorch build for source variant '$source_variant'"
     else
+        # Disable the sudo commands in the manywheel build which restart the Docker daemon
+        replace_once .ci/docker/manywheel/build.sh \
+            'if [ "$(uname -m)" != "s390x" ] && [ -v CI ]; then' \
+            'if false; then'
+        git add .ci/docker/manywheel/build.sh
+        git-with-credentials commit -m "Disable sudo commands in manywheel build"
+
         # https://github.com/pytorch/pytorch/pull/182655 - Update ACL/OpenBLAS/manywheel build scripts and add ccache support
         apply-github-patch pytorch/pytorch 159406ab7f210bacadb757fabef28ac9ddacb706
 

--- a/ML-Frameworks/utils/git-utils.sh
+++ b/ML-Frameworks/utils/git-utils.sh
@@ -11,6 +11,13 @@ patch_cache_dir="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")/patch_cache"
 mkdir -p "$patch_cache_dir"
 export patch_cache_dir
 
+function git-with-credentials() {
+    git -c user.name="apply-github-patch" \
+        -c user.email="noreply@example.com" \
+        -c commit.gpgsign="false" \
+        "$@"
+}
+
 function git-shallow-clone {
     (
         local repo_name=$(basename "$1" .git)
@@ -51,16 +58,9 @@ function apply-github-patch {
         fi
     fi
 
-    _git_with_credentials() {
-        git -c user.name="apply-github-patch" \
-            -c user.email="noreply@example.com" \
-            -c commit.gpgsign="false" \
-            "$@"
-    }
-
     # Approach #1: Try a simple patch application with 'git am'
-    _git_with_credentials am --keep-cr "$patch_file" && return 0
-    _git_with_credentials am --abort || true # wokeignore:rule=abort/terminate
+    git-with-credentials am --keep-cr "$patch_file" && return 0
+    git-with-credentials am --abort || true # wokeignore:rule=abort/terminate
 
     # Approach #2: Try a three-way merge after fetching the parent commit. It can handle
     # scenarios in which the context of the patch has moved. However, we need the parent
@@ -70,12 +70,25 @@ function apply-github-patch {
         fetch_url="https://x-access-token:${GITHUB_TOKEN}@github.com/$1.git"
     fi
     git fetch --no-tags --quiet --depth=2 "$fetch_url" "$2" || true
-    _git_with_credentials am --3way --keep-cr "$patch_file" && return 0
-    _git_with_credentials am --abort || true # wokeignore:rule=abort/terminate
+    git-with-credentials am --3way --keep-cr "$patch_file" && return 0
+    git-with-credentials am --abort || true # wokeignore:rule=abort/terminate
 
     # Approach #3: Fall back to GNU 'patch'
     patch -p1 < "$patch_file" || return 1
     git add -A
-    _git_with_credentials commit -m "Applied patch $2 from $1."
+    git-with-credentials commit -m "Applied patch $2 from $1."
     return 0
+}
+
+function replace_once() {
+    python3 - "$@" <<'PY'
+import sys
+from pathlib import Path
+
+path, old, new = Path(sys.argv[1]), sys.argv[2], sys.argv[3]
+text = path.read_text(encoding="utf-8")
+if old not in text:
+    raise SystemExit(f"{path}: expected text not found: {old!r}")
+path.write_text(text.replace(old, new, 1), encoding="utf-8")
+PY
 }


### PR DESCRIPTION
The PyTorch build script `.ci/docker/manywheel/build.sh` uses a series of `sudo` commands. Our build process shouldn't require these elevated permissions and did not prior to #453 where we changed the build script. 

I've opted for a plain patch file as opposed to a series of `sed` commands; it should be easy to catch when the offending lines have been removed. I also didn't opt to `unset CI` as there may be future changes to the script that require `CI` to be set that we might want. Better to just remove the specific lines we don't want. 