### PR TITLE
Switch to `3.12-trixie` base image.

### DIFF
--- a/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/pytorch-aarch64/CHANGELOG.md
@@ -16,7 +16,7 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 
 ### Changed
-
+ 
 ### Removed
 
 ### Fixed
@@ -31,6 +31,7 @@ where `YY` is the year, and `MM` the month of the increment.
  - Adds the installation of `torchao` via nightly AArch64 wheels in Dockerfile.
 
 ### Changed
+ - Update Dockerfile to use `3.12-trixie` (instead of `3.12-slim`) for the base image.
  - Updates `filelock` from 3.16.1 to 3.20.3.
  - Updates `pillow` from 12.1.1 to 12.2.0.
  - Updates `protobuf` from 5.29.5 to 5.29.6.

--- a/ML-Frameworks/pytorch-aarch64/Dockerfile
+++ b/ML-Frameworks/pytorch-aarch64/Dockerfile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Specify DOCKER_IMAGE_MIRROR if you want to use a mirror of hub.docker.com
-ARG BASE_IMAGE=python:3.12-slim
+ARG BASE_IMAGE=python:3.12-trixie
 ARG DOCKER_IMAGE_MIRROR=""
 
 # ============================
@@ -79,9 +79,6 @@ ENV DOCKER_USER=debian
 
 # Runtime OS bits + UI
 RUN set -eux && \
-    apt-get update && \
-    apt-get install -y --no-install-recommends g++ && \
-    rm -rf /var/lib/apt/lists/* && \
     if ! id "$DOCKER_USER" >/dev/null 2>&1; then useradd --create-home -s /bin/bash "$DOCKER_USER"; fi && \
     echo '[ -n "$TERM" -a -r "$HOME/welcome.txt" ] && cat "$HOME/welcome.txt"' >> /etc/bash.bashrc && \
     echo 'export PATH="$HOME/.local/bin:$HOME/.venv/bin:$PATH"' >> /etc/bash.bashrc && \

--- a/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
+++ b/ML-Frameworks/tensorflow-aarch64/CHANGELOG.md
@@ -26,6 +26,7 @@ where `YY` is the year, and `MM` the month of the increment.
 ### Added
 
 ### Changed
+ - Update Dockerfile to use `3.12-trixie` (instead of `3.12-slim`) for the base image.
  - Updates TensorFlow hash to fff60aa253b3d2a3cb9e0e988e72cdab761530d1 from nightly, May 28th
  - Updates `filelock` from 3.17.0 to 3.20.3.
  - Updates `pillow` from 12.1.1 to 12.2.0.

--- a/ML-Frameworks/tensorflow-aarch64/Dockerfile
+++ b/ML-Frameworks/tensorflow-aarch64/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Specify DOCKER_IMAGE_MIRROR if you want to use a mirror of hub.docker.com
-ARG BASE_IMAGE=python:3.12-slim
+ARG BASE_IMAGE=python:3.12-trixie
 ARG DOCKER_IMAGE_MIRROR=""
 
 # ============================


### PR DESCRIPTION
The slim python base image doesn't come with `g++` which we want for `torch.compile` to generate C++ code. Switching out for `3.12-trixie` which does.