### PR TITLE
Bump sources + add g++ to Dockerfile + update CHANGELOGs for 26.06 release

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -14,7 +14,17 @@ where `YY` is the year, and `MM` the month of the increment.
 ## [unreleased]
 
 ### Added
- - TorchAO installation via nightly AArch64 wheel (0.18.0.dev20260505) in Dockerfile
+
+### Changed
+
+### Removed
+
+### Fixed
+
+## [r26.06] 2026-06-19
+
+### Added
+ - TorchAO installation via nightly AArch64 wheel (0.18.0.dev20260528) in Dockerfile
  - Adds a `--source-variant {upstream,pinned,patched}` option to `build.sh` and
    `get-source.sh` to select PyTorch's upstream submodule hashes, repo-pinned
    component hashes without patches, or the default repo-pinned patched source tree.
@@ -28,12 +38,13 @@ where `YY` is the year, and `MM` the month of the increment.
  - Updates `urllib3` from 2.2.3 to 2.6.3.
  - Updates the build to use Docker layer caching for PyTorch builder image.
  - Updates hashes for:
-   - `PYTORCH_HASH=004acb4e35805062a643ee1588cdae584b2b2957`, 2.13.0.dev20260504 from viable/strict, May 4th, 2026.
-   - `IDEEP_HASH=6469a610baaa94ba15de1902fd1afb25316171d2`, from ideep_pytorch, Apr 23rd, 2026.
-   - `ONEDNN_HASH=8fa20dc93a75c094f618f3f8c206775731d63301`, from main, May 5th, 2026.
-   - `KLEIDIAI_HASH=7a7da265d21f42053d453ef664814c5b5cad8cd3`, v1.24.0 from main, May 4th, 2026.
+   - `PYTORCH_HASH=c230e6986c6aaee101e24ca14813c21add0b148f`, 2.13.0.dev20260528 from viable/strict, May 28th, 2026.
+   - `IDEEP_HASH=e087b6e4b32a7ba684db82231d1558123968ac1d`, from ideep_pytorch, May 11th, 2026.
+   - `ONEDNN_HASH=3004f0a1d9cf92c06eaaca57840aaa2149ebba85`, from main, May 27th, 2026.
+   - `KLEIDIAI_HASH=5866364d3bc079d2d6cae5f0acf6d076594bc7a7`, v1.25.0 from main, May 28th, 2026.
+ - Replaces `ACL_VERSION=v52.8.0` with `ACL_VERSION=v53.1.0`, from main, May 18th.
  - Updates `OPENBLAS_VERSION` from `d26960a21ec5da7f77377f28bd6e230060841ae0` to v0.3.33, from main, Apr 23rd.
- - Updates `torchvision` from 0.26.0.dev20260329 to 0.27.0.dev20260505.
+ - Updates `torchvision` from 0.26.0.dev20260329 to 0.28.0.dev20260527.
 
 ### Removed
  - Removes the `scripts/` directory containing retired helper scripts.

--- a/ML-Frameworks/pytorch-aarch64/Dockerfile
+++ b/ML-Frameworks/pytorch-aarch64/Dockerfile
@@ -79,6 +79,9 @@ ENV DOCKER_USER=debian
 
 # Runtime OS bits + UI
 RUN set -eux && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends g++ && \
+    rm -rf /var/lib/apt/lists/* && \
     if ! id "$DOCKER_USER" >/dev/null 2>&1; then useradd --create-home -s /bin/bash "$DOCKER_USER"; fi && \
     echo '[ -n "$TERM" -a -r "$HOME/welcome.txt" ] && cat "$HOME/welcome.txt"' >> /etc/bash.bashrc && \
     echo 'export PATH="$HOME/.local/bin:$HOME/.venv/bin:$PATH"' >> /etc/bash.bashrc && \

--- a/ML-Frameworks/pytorch-aarch64/get-source.sh
+++ b/ML-Frameworks/pytorch-aarch64/get-source.sh
@@ -66,11 +66,6 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
         apply-github-patch pytorch/pytorch 7c053dd1582b778c81101dd452708c4ec6e58233
         apply-github-patch pytorch/pytorch b1782bbe0eda5957870e2f6e95b8f167e04843cb
         apply-github-patch pytorch/pytorch 337925aed2babb3ef7808f78536bbbc9df346a4f
-
-        # https://github.com/pytorch/pytorch/pull/177867 - Add ASIMD_BF16 Vectorized class specialisation
-        apply-github-patch pytorch/pytorch 6cbed7b8e0d5985569b4cc36931afc717930fe00
-        apply-github-patch pytorch/pytorch 6e6878ec8869fd8f7d9314571a3e84933f149ef5
-        apply-github-patch pytorch/pytorch e14a2184c44c96e433f468ba12e104dc6be85886
     fi
 
     # Remove deps that we don't need for manylinux AArch64 CPU builds before fetching.
@@ -129,11 +124,5 @@ git-shallow-clone https://github.com/pytorch/pytorch.git $PYTORCH_HASH
             cd third_party/kleidiai
             git fetch origin $KLEIDIAI_HASH && git clean -f && git checkout -f FETCH_HEAD
         )
-    fi
-
-    # rebuild third_party/LICENSES_BUNDLED.txt after modifying PyTorch submodules if we can
-    # this will also get done in PyTorch build too
-    if command -v python3 >/dev/null 2>&1; then
-        python3 third_party/build_bundled.py
     fi
 )

--- a/ML-Frameworks/pytorch-aarch64/versions.sh
+++ b/ML-Frameworks/pytorch-aarch64/versions.sh
@@ -9,15 +9,15 @@
 # For information on how to update the versions below, read the README.md.
 
 # get-source.sh deps
-PYTORCH_HASH=004acb4e35805062a643ee1588cdae584b2b2957   # 2.13.0.dev20260504 from viable/strict, May 4th, 2026
-IDEEP_HASH=6469a610baaa94ba15de1902fd1afb25316171d2     # From ideep_pytorch, Apr 23rd, 2026
-ONEDNN_HASH=8fa20dc93a75c094f618f3f8c206775731d63301    # From main, May 5th, 2026
-KLEIDIAI_HASH=7a7da265d21f42053d453ef664814c5b5cad8cd3  # v1.24.0 from main, May 4th, 2026
+PYTORCH_HASH=c230e6986c6aaee101e24ca14813c21add0b148f   # 2.13.0.dev20260528 from viable/strict, May 28th, 2026
+IDEEP_HASH=e087b6e4b32a7ba684db82231d1558123968ac1d     # From ideep_pytorch, May 11th, 2026
+ONEDNN_HASH=3004f0a1d9cf92c06eaaca57840aaa2149ebba85    # From main, May 27th, 2026
+KLEIDIAI_HASH=5866364d3bc079d2d6cae5f0acf6d076594bc7a7  # v1.25.0 from main, May 28th, 2026
 
 # build-wheel.sh deps
-ACL_VERSION="v53.0.0"   # Apr 10th
+ACL_VERSION="v53.1.0"   # May 18th
 OPENBLAS_VERSION="v0.3.33"  # Apr 23rd
 
 # Dockerfile deps
-TORCHVISION_NIGHTLY="0.27.0.dev20260505"
-TORCHAO_NIGHTLY="0.18.0.dev20260505"
+TORCHVISION_NIGHTLY="0.28.0.dev20260527"
+TORCHAO_NIGHTLY="0.18.0.dev20260528"

--- a/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
@@ -16,6 +16,17 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 
 ### Changed
+
+### Removed
+
+### Fixed
+
+## [r26.06] 2026-06-19
+
+### Added
+
+### Changed
+ - Updates TensorFlow hash to fff60aa253b3d2a3cb9e0e988e72cdab761530d1 from nightly, May 28th
  - Updates `filelock` from 3.17.0 to 3.20.3.
  - Updates `pillow` from 12.1.1 to 12.2.0.
 

--- a/ML-Frameworks/tensorflow-aarch64/get-source.sh
+++ b/ML-Frameworks/tensorflow-aarch64/get-source.sh
@@ -8,7 +8,7 @@ source ../utils/git-utils.sh
 
 set -eux -o pipefail
 
-TENSORFLOW_HASH=25cf6546b44bdb3d3f17277a4b49b027dcdc0ae7 # from nightly, Mar 23rd
+TENSORFLOW_HASH=fff60aa253b3d2a3cb9e0e988e72cdab761530d1 # from nightly, May 28th
 
 git-shallow-clone https://github.com/tensorflow/tensorflow.git $TENSORFLOW_HASH
 


### PR DESCRIPTION
Only worthy thing of note in this is that PyTorch removed the `third_party/build_bundled.py` script in https://github.com/pytorch/pytorch/pull/180237 to create an updated bundled license.